### PR TITLE
Feat!: Introducing compile-time Eodash Config

### DIFF
--- a/bin/app.js
+++ b/bin/app.js
@@ -4,12 +4,15 @@ import { buildApp, createDevServer, previewApp } from './cli.js'
 
 const command = process.argv?.[2];
 (async () => {
+  const baseFlag = (  
+    process.argv.indexOf('--base') > -1 ? process.argv[process.argv.indexOf('--base')+1] : null
+  );
   switch (command) {
     case "dev":
       await createDevServer();
       break;
     case "build":
-      await buildApp();
+      await buildApp(baseFlag);
       break;
     case "preview":
       await previewApp();

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import { build, createServer, preview } from "vite"
-import { execPath, appPath, buildTargetPath } from "./utils.js";
+import { rootPath, appPath, buildTargetPath, appPublicPath } from "./utils.js";
 import { writeFile, rm, cp } from "fs/promises";
 import { update } from "./update.js";
 import { indexHtml, serverConfig } from "./serverConfig.js";
@@ -25,7 +25,6 @@ export const buildApp = async () => {
     await rm(htmlPath).catch(() => {
       console.error('failed to remove index.html')
     })
-    const appPublicPath = path.join(appPath, './public')
     if (appPath.includes('node_modules') && existsSync(appPublicPath)) {
       await rm(appPublicPath, { recursive: true }).catch((e) => {
         console.error(e)
@@ -34,7 +33,7 @@ export const buildApp = async () => {
   })
 
   if (appPath.includes('node_modules')) {
-    await cp(appPath + 'dist', buildTargetPath, { recursive: true }).then(() => {
+    await cp(path.join(appPath, 'dist'), buildTargetPath, { recursive: true }).then(() => {
       console.info('dashboard built successfully')
     }).catch((e) => {
       console.error(e)
@@ -45,7 +44,7 @@ export const buildApp = async () => {
 
 export async function previewApp() {
   const previewServer = await preview({
-    root: execPath,
+    root: rootPath,
     preview: {
       port: 8080,
       open: true,

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -17,11 +17,17 @@ export const createDevServer = async () => {
   server.bindCLIShortcuts({ print: true })
 }
 
-export const buildApp = async () => {
+export const buildApp = async (baseFlag) => {
   const htmlPath = path.join(appPath, '/index.html')
   await writeFile(htmlPath, indexHtml).then(async () => {
     await update()
-    await build(await serverConfig({ mode: 'production', command: 'build' }))
+
+    const config = await serverConfig({ mode: 'production', command: 'build' });
+    if (baseFlag !== null) {
+      config.base = baseFlag
+    }
+    await build(config)
+
     await rm(htmlPath).catch(() => {
       console.error('failed to remove index.html')
     })

--- a/bin/serverConfig.js
+++ b/bin/serverConfig.js
@@ -6,7 +6,11 @@ import vue from '@vitejs/plugin-vue';
 import vuetify, { transformAssetUrls } from 'vite-plugin-vuetify';
 import virtual, { updateVirtualModule } from 'vite-plugin-virtual'
 import { fileURLToPath, URL } from 'url';
-import { execPath, runtimeConfigPath, appPath, dotEodashPath, compiletimeConfigPath } from "./utils.js";
+import {
+  runtimeConfigPath,
+  appPath, compiletimeConfigPath,
+  appPublicPath, cachePath, rootPublicPath
+} from "./utils.js";
 import { readFile } from "fs/promises";
 import { defineConfig, searchForWorkspaceRoot } from "vite"
 import { getUserModules } from './utils.js';
@@ -37,7 +41,7 @@ let virtualPlugin = null;
 export const serverConfig = /** @type {import('vite').UserConfigFnPromise}*/(defineConfig(async ({ mode, command }) => {
   return {
     base: '',
-    cacheDir: dotEodashPath + '/cache',
+    cacheDir: cachePath,
     plugins: [
       vue({
         template: {
@@ -77,7 +81,7 @@ export const serverConfig = /** @type {import('vite').UserConfigFnPromise}*/(def
       include: ["webfontloader", "vuetify", "vue", "pinia"],
       noDiscovery: true,
     } : {},
-    publicDir: command === 'build' ? path.join(appPath, './public') : path.join(execPath, '/public'),
+    publicDir: command === 'build' ? appPublicPath : rootPublicPath,
     build: {
       outDir: 'dist',
       rollupOptions: {

--- a/bin/serverConfig.js
+++ b/bin/serverConfig.js
@@ -74,7 +74,6 @@ export const serverConfig = /** @type {import('vite').UserConfigFnPromise}*/(def
       fs: {
         allow: [searchForWorkspaceRoot(process.cwd())]
       },
-      open: '/'
     },
     root: fileURLToPath(new URL('..', import.meta.url)),
     optimizeDeps: mode === "development" ? {

--- a/bin/serverConfig.js
+++ b/bin/serverConfig.js
@@ -1,17 +1,17 @@
 #!/usr/bin/env node
 
-import { defineConfig, searchForWorkspaceRoot } from "vite"
-// Plugins
+
+
 import vue from '@vitejs/plugin-vue';
 import vuetify, { transformAssetUrls } from 'vite-plugin-vuetify';
-
-// Utilities
+import virtual, { updateVirtualModule } from 'vite-plugin-virtual'
 import { fileURLToPath, URL } from 'url';
-import { configPath, appPath, dotEodashPath, execPath } from "./utils.js";
+import { execPath, runtimeConfigPath, appPath, dotEodashPath, compiletimeConfigPath } from "./utils.js";
 import { readFile } from "fs/promises";
-import { existsSync } from "fs";
+import { defineConfig, searchForWorkspaceRoot } from "vite"
+import { getUserModules } from './utils.js';
+import { existsSync } from 'fs';
 import path from "path";
-
 
 export const indexHtml = `
 <!DOCTYPE html>
@@ -26,11 +26,15 @@ export const indexHtml = `
 
 <body>
   <div id="app"></div>
-  <script type="module" src="${path.resolve(`/@fs/${appPath}/core/main.js`)}"></script>
+  <script type="module" src="${path.resolve(`/@fs/${appPath}/core/render.js`)}"></script>
 </body>
 </html>`
 
-export const serverConfig = defineConfig(({ mode, command }) => {
+/**
+ * @type {import('vite').Plugin | null}
+ */
+let virtualPlugin = null;
+export const serverConfig = /** @type {import('vite').UserConfigFnPromise}*/(defineConfig(async ({ mode, command }) => {
   return {
     base: '',
     cacheDir: dotEodashPath + '/cache',
@@ -47,10 +51,11 @@ export const serverConfig = defineConfig(({ mode, command }) => {
       vuetify({
         autoImport: true,
       }),
-      {
-        name: "inject-files",
-        configureServer: mode === "development" ? configureServer : undefined
-      }
+      (mode === "development" && {
+        name: "inject-html",
+        configureServer
+      }),
+      virtualPlugin = virtual(await getUserModules())
     ],
     define: { 'process.env': {} },
     resolve: {
@@ -81,7 +86,7 @@ export const serverConfig = defineConfig(({ mode, command }) => {
       target: "esnext"
     }
   }
-});
+}));
 
 
 
@@ -89,32 +94,33 @@ export const serverConfig = defineConfig(({ mode, command }) => {
  * @type {import("vite").ServerHook}
  */
 async function configureServer(server) {
-  if (existsSync(configPath)) {
-    server.watcher.add(configPath)
-  }
+  server.watcher.add([compiletimeConfigPath, runtimeConfigPath])
 
   server.watcher.on('change', async (path) => {
-    if (path == configPath) {
-      server.hot.send('config:update')
+    if (path == runtimeConfigPath) {
+      server.hot.send('reload')
+    } else if (!path.includes('node_modules') && path.includes('.eodash')) {
+      updateVirtualModule(virtualPlugin, 'user:config',
+        await getUserModules().then(modules => modules['user:config']))
     }
   })
+
   return () => {
     server.middlewares.use(async (req, res, next) => {
-      if (req.originalUrl === '/@fs/config.js' && existsSync(configPath)) {
-        await readFile(configPath).then(config => {
+      if (req.originalUrl === '/@fs/config.js' && existsSync(runtimeConfigPath)) {
+        await readFile(runtimeConfigPath).then(runtimeConfig => {
           res.statusCode = 200
           res.setHeader('Content-Type', 'text/javascript')
-          res.write(config)
+          res.write(runtimeConfig)
           res.end()
-        }).catch()
+        })
         return
       }
 
-      const url = req.url
-      if (url?.endsWith('.html')) {
+      if (req.url?.endsWith('.html')) {
         res.statusCode = 200
         res.setHeader('Content-Type', 'text/html')
-        const html = await server.transformIndexHtml(url, indexHtml, req.originalUrl)
+        const html = await server.transformIndexHtml(req.url, indexHtml, req.originalUrl)
         res.end(html)
         return
       }

--- a/bin/update.js
+++ b/bin/update.js
@@ -1,13 +1,11 @@
 import { cp } from "fs/promises";
-import { execPath, appPath, runtimeConfigPath } from "./utils.js";
+import { rootPublicPath, appPath, runtimeConfigPath, appPublicPath } from "./utils.js";
 import { existsSync } from "fs";
 import path from "path";
 
 export async function update() {
-  const execPublicPath = path.join(execPath, "/public"),
-    appPublicPath = path.join(appPath, "/public")
-  if (execPublicPath !== appPublicPath) {
-    await cp(execPublicPath, appPublicPath, { recursive: true }).catch(err => {
+  if (rootPublicPath !== appPublicPath) {
+    await cp(rootPublicPath, appPublicPath, { recursive: true }).catch(err => {
       console.error(err)
     })
     if (existsSync(runtimeConfigPath)) {

--- a/bin/update.js
+++ b/bin/update.js
@@ -1,15 +1,15 @@
 import { cp } from "fs/promises";
-import { execPath, appPath, configPath } from "./utils.js";
+import { execPath, appPath, runtimeConfigPath } from "./utils.js";
 import { existsSync } from "fs";
 import path from "path";
 
 export async function update() {
-  if (existsSync(configPath)) {
-    await cp(path.join(execPath, "/public"), path.join(appPath, "/public"), { recursive: true }).catch(err => {
-      console.error(err)
-    })
-    await cp(configPath, path.join(appPath, '/public/config.js')).catch((e) => {
+  await cp(path.join(execPath, "/public"), path.join(appPath, "/public"), { recursive: true }).catch(err => {
+    console.error(err)
+  })
+  if (existsSync(runtimeConfigPath)) {
+    await cp(runtimeConfigPath, path.join(appPath, '/public/config.js')).catch((e) => {
       console.error(e)
     })
-  } else console.error('no config file was found');
+  }
 }

--- a/bin/update.js
+++ b/bin/update.js
@@ -4,12 +4,16 @@ import { existsSync } from "fs";
 import path from "path";
 
 export async function update() {
-  await cp(path.join(execPath, "/public"), path.join(appPath, "/public"), { recursive: true }).catch(err => {
-    console.error(err)
-  })
-  if (existsSync(runtimeConfigPath)) {
-    await cp(runtimeConfigPath, path.join(appPath, '/public/config.js')).catch((e) => {
-      console.error(e)
+  const execPublicPath = path.join(execPath, "/public"),
+    appPublicPath = path.join(appPath, "/public")
+  if (execPublicPath !== appPublicPath) {
+    await cp(execPublicPath, appPublicPath, { recursive: true }).catch(err => {
+      console.error(err)
     })
+    if (existsSync(runtimeConfigPath)) {
+      await cp(runtimeConfigPath, path.join(appPath, '/public/config.js')).catch((e) => {
+        console.error(e)
+      })
+    }
   }
 }

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 
+import { readFile } from 'fs/promises';
+import { existsSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -7,6 +9,20 @@ import { fileURLToPath } from 'url';
 export const appPath = fileURLToPath(new URL("..", import.meta.url));
 export const execPath = fileURLToPath(new URL(process.cwd(), import.meta.url));
 export const dotEodashPath = path.join(execPath, "/.eodash");
-export const configPath = path.join(dotEodashPath, "/config.js");
+export const runtimeConfigPath = path.join(dotEodashPath, "./config.runtime.js");
+export const compiletimeConfigPath = path.join(dotEodashPath, "/config.js");
 export const buildTargetPath = path.join(dotEodashPath, '/dist')
 
+
+
+export const getUserModules = async () => {
+  /** @type {Record<string,string>} */
+  let userModules = {}
+  const indexJs = await readFile(compiletimeConfigPath, 'utf-8').catch(() => {
+    if (!existsSync(runtimeConfigPath)) {
+      console.error(new Error("no eodash configuration found"))
+    }
+  })
+  userModules['user:config'] = typeof indexJs === 'string' ? indexJs : ''
+  return userModules
+}

--- a/bin/utils.js
+++ b/bin/utils.js
@@ -4,14 +4,19 @@ import { readFile } from 'fs/promises';
 import { existsSync } from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { searchForWorkspaceRoot } from 'vite';
 
 // global paths
-export const appPath = fileURLToPath(new URL("..", import.meta.url));
-export const execPath = fileURLToPath(new URL(process.cwd(), import.meta.url));
-export const dotEodashPath = path.join(execPath, "/.eodash");
-export const runtimeConfigPath = path.join(dotEodashPath, "./config.runtime.js");
-export const compiletimeConfigPath = path.join(dotEodashPath, "/config.js");
-export const buildTargetPath = path.join(dotEodashPath, '/dist')
+export const appPath = fileURLToPath(new URL("..", import.meta.url)),
+  appPublicPath = path.join(appPath, './public'),
+  rootPath = searchForWorkspaceRoot(process.cwd()),
+  rootPublicPath = path.join(rootPath, './public'),
+  srcPath = path.join(rootPath, "/src"),
+  runtimeConfigPath = path.join(srcPath, "./config.runtime.js"),
+  compiletimeConfigPath = path.join(srcPath, "/config.js"),
+  dotEodashPath = path.join(rootPath, "/.eodash"),
+  buildTargetPath = path.join(dotEodashPath, '/dist'),
+  cachePath = path.join(dotEodashPath, 'cache');
 
 
 

--- a/core/eodashConfig.js
+++ b/core/eodashConfig.js
@@ -112,7 +112,7 @@ const eodashConfig = reactive({
         title: 'Information',
         layout: { "x": 9, "y": 0, "w": 3, "h": 12 },
         widget: {
-          link: '@eox/stacinfo',
+          link: async () => await import('@eox/stacinfo'),
           properties: {
             for: currentUrl,
             allowHtml: "true",

--- a/core/main.js
+++ b/core/main.js
@@ -1,15 +1,4 @@
 // Plugins
-import { registerPlugins } from '@/plugins';
+import { defineCompiletimeConfig } from '@/composables/DefineConfig';
 
-// Components
-import App from './App.vue';
-
-// Composables
-import { createApp } from 'vue';
-
-
-const app = createApp(App);
-
-registerPlugins(app);
-
-app.mount('#app');
+export { defineCompiletimeConfig as defineConfig }

--- a/core/plugins/router.js
+++ b/core/plugins/router.js
@@ -13,7 +13,7 @@ const routes = [
 ];
 
 const router = createRouter({
-  history: createWebHistory(process.env.BASE_URL),
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes,
 });
 

--- a/core/render.js
+++ b/core/render.js
@@ -1,0 +1,13 @@
+import { registerPlugins } from '@/plugins';
+// Components
+import App from './App.vue';
+
+// Composables
+import { createApp } from 'vue';
+
+
+const app = createApp(App);
+
+registerPlugins(app);
+
+app.mount('#app');

--- a/core/store/States.js
+++ b/core/store/States.js
@@ -7,6 +7,6 @@ export const currentUrl = ref('');
 
 /**
  * ol map object. Updated by the config file.
- * @type {import("vue").Ref<import('ol').Map | null>}
+ * @type {import("vue").Ref<import('openlayers').Map | null>}
  */
 export const mapInstance = ref(null);

--- a/core/types.d.ts
+++ b/core/types.d.ts
@@ -73,7 +73,7 @@ declare global {
        */
       h: number
     }
-    widget: WebComponentProps<T> // | NodeModuleWebComponentProps
+    widget: WebComponentProps<T>
     /**
      * Widget type
      */
@@ -205,7 +205,7 @@ declare global {
   type WidgetConfig<T extends ExecutionTime = "compiletime"> = StaticWidget<T> | FunctionalWidget<T>
 
 
-  type BackgroundWidgetConfig = Omit<WebComponentConfig, 'layout' | 'title'> | Omit<InternalComponentConfig, 'layout' | 'title'> | Omit<IFrameConfig, 'layout' | 'title'> | Omit<FunctionalWidget, 'layout'>
+  type BackgroundWidgetConfig<T extends ExecutionTime = "compiletime"> = Omit<WebComponentConfig<T>, 'layout' | 'title'> | Omit<InternalComponentConfig, 'layout' | 'title'> | Omit<IFrameConfig, 'layout' | 'title'> | Omit<FunctionalWidget, 'layout'>
   /**
    * Dashboard rendered widgets configuration specification.
    * 3 types of widgets are supported: `"iframe"`, `"internal"`, and `"web-component"`.
@@ -220,7 +220,7 @@ declare global {
      * Widget rendered as the dashboard background.
      * Has the same specifications of [WidgetConfig](../readme#widgetconfig) without the `title` and  `layout` properties
      */
-    background?: BackgroundWidgetConfig
+    background?: BackgroundWidgetConfig<T>
     /**
      * Array of widgets that will be rendered as dashboard panels.
      */

--- a/core/types.d.ts
+++ b/core/types.d.ts
@@ -1,6 +1,7 @@
 import { useSTAcStore } from "@/store/stac"
 import type { Router } from "vue-router";
 import type { StacCatalog, StacCollection, StacItem } from "stac-ts";
+import { defineCompiletimeConfig } from "./composables/DefineConfig";
 
 declare global {
   /**
@@ -360,3 +361,4 @@ declare global {
   ///////
 }
 export type { EodashConfig, EodashStore }
+export declare const defineConfig: typeof defineCompiletimeConfig

--- a/core/types.d.ts
+++ b/core/types.d.ts
@@ -5,13 +5,11 @@ import { defineCompiletimeConfig } from "./composables/DefineConfig";
 
 declare global {
   /**
-   * Specification of web components imported from an external URL
+   * Web Component configuration
    */
-  interface ExternalWebComponentProps {
+  interface WebComponentProps<T extends ExecutionTime = "compiletime"> {
     /** Web component definition file URL*/
-    link: string
-    /** Indicates if the widget is a node module */
-    // node_module?: false
+    link: T extends 'runtime' ? string : (string | (() => Promise));
     /** Exported Constructor, needs to be provided if the web component is not registered by the `link` provided */
     constructorProp?: string
     /** Custom tag name */
@@ -23,44 +21,15 @@ declare global {
      * @param el - web component
      * @param store - return value of the core STAC pinia store in `/core/store/stac.ts`
      */
-    onMounted?: (el: Element, store: ReturnType<typeof useSTAcStore>, router: Router) => (Promise<void> | void)
+    onMounted?: (el: Element | null, store: ReturnType<typeof useSTAcStore>, router: Router) => (Promise<void> | void)
     /**
      * Function that is triggered when the web component is unmounted from the DOM.
      * @param el - web component
      * @param store - return value of the core STAC pinia store in `/core/store/stac.ts`
      */
-    onUnmounted?: (el: Element, store: ReturnType<typeof useSTAcStore>, router: Router) => (Promise<void> | void)
+    onUnmounted?: (el: Element | null, store: ReturnType<typeof useSTAcStore>, router: Router) => (Promise<void> | void)
   }
 
-  // /**
-  //  * Specification of web components imported as a node_module.
-  //  */
-  // export interface NodeModuleWebComponentProps {
-  //   /** Type of `modulesMap` key. Defined in `/core/modulesMap.ts`*/
-  //   link: keyof typeof modulesMap;
-  //   /** Indicates if the widget is a node module */
-  //   node_module: true;
-  //   /** Exported Constructor, needs to be provided if the web component is not registered */
-  //   constructorProp?: string
-  //   /** Custom tag name */
-  //   tagName: `${string}-${string}`
-  //   /** Object defining all the properties and attributes of the web component */
-  //   properties?: Record<string, any>
-  //   /**
-  //    * Function that is triggered when the web component is mounted in the DOM.
-  //    * @param el - web component
-  //    * @param store - return value of the core STAC pinia store in `/core/store/stac.ts`
-  //    */
-  //   onMounted?: (el: Element, store: ReturnType<typeof useSTAcStore>, router: Router) => (Promise<void> | void)
-  //   /**
-  //    * Function that is triggered when the web component is unmounted from the DOM.
-  //    * @param el - web component
-  //    * @param store - return value of the core STAC pinia store in `/core/store/stac.ts`
-  //    */
-  //   onUnmounted?: (el: Element, store: ReturnType<typeof useSTAcStore>, router: Router) => (Promise<void> | void)
-  // }
-  /** @ignore */
-  type DynamicWebComponentProps = ExternalWebComponentProps // ExternalWebComponentProps | NodeModuleWebComponentProps
 
   /** @ignore */
   interface WidgetsContainerProps {
@@ -74,7 +43,7 @@ declare global {
    * Installed node_module web components import should be mapped in `/core/modulesMap.ts`,
    * then setting `widget.link`:`(import-map-key)` and `node_module`:`true`
    */
-  interface WebComponentConfig {
+  interface WebComponentConfig<T extends ExecutionTime = "compiletime"> {
     /**
    * Unique Identifier, triggers rerender when using `defineWidget`
    **/
@@ -104,7 +73,7 @@ declare global {
        */
       h: number
     }
-    widget: ExternalWebComponentProps // | NodeModuleWebComponentProps
+    widget: WebComponentProps<T> // | NodeModuleWebComponentProps
     /**
      * Widget type
      */
@@ -206,13 +175,13 @@ declare global {
     */
     type: 'iframe'
   }
-  interface FunctionalWidget {
+  interface FunctionalWidget<T extends ExecutionTime = "compiletime"> {
     /**
      * Provides a functional definition of the widget,
      * gets triggered whenever a stac object is selected.
      * @param selectedSTAC - currently selected stac object
      */
-    defineWidget: (selectedSTAC: StacCatalog | StacCollection | StacItem | null) => Omit<StaticWidget, 'layout'>
+    defineWidget: (selectedSTAC: StacCatalog | StacCollection | StacItem | null) => Omit<StaticWidget<T>, 'layout'>
     layout: {
       /**
        *  Horizontal start position. Integer (1 - 12)
@@ -232,8 +201,8 @@ declare global {
       h: number
     }
   }
-  type StaticWidget = WebComponentConfig | InternalComponentConfig | IFrameConfig
-  type WidgetConfig = StaticWidget | FunctionalWidget
+  type StaticWidget<T extends ExecutionTime = "compiletime"> = WebComponentConfig<T> | InternalComponentConfig | IFrameConfig
+  type WidgetConfig<T extends ExecutionTime = "compiletime"> = StaticWidget<T> | FunctionalWidget<T>
 
 
   type BackgroundWidgetConfig = Omit<WebComponentConfig, 'layout' | 'title'> | Omit<InternalComponentConfig, 'layout' | 'title'> | Omit<IFrameConfig, 'layout' | 'title'> | Omit<FunctionalWidget, 'layout'>
@@ -242,7 +211,7 @@ declare global {
    * 3 types of widgets are supported: `"iframe"`, `"internal"`, and `"web-component"`.
    * A specific configuration should be provided based on the type of the widget.
    */
-  interface TemplateConfig {
+  interface TemplateConfig<T extends ExecutionTime = "compiletime"> {
     /**
      * Gap between widgets
      */
@@ -255,19 +224,19 @@ declare global {
     /**
      * Array of widgets that will be rendered as dashboard panels.
      */
-    widgets: WidgetConfig[]
+    widgets: WidgetConfig<T>[]
   }
 
   type ExternalURL = `${'https://' | 'http://'}${string}`;
   type InternalRoute = `/${string}`
   type StacEndpoint = `${'https://' | 'http://'}${string}/catalog.json`
 
-
+  type ExecutionTime = "runtime" | "compiletime";
 
   /**
    * Eodash configuration specification.
    */
-  interface EodashConfig {
+  interface EodashConfig<T extends ExecutionTime = "compiletime"> {
     /**
      * Configuration ID that defines the route of the dashboard.
      * Rendered dashboard can be accessed on route `/dashboard/config-id`
@@ -328,7 +297,7 @@ declare global {
     /**
      * Rendered widgets configuration
      */
-    template: TemplateConfig
+    template: TemplateConfig<T>
   }
   /////////
 

--- a/core/views/Dashboard.vue
+++ b/core/views/Dashboard.vue
@@ -35,11 +35,11 @@ const { mainRect } = useLayout()
 onUnmounted(() => {
   theme.global.name.value = 'light'
 })
-if (import.meta.hot) {
-  import.meta.hot.on('config:update', () => {
-    window.location.reload()
-  })
-}
+
+import.meta.hot?.on('reload', () => {
+  window.location.reload()
+})
+
 </script>
 
 <style scoped lang="scss">

--- a/core/vite-env.d.ts
+++ b/core/vite-env.d.ts
@@ -29,3 +29,7 @@ declare module '@eox/timecontrol' {
 declare module '@eox/jsonform' {
   export const EOxJSONForm: CustomElementConstructor
 }
+declare module 'user:config' {
+  const config: EodashConfig;
+  export default config
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,12 @@
 {
-
   "name": "@eodash/eodash",
-  "version": "5.0.0-alpha.1.6",
+  "version": "5.0.0-alpha.1.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@eodash/eodash",
-      "version": "5.0.0-alpha.1.6",
+      "version": "5.0.0-alpha.1.7",
       "dependencies": {
         "@eox/layout": "^0.1.0",
         "@eox/stacinfo": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,8 @@
       "name": "eodash",
       "version": "5.0.0-alpha.1",
       "dependencies": {
-        "@eox/chart": "^2.0.0-beta2",
-        "@eox/drawtools": "^0.6.1",
-        "@eox/itemfilter": "^0.12.1",
-        "@eox/jsonform": "^0.2.1",
-        "@eox/layercontrol": "^0.15.1",
         "@eox/layout": "^0.1.0",
-        "@eox/map": "^1.1.0",
         "@eox/stacinfo": "^0.3.0",
-        "@eox/timecontrol": "^0.3.0",
         "@mdi/font": "7.0.96",
         "@vitejs/plugin-vue": "^5.0.0",
         "animated-details": "gist:2912bb049fa906671807415eb0e87188",
@@ -105,97 +98,10 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@eox/chart": {
-      "version": "2.0.0-beta2",
-      "resolved": "https://registry.npmjs.org/@eox/chart/-/chart-2.0.0-beta2.tgz",
-      "integrity": "sha512-Q0BB/7eJQUJpjo9IjmTxwUYHUeHFbIVA+yjoIisyh/TgbyoPqbId1++1aexhfB6O2MBUNP36XVIXrNMNJ4ZF0g==",
-      "dependencies": {
-        "chart.js": "^4.2.1",
-        "chartjs-adapter-luxon": "^1.3.1",
-        "chartjs-chart-error-bars": "^4.1.2"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      }
-    },
-    "node_modules/@eox/drawtools": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/@eox/drawtools/-/drawtools-0.6.1.tgz",
-      "integrity": "sha512-LwFvCNAfX+VUGF4qbwL3PQgrdhcT24iBcPabRhDSht++edu8vXUmWKQjoRhOax3xOn7J2ER5tR9c4N4uj34Yqg==",
-      "dependencies": {
-        "lit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      }
-    },
-    "node_modules/@eox/itemfilter": {
-      "version": "0.12.1",
-      "resolved": "https://registry.npmjs.org/@eox/itemfilter/-/itemfilter-0.12.1.tgz",
-      "integrity": "sha512-goE844hAKPV+/nj4l5iPVIFR3UHqvzSxrYR2GzwQE0Xo0fLENtefDqsFgpQylmuHMmBujeRmZV0j3DWUvyXvFA==",
-      "dependencies": {
-        "@floating-ui/dom": "^1.5.3",
-        "@turf/boolean-intersects": "^6.5.0",
-        "@turf/boolean-within": "^6.5.0",
-        "fuse.js": "^7.0.0",
-        "lit": "^3.0.2",
-        "lodash.debounce": "^4.0.8",
-        "toolcool-range-slider": "^4.0.27"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      }
-    },
-    "node_modules/@eox/jsonform": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@eox/jsonform/-/jsonform-0.2.1.tgz",
-      "integrity": "sha512-kCrPkMq+USwrZ6SrE8OFjWWSxf/tB/k0b2urmb1bBw+8wAH/vDeARowRt/UfVT1yW5atKbjGNf8O9ZO4ups8ig==",
-      "dependencies": {
-        "@json-editor/json-editor": "^2.11.0",
-        "toolcool-range-slider": "^4.0.28"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      }
-    },
-    "node_modules/@eox/layercontrol": {
-      "version": "0.15.1",
-      "resolved": "https://registry.npmjs.org/@eox/layercontrol/-/layercontrol-0.15.1.tgz",
-      "integrity": "sha512-iI73VMWOSk4UIRy/XAt0YHx4fHiw9V8ehLhO8+akGnV50CCY7Vaghhbe8xFiLwaTv2GOYxkpVVS+jJfvd7q9EQ==",
-      "dependencies": {
-        "dayjs": "^1.11.8",
-        "lit": "^3.0.2",
-        "lodash.debounce": "^4.0.8",
-        "wms-capabilities": "^0.6.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      }
-    },
     "node_modules/@eox/layout": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@eox/layout/-/layout-0.1.0.tgz",
       "integrity": "sha512-FkcpjZ0uT6Dj5RVoWmtEEPUU/l1QGULEAdR/O120NH3JyjGxke1uU1GMmTDJRnOzdsUyl6YD+W9W+RY1ltpsug=="
-    },
-    "node_modules/@eox/map": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@eox/map/-/map-1.3.0.tgz",
-      "integrity": "sha512-ADXBWaa1gduNhzAEyGi4lvIFQi5sgUBtIvRVGT75XDEYTErh1rqDHQxnVRFcOesZK0QadW7p9hZ/QBGzBg8YoA==",
-      "dependencies": {
-        "lit": "^3.0.2",
-        "ol": "^9.0.0",
-        "ol-stac": "^1.0.0-beta.8",
-        "proj4": "^2.9.2"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      }
     },
     "node_modules/@eox/stacinfo": {
       "version": "0.3.0",
@@ -204,20 +110,6 @@
       "dependencies": {
         "@radiantearth/stac-fields": "^1.3.2",
         "lit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
-      }
-    },
-    "node_modules/@eox/timecontrol": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@eox/timecontrol/-/timecontrol-0.3.0.tgz",
-      "integrity": "sha512-KLVtaY/+CE58t+NNxXffIHPXPk/2y6Iam268h9Ba6qCNZYhM0r/dCy5FxZhKibvAxF60K2OygMVT/S2WIWGaJA==",
-      "dependencies": {
-        "dayjs": "^1.11.9",
-        "lit": "^3.0.2",
-        "toolcool-range-slider": "^4.0.27"
       },
       "engines": {
         "node": ">=18.0.0",
@@ -625,28 +517,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/@floating-ui/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.1"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
-      "dependencies": {
-        "@floating-ui/core": "^1.0.0",
-        "@floating-ui/utils": "^0.2.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.14",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.14.tgz",
@@ -684,22 +554,6 @@
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
       "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
-    },
-    "node_modules/@json-editor/json-editor": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/@json-editor/json-editor/-/json-editor-2.14.1.tgz",
-      "integrity": "sha512-Q6ACH6bHYtOCtM8AElkwzLYlTt9wzwzea2+ju40cl+s2IH0nM2r9nq3EX9jxSO9/oWJstJLnyuV95vomtSZYqw==",
-      "dependencies": {
-        "core-js": "^3.27.2"
-      },
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/@kurkle/color": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.2.tgz",
-      "integrity": "sha512-fuscdXJ9G1qb7W8VdHi+IwRqij3lBkosAm4ydQtEmbY58OzHXqQhvlxqEkoz0yssNVn38bcpRWgA9PP+OGoisw=="
     },
     "node_modules/@lit-labs/ssr-dom-shim": {
       "version": "1.2.0",
@@ -844,11 +698,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/@petamoriken/float16": {
-      "version": "3.8.5",
-      "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.5.tgz",
-      "integrity": "sha512-XCO48r7/l1BMzA0DuB9/osQ6cXWk3PUl90RqFUjR2DB/LIpY98aEpzjYTkiRh2a5nTgEA8kDFDy88O0Kiib/wA=="
-    },
     "node_modules/@radiantearth/stac-fields": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@radiantearth/stac-fields/-/stac-fields-1.3.2.tgz",
@@ -858,19 +707,6 @@
         "commonmark": "^0.29.3",
         "content-type": "^1.0.4",
         "multihashes": "^3.1.2"
-      }
-    },
-    "node_modules/@radiantearth/stac-migrate": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@radiantearth/stac-migrate/-/stac-migrate-1.6.0.tgz",
-      "integrity": "sha512-/Ke5Uyz4gvi0EyhYF3X2ZrMZ96Ikc9LvhgXgo1RbTWzFhD2s9w9KzK1N9V7odGdsBLlqVjvVwQCT73pghfdZzg==",
-      "dependencies": {
-        "compare-versions": "^3.6.0",
-        "multihashes": "^3.1.2",
-        "yargs": "^17.6.2"
-      },
-      "bin": {
-        "stac-migrate": "bin/cli.js"
       }
     },
     "node_modules/@rollup/pluginutils": {
@@ -1152,155 +988,6 @@
         "sprintf-js": "~1.0.2"
       }
     },
-    "node_modules/@turf/bbox": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.5.0.tgz",
-      "integrity": "sha512-RBbLaao5hXTYyyg577iuMtDB8ehxMlUqHEJiMs8jT1GHkFhr6sYre3lmLsPeYEi/ZKj5TP5tt7fkzNdJ4GIVyw==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-disjoint": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-disjoint/-/boolean-disjoint-6.5.0.tgz",
-      "integrity": "sha512-rZ2ozlrRLIAGo2bjQ/ZUu4oZ/+ZjGvLkN5CKXSKBcu6xFO6k2bgqeM8a1836tAW+Pqp/ZFsTA5fZHsJZvP2D5g==",
-      "dependencies": {
-        "@turf/boolean-point-in-polygon": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/line-intersect": "^6.5.0",
-        "@turf/meta": "^6.5.0",
-        "@turf/polygon-to-line": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-intersects": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-intersects/-/boolean-intersects-6.5.0.tgz",
-      "integrity": "sha512-nIxkizjRdjKCYFQMnml6cjPsDOBCThrt+nkqtSEcxkKMhAQj5OO7o2CecioNTaX8EayqwMGVKcsz27oP4mKPTw==",
-      "dependencies": {
-        "@turf/boolean-disjoint": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/meta": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-point-in-polygon": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz",
-      "integrity": "sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-point-on-line": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-point-on-line/-/boolean-point-on-line-6.5.0.tgz",
-      "integrity": "sha512-A1BbuQ0LceLHvq7F/P7w3QvfpmZqbmViIUPHdNLvZimFNLo4e6IQunmzbe+8aSStH9QRZm3VOflyvNeXvvpZEQ==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/boolean-within": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/boolean-within/-/boolean-within-6.5.0.tgz",
-      "integrity": "sha512-YQB3oU18Inx35C/LU930D36RAVe7LDXk1kWsQ8mLmuqYn9YdPsDQTMTkLJMhoQ8EbN7QTdy333xRQ4MYgToteQ==",
-      "dependencies": {
-        "@turf/bbox": "^6.5.0",
-        "@turf/boolean-point-in-polygon": "^6.5.0",
-        "@turf/boolean-point-on-line": "^6.5.0",
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/helpers": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-6.5.0.tgz",
-      "integrity": "sha512-VbI1dV5bLFzohYYdgqwikdMVpe7pJ9X3E+dlr425wa2/sMJqYDhTO++ec38/pcPvPE6oD9WEEeU3Xu3gza+VPw==",
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/invariant": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/invariant/-/invariant-6.5.0.tgz",
-      "integrity": "sha512-Wv8PRNCtPD31UVbdJE/KVAWKe7l6US+lJItRR/HOEW3eh+U/JwRCSUl/KZ7bmjM/C+zLNoreM2TU6OoLACs4eg==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-intersect": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-intersect/-/line-intersect-6.5.0.tgz",
-      "integrity": "sha512-CS6R1tZvVQD390G9Ea4pmpM6mJGPWoL82jD46y0q1KSor9s6HupMIo1kY4Ny+AEYQl9jd21V3Scz20eldpbTVA==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/line-segment": "^6.5.0",
-        "@turf/meta": "^6.5.0",
-        "geojson-rbush": "3.x"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/line-segment": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/line-segment/-/line-segment-6.5.0.tgz",
-      "integrity": "sha512-jI625Ho4jSuJESNq66Mmi290ZJ5pPZiQZruPVpmHkUw257Pew0alMmb6YrqYNnLUuiVVONxAAKXUVeeUGtycfw==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0",
-        "@turf/meta": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/meta": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-6.5.0.tgz",
-      "integrity": "sha512-RrArvtsV0vdsCBegoBtOalgdSOfkBrTJ07VkpiCnq/491W67hnMWmDu7e6Ztw0C3WldRYTXkg3SumfdzZxLBHA==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
-    "node_modules/@turf/polygon-to-line": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/@turf/polygon-to-line/-/polygon-to-line-6.5.0.tgz",
-      "integrity": "sha512-5p4n/ij97EIttAq+ewSnKt0ruvuM+LIDzuczSzuHTpq4oS7Oq8yqg5TQ4nzMVuK41r/tALCk7nAoBuw3Su4Gcw==",
-      "dependencies": {
-        "@turf/helpers": "^6.5.0",
-        "@turf/invariant": "^6.5.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/turf"
-      }
-    },
     "node_modules/@types/argparse": {
       "version": "1.0.38",
       "resolved": "https://registry.npmjs.org/@types/argparse/-/argparse-1.0.38.tgz",
@@ -1311,11 +998,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.5.tgz",
       "integrity": "sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw=="
-    },
-    "node_modules/@types/geojson": {
-      "version": "7946.0.8",
-      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.8.tgz",
-      "integrity": "sha512-1rkryxURpr6aWP7R786/UQOkJ3PcpQiWkAXBmdWc7ryFWqN6a4xfK7BtjXvFBKO9LjQ+MWQSWxYeZX1OApnArA=="
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1832,6 +1514,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -1846,6 +1529,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1996,34 +1680,6 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
-    "node_modules/chart.js": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.4.2.tgz",
-      "integrity": "sha512-6GD7iKwFpP5kbSD4MeRRRlTnQvxfQREy36uEtm1hzHzcOqwWx0YEHuspuoNlslu+nciLIB7fjjsHkUv/FzFcOg==",
-      "dependencies": {
-        "@kurkle/color": "^0.3.0"
-      },
-      "engines": {
-        "pnpm": ">=8"
-      }
-    },
-    "node_modules/chartjs-adapter-luxon": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/chartjs-adapter-luxon/-/chartjs-adapter-luxon-1.3.1.tgz",
-      "integrity": "sha512-yxHov3X8y+reIibl1o+j18xzrcdddCLqsXhriV2+aQ4hCR66IYFchlRXUvrJVoxglJ380pgytU7YWtoqdIgqhg==",
-      "peerDependencies": {
-        "chart.js": ">=3.0.0",
-        "luxon": ">=1.0.0"
-      }
-    },
-    "node_modules/chartjs-chart-error-bars": {
-      "version": "4.3.4",
-      "resolved": "https://registry.npmjs.org/chartjs-chart-error-bars/-/chartjs-chart-error-bars-4.3.4.tgz",
-      "integrity": "sha512-EQdWsbiMZ5hatjEFEIeKEzhArJsbbd10h6jfx9LTdDl4Ywyoel5ApbJX5iqqm9jXGfaEw3ZdpuzzmEvswQqfDw==",
-      "peerDependencies": {
-        "chart.js": "^4.1.0"
-      }
-    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -2047,23 +1703,11 @@
         "fsevents": "~2.3.2"
       }
     },
-    "node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2074,29 +1718,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-    },
-    "node_modules/color-parse": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.0.tgz",
-      "integrity": "sha512-g2Z+QnWsdHLppAbrpcFWo629kLOnOPtpxYV69GCqm92gqSgyXbzlfyN3MXs0412fPBkFmiuS+rXposgBgBa6Kg==",
-      "dependencies": {
-        "color-name": "^1.0.0"
-      }
-    },
-    "node_modules/color-rgba": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
-      "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
-      "dependencies": {
-        "color-parse": "^2.0.0",
-        "color-space": "^2.0.0"
-      }
-    },
-    "node_modules/color-space": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz",
-      "integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/colors": {
       "version": "1.2.5",
@@ -2144,11 +1767,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/compare-versions": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-3.6.0.tgz",
-      "integrity": "sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA=="
     },
     "node_modules/computeds": {
       "version": "0.0.1",
@@ -2210,11 +1828,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.10",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.10.tgz",
-      "integrity": "sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ=="
     },
     "node_modules/de-indent": {
       "version": "1.0.2",
@@ -2292,16 +1905,6 @@
         "node": ">=6.0.0"
       }
     },
-    "node_modules/earcut": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
-    },
-    "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-    },
     "node_modules/entities": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
@@ -2361,14 +1964,6 @@
         "@esbuild/win32-arm64": "0.19.12",
         "@esbuild/win32-ia32": "0.19.12",
         "@esbuild/win32-x64": "0.19.12"
-      }
-    },
-    "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/escape-string-regexp": {
@@ -2646,11 +2241,6 @@
         "reusify": "^1.0.4"
       }
     },
-    "node_modules/fflate": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
-      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A=="
-    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -2775,52 +2365,6 @@
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/fuse.js": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.0.0.tgz",
-      "integrity": "sha512-14F4hBIxqKvD4Zz/XjDc3y94mNZN6pRv3U13Udo0lNLCWRBUsrMv2xwcF/y/Z5sV6+FQW+/ow68cHpm4sunt8Q==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/geojson-rbush": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/geojson-rbush/-/geojson-rbush-3.2.0.tgz",
-      "integrity": "sha512-oVltQTXolxvsz1sZnutlSuLDEcQAKYC/uXt9zDzJJ6bu0W+baTI8LZBaTup5afzibEH4N3jlq2p+a152wlBJ7w==",
-      "dependencies": {
-        "@turf/bbox": "*",
-        "@turf/helpers": "6.x",
-        "@turf/meta": "6.x",
-        "@types/geojson": "7946.0.8",
-        "rbush": "^3.0.1"
-      }
-    },
-    "node_modules/geotiff": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.3.tgz",
-      "integrity": "sha512-PT6uoF5a1+kbC3tHmZSUsLHBp2QJlHasxxxxPW47QIY1VBKpFB+FcDvX+MxER6UzgLQZ0xDzJ9s48B9JbOCTqA==",
-      "dependencies": {
-        "@petamoriken/float16": "^3.4.7",
-        "lerc": "^3.0.0",
-        "pako": "^2.0.4",
-        "parse-headers": "^2.0.2",
-        "quick-lru": "^6.1.1",
-        "web-worker": "^1.2.0",
-        "xml-utils": "^1.0.2",
-        "zstddec": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=10.19"
-      }
-    },
-    "node_modules/get-caller-file": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
-      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
-      "engines": {
-        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/get-intrinsic": {
@@ -3007,25 +2551,6 @@
         "he": "bin/he"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -3144,14 +2669,6 @@
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-fullwidth-code-point": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
-      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-generator-function": {
@@ -3273,11 +2790,6 @@
       "integrity": "sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==",
       "dev": true
     },
-    "node_modules/lerc": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
-      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
-    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -3340,11 +2852,6 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
-    "node_modules/lodash.debounce": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
-      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -3380,15 +2887,6 @@
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
       "integrity": "sha512-zTU3DaZaF3Rt9rhN3uBMGQD3dD2/vFQqnvZCDv4dl5iOzq2IZQqTxu90r4E5J+nP70J3ilqVCrbho2eWaeW8Ow==",
       "dev": true
-    },
-    "node_modules/luxon": {
-      "version": "3.4.4",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
-      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/magic-string": {
       "version": "0.30.8",
@@ -3426,11 +2924,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/mgrs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/mgrs/-/mgrs-1.0.0.tgz",
-      "integrity": "sha512-awNbTOqCxK1DBGjalK3xqWIstBZgN6fxsMSiXLs9/spqWkF2pAhb2rrYCFSsr1/tT7PhcDGjZndG8SWYn0byYA=="
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -3583,46 +3076,6 @@
         "url": "https://github.com/fb55/nth-check?sponsor=1"
       }
     },
-    "node_modules/ol": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/ol/-/ol-9.0.0.tgz",
-      "integrity": "sha512-+nYHZYbHrRUTDJ8ryxXPdDoAiaT6Zea02cocmGqsJXs4Oac1fYC9EbTIU2Y7803QcmG3u2MR88RxbksBvK+ZfQ==",
-      "dependencies": {
-        "color-rgba": "^3.0.0",
-        "color-space": "^2.0.1",
-        "earcut": "^2.2.3",
-        "geotiff": "^2.0.7",
-        "pbf": "3.2.1",
-        "rbush": "^3.0.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/openlayers"
-      }
-    },
-    "node_modules/ol-pmtiles": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/ol-pmtiles/-/ol-pmtiles-0.2.0.tgz",
-      "integrity": "sha512-PPDc77kJ+GlDNFjCcoAQ5MTHQTDfxuBN4fL1x/TXnAEPmUT/DAyQsHZZtU3PXnw2NimlgCX7v/Plr9SVivPpAQ==",
-      "dependencies": {
-        "pmtiles": "^2.10.0"
-      },
-      "peerDependencies": {
-        "ol": ">=7.3.0"
-      }
-    },
-    "node_modules/ol-stac": {
-      "version": "1.0.0-beta.8",
-      "resolved": "https://registry.npmjs.org/ol-stac/-/ol-stac-1.0.0-beta.8.tgz",
-      "integrity": "sha512-3DzU+hDE0RRSjdIEoLUtTZc/lDNilK5WHLb1pb3cJqV1A4vEfMykZSu304jpoFqA9G2Hc9i3q0r/eaK3deZe2w==",
-      "dependencies": {
-        "ol-pmtiles": "^0.2.0",
-        "stac-js": "0.0.8"
-      },
-      "peerDependencies": {
-        "ol": ">=7.0.0"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3679,11 +3132,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/pako": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -3695,11 +3143,6 @@
       "engines": {
         "node": ">=6"
       }
-    },
-    "node_modules/parse-headers": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "node_modules/path-browserify": {
       "version": "1.0.1",
@@ -3747,18 +3190,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/pbf": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
-      "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "dependencies": {
-        "ieee754": "^1.1.12",
-        "resolve-protobuf-schema": "^2.1.0"
-      },
-      "bin": {
-        "pbf": "bin/pbf"
       }
     },
     "node_modules/picocolors": {
@@ -3827,14 +3258,6 @@
         }
       }
     },
-    "node_modules/pmtiles": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/pmtiles/-/pmtiles-2.11.0.tgz",
-      "integrity": "sha512-dU9SzzaqmCGpdEuTnIba6bDHT6j09ZJFIXxwGpvkiEnce3ZnBB1VKt6+EOmJGueriweaZLAMTUmKVElU2CBe0g==",
-      "dependencies": {
-        "fflate": "^0.8.0"
-      }
-    },
     "node_modules/possible-typed-array-names": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.0.0.tgz",
@@ -3892,20 +3315,6 @@
         "node": ">= 0.8.0"
       }
     },
-    "node_modules/proj4": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/proj4/-/proj4-2.10.0.tgz",
-      "integrity": "sha512-0eyB8h1PDoWxucnq88/EZqt7UZlvjhcfbXCcINpE7hqRN0iRPWE/4mXINGulNa/FAvK+Ie7F+l2OxH/0uKV36A==",
-      "dependencies": {
-        "mgrs": "1.0.0",
-        "wkt-parser": "^1.3.3"
-      }
-    },
-    "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
-    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3940,30 +3349,6 @@
         }
       ]
     },
-    "node_modules/quick-lru": {
-      "version": "6.1.2",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
-      "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/quickselect": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
-    },
-    "node_modules/rbush": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
-      "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-      "dependencies": {
-        "quickselect": "^2.0.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3973,14 +3358,6 @@
       },
       "engines": {
         "node": ">=8.10.0"
-      }
-    },
-    "node_modules/require-directory": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
-      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -4007,14 +3384,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/resolve-protobuf-schema": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
-      "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dependencies": {
-        "protocol-buffers-schema": "^3.3.1"
       }
     },
     "node_modules/reusify": {
@@ -4233,15 +3602,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
     },
-    "node_modules/stac-js": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/stac-js/-/stac-js-0.0.8.tgz",
-      "integrity": "sha512-x8dC5eoDY3kAeuvhmsLUHTCYZIJeoWg3s3vjo7IKZg+TSx3lJ1+i3oy7K8urTE4JU0sxldrttwBfacwLYYrkMw==",
-      "dependencies": {
-        "@radiantearth/stac-migrate": "^1.5.0",
-        "urijs": "^1.19.11"
-      }
-    },
     "node_modules/stac-ts": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stac-ts/-/stac-ts-1.0.3.tgz",
@@ -4257,19 +3617,6 @@
         "node": ">=0.6.19"
       }
     },
-    "node_modules/string-width": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
-      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-      "dependencies": {
-        "emoji-regex": "^8.0.0",
-        "is-fullwidth-code-point": "^3.0.0",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/string.prototype.repeat": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz",
@@ -4279,6 +3626,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -4347,11 +3695,6 @@
       "engines": {
         "node": ">=8.0"
       }
-    },
-    "node_modules/toolcool-range-slider": {
-      "version": "4.0.28",
-      "resolved": "https://registry.npmjs.org/toolcool-range-slider/-/toolcool-range-slider-4.0.28.tgz",
-      "integrity": "sha512-DDZAEJ9hItgSbGWY6DkjvMoUBLZG9J3X6qvBzAruvGzcPwrZKRt3EB2ixPqFmrpEy98SyyM+WZbKL0+TR4fOkg=="
     },
     "node_modules/tslib": {
       "version": "1.14.1",
@@ -4544,11 +3887,6 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
-    },
-    "node_modules/urijs": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.11.tgz",
-      "integrity": "sha512-HXgFDgDommxn5/bIv0cnQZsPhHDA90NPHD6+c/v21U5+Sx5hoP8+dP9IZXBU1gIfvdRfhG8cel9QNPeionfcCQ=="
     },
     "node_modules/util": {
       "version": "0.12.5",
@@ -4854,11 +4192,6 @@
         "@zxing/text-encoding": "0.9.0"
       }
     },
-    "node_modules/web-worker": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
-      "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA=="
-    },
     "node_modules/webfontloader": {
       "version": "1.6.28",
       "resolved": "https://registry.npmjs.org/webfontloader/-/webfontloader-1.6.28.tgz",
@@ -4912,40 +4245,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/wkt-parser": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/wkt-parser/-/wkt-parser-1.3.3.tgz",
-      "integrity": "sha512-ZnV3yH8/k58ZPACOXeiHaMuXIiaTk1t0hSUVisbO0t4RjA5wPpUytcxeyiN2h+LZRrmuHIh/1UlrR9e7DHDvTw=="
-    },
-    "node_modules/wms-capabilities": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/wms-capabilities/-/wms-capabilities-0.6.0.tgz",
-      "integrity": "sha512-yTbtesuSyKkHhw1TUX4VklXEkbQByc+hyo7TWq1sGjBA6tQ+XN32w546TPDTzROuwFTE/Dcq5F5FN4aA9nesaQ==",
-      "bin": {
-        "wmscapabilities": "bin/wmscapabilities"
-      }
-    },
     "node_modules/wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
       "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q==",
       "dev": true
-    },
-    "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-      "dependencies": {
-        "ansi-styles": "^4.0.0",
-        "string-width": "^4.1.0",
-        "strip-ansi": "^6.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-      }
     },
     "node_modules/wrappy": {
       "version": "1.0.2",
@@ -4962,49 +4266,11 @@
         "node": ">=12"
       }
     },
-    "node_modules/xml-utils": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.7.0.tgz",
-      "integrity": "sha512-bWB489+RQQclC7A9OW8e5BzbT8Tu//jtAOvkYwewFr+Q9T9KDGvfzC1lp0pYPEQPEoPQLDkmxkepSC/2gIAZGw=="
-    },
-    "node_modules/y18n": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
-      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
-    },
-    "node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "engines": {
-        "node": ">=12"
-      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
@@ -5037,11 +4303,6 @@
       "optionalDependencies": {
         "commander": "^9.4.1"
       }
-    },
-    "node_modules/zstddec": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
-      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "eodash",
-  "version": "5.0.0-alpha.1",
+
+  "name": "@eodash/eodash",
+  "version": "5.0.0-alpha.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "eodash",
-      "version": "5.0.0-alpha.1",
+      "name": "@eodash/eodash",
+      "version": "5.0.0-alpha.1.6",
       "dependencies": {
         "@eox/layout": "^0.1.0",
         "@eox/stacinfo": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "eodash",
-  "version": "5.0.0-alpha",
+  "version": "5.0.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "eodash",
-      "version": "5.0.0-alpha",
+      "version": "5.0.0-alpha.1",
       "dependencies": {
         "@eox/chart": "^2.0.0-beta2",
         "@eox/drawtools": "^0.6.1",
@@ -26,6 +26,7 @@
         "roboto-fontface": "*",
         "sass": "^1.60.0",
         "vite": "^5.1.5",
+        "vite-plugin-virtual": "^0.3.0",
         "vite-plugin-vuetify": "^2.0.0",
         "vue": "^3.2.0",
         "vue-router": "^4.0.0",
@@ -2840,26 +2841,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/glob-parent": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
@@ -4061,6 +4042,26 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rimraf/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/roboto-fontface": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/roboto-fontface/-/roboto-fontface-0.10.0.tgz",
@@ -4659,6 +4660,14 @@
         "vite": {
           "optional": true
         }
+      }
+    },
+    "node_modules/vite-plugin-virtual": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/vite-plugin-virtual/-/vite-plugin-virtual-0.3.0.tgz",
+      "integrity": "sha512-TOtrWw6jKrJNXfxhGRUiQzfAP1gRkYkVzMkJNjHUJ8idLuxf8eeeDKZKZHhdeYfaCc/87rv+KvWE2iCy1QInWA==",
+      "peerDependencies": {
+        "vite": "^2.0.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/vite-plugin-vuetify": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eodash/eodash",
-  "version": "5.0.0-alpha.1",
+  "version": "5.0.0-alpha.1.1",
   "type": "module",
   "types": "./core/types.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -26,15 +26,8 @@
     "docs:generate": "typedoc --plugin typedoc-plugin-markdown core/store/Types.ts --tsconfig tsconfig.json --out docs --readme none"
   },
   "dependencies": {
-    "@eox/chart": "^2.0.0-beta2",
-    "@eox/drawtools": "^0.6.1",
-    "@eox/itemfilter": "^0.12.1",
-    "@eox/jsonform": "^0.2.1",
-    "@eox/layercontrol": "^0.15.1",
     "@eox/layout": "^0.1.0",
-    "@eox/map": "^1.1.0",
     "@eox/stacinfo": "^0.3.0",
-    "@eox/timecontrol": "^0.3.0",
     "@mdi/font": "7.0.96",
     "@vitejs/plugin-vue": "^5.0.0",
     "animated-details": "gist:2912bb049fa906671807415eb0e87188",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eodash",
+  "name": "@eodash/eodash",
   "version": "5.0.0-alpha.1",
   "type": "module",
   "types": "./core/types.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eodash/eodash",
-  "version": "5.0.0-alpha.1.6",
+  "version": "5.0.0-alpha.1.7",
   "type": "module",
   "types": "./core/types.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eodash/eodash",
-  "version": "5.0.0-alpha.1.1",
+  "version": "5.0.0-alpha.1.6",
   "type": "module",
   "types": "./core/types.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,14 +1,20 @@
 {
   "name": "eodash",
-  "version": "5.0.0-alpha",
+  "version": "5.0.0-alpha.1",
   "type": "module",
-  "types": "core/types.d.ts",
+  "types": "./core/types.d.ts",
   "files": [
     "core",
     "bin",
     "widgets"
   ],
-  "browser": "./dist/index.html",
+  "exports": {
+    ".": {
+      "types": "./core/types.d.ts",
+      "default": "./core/main.js"
+    }
+  },
+  "browser": "./core/main.js",
   "scripts": {
     "dev": "npx eodash dev",
     "build": "npx eodash build",
@@ -37,6 +43,7 @@
     "pinia": "^2.0.0",
     "roboto-fontface": "*",
     "vite": "^5.1.5",
+    "vite-plugin-virtual": "^0.3.0",
     "vite-plugin-vuetify": "^2.0.0",
     "vue": "^3.2.0",
     "vue-router": "^4.0.0",


### PR DESCRIPTION
This exposes [defineConfig](https://github.com/eodash/eodash/blob/3a6fecd3d95348b7c55cb4fd297d179593f1d6c1/core/composables/DefineConfig.js#L40) function to define compile-time configuration. It assumes that the function is exported as a default in `src/config.js` and imports the file as a virtual module into the app. Giving priority to the runtime config, the application checks for `src/config.runtime.js` first, and if it doesn't exist then it imports `src/config.js`.  It also solves importing web components as node modules by changing the widgets of type `"web-component"` API to enable adding an import function in the `link` property after installing the desired package in the root project. See [config-template](https://github.com/eodash/config-template/blob/1a55d4f049a48c21bff7bb5b39453b83a158fbb8/src/config.js#L176) on branch [compile-time-config](https://github.com/eodash/config-template/tree/compile-time-config).

### Changes include:
* making `core/main.js` the main entry point of the package and moving the app's mounting implementation to `core/render.js`.
* removing node modules map.
* adapting package.json.
* adapting type definitions
* changing package name to `@eodash/eodash`
* update  to version `5.0.0-alpha.1.1`