### PR TITLE
Feat: general fixes and API changes

### DIFF
--- a/core/components/DashboardLayout.vue
+++ b/core/components/DashboardLayout.vue
@@ -7,8 +7,8 @@
       <eox-layout-item v-for="(config, idx) in widgetsConfig" ref="itemEls" :key="idx" class="custom-widget"
         :x="config.layout.x" :y="config.layout.y" :h="config.layout.h" :w="config.layout.w">
 
-        <v-btn position="absolute" variant="tonal" :style="slideBtns[idx].style" class="slide-btn"
-          @click="slideInOut(idx)">
+        <v-btn v-if="slideBtns[idx].enabled" position="absolute" variant="tonal" :style="slideBtns[idx].style"
+          class="slide-btn" @click="slideInOut(idx)">
           <v-icon :icon="slideBtns[idx].active ? slideBtns[idx].icon.in : slideBtns[idx].icon.out" />
         </v-btn>
         <component :key="importedWidgets[idx].value.id" :is="importedWidgets[idx].value.component"

--- a/core/components/Footer.vue
+++ b/core/components/Footer.vue
@@ -2,7 +2,7 @@
   <v-footer ref="footer" :height="mdAndDown ? '48px' : 'auto'" color="secondary" app
     class="d-flex justify-space-between">
     <p class="pt-0 footer-text">
-      Phasellus feugiat arcu sapien, et iaculis ipsum elementum sit amet. Mauris cursus commodo interdum.
+      {{ eodash.brand.footerText ?? "" }}
     </p>
     <div class="footer-text">
       {{ new Date().getFullYear() }} — <strong>{{ title }}</strong>

--- a/core/components/MobileLayout.vue
+++ b/core/components/MobileLayout.vue
@@ -1,29 +1,29 @@
 <template>
-  <v-main class="overflow-none" style="height: 91dvh;">
+  <v-main class="overflow-hidden" style="height: 91dvh;">
 
     <component :is="bgWidget.component" v-bind="bgWidget.props"></component>
 
-    <v-row no-gutters class="d-flex justify-center align-end">
-      <v-col v-for="(importedWidget, idx) in importedWidgets" :key="idx" :cols="cols"
-        class="flex-column fill-height fill-width elevation-1 align-start ma-0 justify-center">
-        <span class="d-flex pa-2 justify-center ma-0 panel-header align-center fill-width"
-          @click="handleSelection(idx)">
-          {{ importedWidget.value.title }}
-        </span>
-        <div v-show="activeIdx === idx" class="overlay align-self-end overflow-auto pa-2">
-          <v-btn icon variant="text" class="close-btn" @click="activeIdx = -1">&#x2715;</v-btn>
-          <component :key="importedWidget.value.id" :is="importedWidget.value.component" v-show="activeIdx === idx"
-            v-bind="importedWidget.value.props" />
-        </div>
-      </v-col>
-    </v-row>
+    <div v-show="activeIdx === idx" class="overlay pa-2" :style="{ bottom: tabsBottom }"
+      v-for="(importedWidget, idx) in importedWidgets" :key="idx">
+      <v-btn icon variant="text" class="close-btn" @click="activeIdx = -1">&#x2715;</v-btn>
+      <component :key="importedWidget.value.id" :is="importedWidget.value.component" v-show="activeIdx === idx"
+        v-bind="importedWidget.value.props" />
+    </div>
+
+    <v-tabs ref="tabs" align-tabs="center" bg-color="surface"
+      :style="{ position: 'relative', bottom: mainRect.bottom + 'px', zIndex: 10 }" show-arrows v-model="activeIdx">
+      <v-tab v-for="(importedWidget, idx) in importedWidgets" :key="idx" :value="idx">
+        {{ importedWidget.value.title }}
+      </v-tab>
+    </v-tabs>
+
   </v-main>
 </template>
 <script setup>
 import { eodashKey } from '@/store/Keys';
-import { inject } from 'vue';
+import { inject, ref, onMounted } from 'vue';
 import { useDefineWidgets } from '@/composables/DefineWidgets'
-import { ref } from 'vue';
+import { useLayout } from "vuetify"
 
 const eodash = /** @type {import("@/types").Eodash} */(inject(eodashKey));
 
@@ -32,47 +32,30 @@ const widgetsConfig = eodash.template.widgets
 const importedWidgets = useDefineWidgets(widgetsConfig)
 const [bgWidget] = useDefineWidgets([eodash.template?.background])
 
+const { mainRect } = useLayout()
 
-
-/**
- * number of flex columns
- */
-const cols = importedWidgets.length / 12
-
-/**
- * index of the active tab
- */
 const activeIdx = ref(-1)
 
-/**
-* @param {number} idx
-**/
-const handleSelection = (idx) => {
-  activeIdx.value = activeIdx.value === idx ? -1 : idx
-}
+/** @type {import("vue").Ref<import("vuetify/components").VTabs|null>} */
+const tabs = ref(null)
+const tabsBottom = ref('')
+onMounted(() => {
+  tabsBottom.value = mainRect.value.bottom + (/** @type {HTMLElement} */(tabs.value?.$el)?.clientHeight ?? 0) + "px"
+})
 </script>
 <style scoped lang='scss'>
-.panel-header {
-  height: auto;
-  margin: 0;
-  width: 100%;
-  position: relative;
-  bottom: 64px;
-  z-index: 10;
-  background: rgb(var(--v-theme-background));
-}
-
 .overlay {
   position: absolute;
   width: 100%;
   left: 0;
   top: 64px;
-  bottom: 64px;
   z-index: 1;
-  background: rgb(var(--v-theme-background));
+  background: rgb(var(--v-theme-surface));
 }
 
 .close-btn {
-  justify-self: end;
+  position: relative;
+  height: 1rem;
+  font-size: 0.8rem;
 }
 </style>

--- a/core/composables/DefineWidgets.js
+++ b/core/composables/DefineWidgets.js
@@ -94,7 +94,7 @@ const getWidgetDefinition = (config) => {
         loader: internalWidgets[/** @type {import("@/types").InternalComponentWidget} **/(config)?.widget.name],
         suspensible: true
       })
-      importedWidget.props = reactive(/** @type {import("@/types").InternalComponentWidget} **/(config)?.widget.props ?? {})
+      importedWidget.props = reactive(/** @type {import("@/types").InternalComponentWidget} **/(config)?.widget.properties ?? {})
 
       break;
 

--- a/core/composables/index.js
+++ b/core/composables/index.js
@@ -53,9 +53,14 @@ export const useSlidePanels = (elements, configs) => {
   /**
    * Array of sliding button's style and icons
    */
-  const slideBtns = slideDirs.map(d => {
-    const btn = reactive({ style: {}, icon: { in: '', out: '' }, active: false })
-    switch (d) {
+  const slideBtns = slideDirs.map((dir, idx) => {
+    const btn = reactive({ style: {}, icon: { in: '', out: '' }, active: false, enabled: true })
+    if (configs[idx].slidable === false) {
+      btn.enabled = false
+      return btn
+    }
+
+    switch (dir) {
       case 'left':
         btn.style = { 'top': '50%', 'right': '-11%' }
         btn.icon.in = 'mdi-chevron-double-right'

--- a/core/eodash.js
+++ b/core/eodash.js
@@ -22,7 +22,8 @@ const eodash = reactive({
         surface: "#f0f0f0f0",
       }
     },
-    meta: {}
+    meta: {},
+    footerText: "Demo"
   },
   template: {
     background: {

--- a/core/eodash.js
+++ b/core/eodash.js
@@ -23,7 +23,7 @@ const eodash = reactive({
       }
     },
     meta: {},
-    footerText: "Demo"
+    footerText: "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
   },
   template: {
     background: {

--- a/core/eodash.js
+++ b/core/eodash.js
@@ -35,6 +35,7 @@ const eodash = reactive({
     widgets: [
       {
         id: Symbol(),
+        slidable: false,
         title: 'Tools',
         layout: { "x": 0, "y": 0, "w": 3, "h": 12 },
         widget: {

--- a/core/types.d.ts
+++ b/core/types.d.ts
@@ -312,8 +312,14 @@ export interface Eodash<T extends ExecutionTime = "compiletime"> {
      * Dashboard theme as a custom vuetifyJs theme.
      */
     theme?: ThemeDefinition
-
-    meta?: import("@unhead/vue").UseSeoMetaInput
+    /**
+     * meta tags configuration, using unhead's [useSeoMeta](https://unhead.unjs.io/usage/composables/use-seo-meta)
+     */
+    meta?: import("@unhead/vue").UseSeoMetaInput;
+    /**
+     * Text applied to the footer.
+     */
+    footerText?: string;
   }
   /**
    * Template configuration

--- a/core/types.d.ts
+++ b/core/types.d.ts
@@ -130,7 +130,7 @@ export interface InternalComponentWidget {
     /**
      * Specified Vue component props
      */
-    props?: Record<string, unknown>
+    properties?: Record<string, unknown>
   }
   type: 'internal'
 }

--- a/core/types.d.ts
+++ b/core/types.d.ts
@@ -123,8 +123,8 @@ export interface InternalComponentWidget {
   slidable?: boolean
   widget: {
     /**
-     * Internal Vue Components inside the [widgets](https://github.com/eodash/eodash/tree/main/widgets) folder can be referenced
-     * using their name without the extention .vue
+     * Internal Vue Components inside the [widgets](https://github.com/eodash/eodash/tree/main/widgets) folder. Referenced
+     * using their name without the .vue extention
      */
     name: string;
     /**
@@ -184,8 +184,8 @@ export interface IFrameWidget {
 export interface FunctionalWidget<T extends ExecutionTime = "compiletime"> {
   /**
    * Provides a functional definition of the widget,
-   * gets triggered whenever a stac object is selected.
-   * @param selectedSTAC - currently selected stac object
+   * gets triggered whenever a STAC object is selected.
+   * @param selectedSTAC - Currently selected STAC object
    */
   defineWidget: (selectedSTAC: StacCatalog | StacCollection | StacItem | null) => Omit<StaticWidget<T>, 'layout' | 'slidable'>
   layout: {
@@ -238,7 +238,8 @@ export interface Template<T extends ExecutionTime = "compiletime"> {
   gap?: number;
   /**
    * Widget rendered as the dashboard background.
-   * Has the same specifications of Widget without the `title` and  `layout` properties
+   * Has the same specifications of `Widget` without the `title` and  `layout` properties
+   * @see {@link Widget}
    */
   background?: BackgroundWidget<T>
   /**
@@ -254,6 +255,7 @@ export type InternalRoute = `/${string}`
 export type StacEndpoint = `${'https://' | 'http://'}${string}/catalog.json`
 
 /**
+ * @ignore
  * @group Eodash
  */
 export type ExecutionTime = "runtime" | "compiletime";
@@ -272,7 +274,7 @@ export interface Eodash<T extends ExecutionTime = "compiletime"> {
    **/
   stacEndpoint: StacEndpoint
   /**
-  * Renderes to navigation buttons on the app header.
+  * Renders navigation buttons on the app header.
   **/
   routes?: Array<{
     title: string,
@@ -288,7 +290,7 @@ export interface Eodash<T extends ExecutionTime = "compiletime"> {
      */
     font?: {
       /**
-       * Link to stylesheet that defines font-face.
+       * Link to stylesheet that defines font-face. Could be either a relative or absolute URL.
        */
       link?: string;
       /**
@@ -305,11 +307,11 @@ export interface Eodash<T extends ExecutionTime = "compiletime"> {
      */
     shortName?: string
     /**
-     * brand logo
+     * Brand logo
      */
     logo?: string;
     /**
-     * Dashboard theme as a custom vuetifyJs theme.
+     * Dashboard theme as a custom [vuetifyJs theme](https://vuetifyjs.com/en/features/theme/).
      */
     theme?: ThemeDefinition
     /**
@@ -364,7 +366,7 @@ export interface EodashStore {
 }
 ///////
 /**
- * Eodash server, build and setup configuration
+ * Extending [Vite's](https://vitejs.dev/) config to configure eodash's server, build and setup.
  * @group EodashConfig
  */
 export interface EodashConfig {
@@ -383,31 +385,32 @@ export interface EodashConfig {
     open?: boolean
   }
   /**
-   * base public path
+   * Base public path
    */
   base?: string;
   /**
-   * build target folder path
+   * Build target folder path
    */
   outDir?: string;
-  /** path to statically served assets folder, can be set to `false`
-   *  to disable serving assets statically
+  /**
+   * Path to statically served assets folder, can be set to `false`
+   * to disable serving assets statically
    **/
   publicDir?: string | false;
   /**
-   * cache folder
+   * Cache folder
    */
   cacheDir?: string
-  /** specifies main entry file, exporting `createEodash`*/
+  /** Specifies main entry file, exporting `createEodash`*/
   entryPoint?: string
   /**
-   * file exporting eodash client runtime config
+   * File exporting eodash client runtime config
    */
   runtime?: string
   widgets?: string
 }
 /**
- * project entry point should export this function as a default
+ * the project's entry point should export this function as a default
  * to instantiate eodash
  *
  * @param  configCallback

--- a/core/types.d.ts
+++ b/core/types.d.ts
@@ -48,7 +48,7 @@ export interface WebComponentProps<T extends ExecutionTime = "compiletime"> {
 
 /** @ignore */
 export interface WidgetsContainerProps {
-  widgets: Omit<Widget, 'layout'>[]
+  widgets: Omit<Widget, 'layout' | 'slidable'>[]
 }
 
 // eodash types:
@@ -79,7 +79,11 @@ export interface WebComponentWidget<T extends ExecutionTime = "compiletime"> {
      *  Height. Integer between 1 and 12
      */
     h: number
-  }
+  },
+  /**
+ * Enable/Disable widget sliding.
+ */
+  slidable?: boolean
   widget: WebComponentProps<T>
   type: 'web-component'
 }
@@ -113,6 +117,10 @@ export interface InternalComponentWidget {
      */
     h: number
   }
+  /**
+   * Enable/Disable widget sliding.
+   */
+  slidable?: boolean
   widget: {
     /**
      * Internal Vue Components inside the [widgets](https://github.com/eodash/eodash/tree/main/widgets) folder can be referenced
@@ -158,6 +166,10 @@ export interface IFrameWidget {
      */
     h: number
   }
+  /**
+  * Enable/Disable widget sliding.
+  */
+  slidable?: boolean;
   widget: {
     /**
      * The URL of the page to embed
@@ -175,7 +187,7 @@ export interface FunctionalWidget<T extends ExecutionTime = "compiletime"> {
    * gets triggered whenever a stac object is selected.
    * @param selectedSTAC - currently selected stac object
    */
-  defineWidget: (selectedSTAC: StacCatalog | StacCollection | StacItem | null) => Omit<StaticWidget<T>, 'layout'>
+  defineWidget: (selectedSTAC: StacCatalog | StacCollection | StacItem | null) => Omit<StaticWidget<T>, 'layout' | 'slidable'>
   layout: {
     /**
      *  Horizontal start position. Integer between 1 and 12
@@ -194,6 +206,10 @@ export interface FunctionalWidget<T extends ExecutionTime = "compiletime"> {
      */
     h: number
   }
+  /**
+  * Enable/Disable widget sliding.
+  */
+  slidable?: boolean
 }
 /**
  * @group Eodash
@@ -208,7 +224,7 @@ export type Widget<T extends ExecutionTime = "compiletime"> = StaticWidget<T> | 
 /**
  * @group Eodash
  */
-export type BackgroundWidget<T extends ExecutionTime = "compiletime"> = Omit<WebComponentWidget<T>, 'layout' | 'title'> | Omit<InternalComponentWidget, 'layout' | 'title'> | Omit<IFrameWidget, 'layout' | 'title'> | Omit<FunctionalWidget, 'layout'>
+export type BackgroundWidget<T extends ExecutionTime = "compiletime"> = Omit<WebComponentWidget<T>, 'layout' | 'title' | 'slidable'> | Omit<InternalComponentWidget, 'layout' | 'title' | 'slidable'> | Omit<IFrameWidget, 'layout' | 'title' | 'slidable'> | Omit<FunctionalWidget<T>, 'layout' | 'slidable'>
 /**
  * Dashboard rendered widgets  specification.
  * 3 types of widgets are supported: `"iframe"`, `"internal"`, and `"web-component"`.

--- a/core/utils/index.js
+++ b/core/utils/index.js
@@ -44,5 +44,4 @@ export const assignIndicator = (selectedSTAC) => {
   } else {
     indicator.value = ""
   }
-  console.log(indicator.value,/** @type {string} */(selectedSTAC?.code)),/** @type {string[]} */(selectedSTAC?.subcode)
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "preview": "vite preview",
     "lint": "eslint . --fix",
     "docs:generate": "typedoc --options typedoc.config.json",
-    "docs:dev": "vitepress dev docs",
+    "docs:dev": "vitepress dev docs --port 3333",
     "docs:build": "npm run docs:generate && vitepress build docs",
     "docs:preview": "vitepress preview docs"
   },

--- a/typedoc.config.json
+++ b/typedoc.config.json
@@ -9,5 +9,4 @@
     "excludeExternals": true,
     "entryPointStrategy": "resolve",
     "categorizeByGroup":true
-    
 }

--- a/widgets/EodashDatePicker.vue
+++ b/widgets/EodashDatePicker.vue
@@ -1,19 +1,18 @@
 <template>
   <span class="fill-height fill-width align-center justify-center">
     <div v-if="inline" class="fill-height fill-width">
-      <!-- <p class="text-subtitle-1 ma-1 pa-2">currently selected date is {{ currentDate }}</p> -->
-      <v-text-field base-color="primary" density="comfortable" type="date" bg-color="surface" color="primary"
-        validate-on="input" min="1980-01-01" :max="new Date().toISOString().split(`T`)[0]" label="Select Date"
-        :value="currentDate" v-model="currentDate" />
-    </div>
 
-    <v-date-picker v-else v-model="currentDate" color="primary" elevation="0" bg-color="surface" location="center"
-      class="overflow-auto fill-height fill-width" :max="new Date()" position="relative"
-      show-adjacent-months></v-date-picker>
+      <v-text-field base-color="primary" class="fill-height fill-width pa-2 align-center" type="date" bg-color="surface"
+        color="primary" density="comfortable" min="1980-01-01" :max="new Date().toISOString().split(`T`)[0]"
+        label="Select Date" v-model="currentDate" variant="plain" hide-details />
+    </div>
+    <v-date-picker v-else ref="datePicker" :width="width" :height="height" hide-header v-model="currentDate"
+      color="primary" bg-color="surface" location="center" class="overflow-auto fill-height fill-width" min="1980-01-01"
+      :max="new Date()" position="relative" show-adjacent-months></v-date-picker>
   </span>
 </template>
 <script setup>
-import { computed } from "vue";
+import { computed, ref, onMounted } from "vue";
 import { datetime } from "@/store/States"
 
 const props = defineProps(["inline"])
@@ -28,5 +27,20 @@ const currentDate = computed({
     }
     datetime.value = /** @type {Date} */ (updatedDate).toISOString()
   }
+})
+/**
+ * @type {import("vue").Ref<import("vuetify/components").VDatePicker
+ * | import("vuetify/components").VTextField | null>}
+ **/
+const datePicker = ref(null)
+/** @type {import("vue").Ref<string|undefined>} */
+const width = ref()
+/** @type {import("vue").Ref<string|undefined>} */
+const height = ref()
+onMounted(() => {
+  /** @type {HTMLElement} */
+  const parentEl = datePicker.value?.$el.parentElement?.parentElement
+  width.value = parentEl?.clientWidth ? parentEl?.clientWidth + "px" : undefined
+  height.value = parentEl?.clientHeight ? parentEl?.clientHeight + "px" : undefined
 })
 </script>


### PR DESCRIPTION
updates include:
-  introducing `slidable` property on widgets for enabling/disabling the sliding button.
- introducing `brand.footerText` property
- renaming widgets type "internal" `props` to `properties`
- fixing `widgets/EodashDatePicker.vue` size to fill widgets
- replacing mobile tabs with Vuetify's Vtabs.