### PR TITLE
Feat: Changing functional widgets position and size on indicator selection

### DIFF
--- a/core/client/components/DashboardLayout.vue
+++ b/core/client/components/DashboardLayout.vue
@@ -6,14 +6,13 @@
           <component id="bg-widget" :is="bgWidget.component" v-bind="bgWidget.props" />
         </Suspense>
       </eox-layout-item>
-      <template v-for="(config, idx) in widgetsConfig" :key="idx">
-        <eox-layout-item v-if="importedWidgets[idx].value.component"
+      <template v-for="(importedWidget, idx) in importedWidgets" :key="idx">
+        <eox-layout-item v-if="importedWidget.value.component" :key="importedWidget.value.id"
           style="position: relative; overflow: visible; z-index: 1; border-radius: 0px; background: rgb(var(--v-theme-surface))"
-          :x="config.layout.x" :y="config.layout.y" :h="config.layout.h" :w="config.layout.w">
-
+          v-bind="importedWidget.value.layout">
           <Suspense suspensible>
-            <component :key="importedWidgets[idx].value.id" :is="importedWidgets[idx].value.component"
-              v-bind="importedWidgets[idx].value.props" />
+            <component :key="importedWidget.value.id" :is="importedWidget.value.component"
+              v-bind="importedWidget.value.props" />
           </Suspense>
         </eox-layout-item>
       </template>
@@ -30,7 +29,5 @@ const eodash = /** @type {import("@/types").Eodash} */ (inject(eodashKey))
 
 const [bgWidget] = useDefineWidgets([eodash.template?.background])
 
-const widgetsConfig = eodash.template?.widgets
-
-const importedWidgets = useDefineWidgets(widgetsConfig)
+const importedWidgets = useDefineWidgets(eodash.template?.widgets)
 </script>

--- a/core/client/components/DashboardLayout.vue
+++ b/core/client/components/DashboardLayout.vue
@@ -7,14 +7,16 @@
         </Suspense>
       </eox-layout-item>
       <template v-for="(importedWidget, idx) in importedWidgets" :key="idx">
-        <eox-layout-item v-if="importedWidget.value.component" :key="importedWidget.value.id"
-          style="position: relative; overflow: visible; z-index: 1; border-radius: 0px; background: rgb(var(--v-theme-surface))"
-          v-bind="importedWidget.value.layout">
-          <Suspense suspensible>
-            <component :key="importedWidget.value.id" :is="importedWidget.value.component"
-              v-bind="importedWidget.value.props" />
-          </Suspense>
-        </eox-layout-item>
+        <Transition name="fade">
+          <eox-layout-item v-if="importedWidget.value.component" :key="importedWidget.value.id"
+            style="position: relative; overflow: visible; z-index: 1; border-radius: 0px; background: rgb(var(--v-theme-surface))"
+            v-bind="importedWidget.value.layout">
+            <Suspense suspensible>
+              <component :key="importedWidget.value.id" :is="importedWidget.value.component"
+                v-bind="importedWidget.value.props" />
+            </Suspense>
+          </eox-layout-item>
+        </Transition>
       </template>
     </eox-layout>
   </v-main>
@@ -31,3 +33,15 @@ const [bgWidget] = useDefineWidgets([eodash.template?.background])
 
 const importedWidgets = useDefineWidgets(eodash.template?.widgets)
 </script>
+
+<style scoped lang="scss">
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.25s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+  opacity: 0;
+}
+</style>

--- a/core/client/composables/DefineWidgets.js
+++ b/core/client/composables/DefineWidgets.js
@@ -5,10 +5,11 @@ import Loading from '@/components/Loading.vue';
 
 /**
  * @typedef {{
- *   component:import('vue').Component | null;
+ *   component: import('vue').Component | null;
  *   props: Record<string, unknown>;
- *   title :string;
- *   id:string|number|symbol;
+ *   title: string;
+ *   id: string | number | symbol;
+ *   layout: { x: number; y: number; h: number; w: number }
  * }} DefinedWidget
 */
 
@@ -55,6 +56,7 @@ export const useDefineWidgets = (widgetConfigs) => {
       props: {},
       title: '',
       id: Symbol(),
+      layout: { x: 0, y: 0, h: 0, w: 0 }
     })
 
     if ('defineWidget' in (config ?? {})) {
@@ -78,7 +80,7 @@ export const useDefineWidgets = (widgetConfigs) => {
 
 /**
  * Converts a static widget configuration to a defined imported widget
- * @param {import("@/types").StaticWidget| Omit<import("@/types").StaticWidget, "layout">| undefined | null} config
+ * @param {import("@/types").StaticWidget| Omit<import("@/types").StaticWidget, "layout">| undefined | null} [config]
  * @returns {DefinedWidget}
  **/
 const getWidgetDefinition = (config) => {
@@ -90,6 +92,7 @@ const getWidgetDefinition = (config) => {
     props: {},
     title: '',
     id: Symbol(),
+    layout: reactive({ x: 0, y: 0, h: 0, w: 0 })
   }
   switch (config?.type) {
     case 'internal':
@@ -130,6 +133,13 @@ const getWidgetDefinition = (config) => {
   }
   importedWidget.title = config?.title ?? ''
   importedWidget.id = config?.id ?? importedWidget.id
+
+  if ("layout" in config) {
+    importedWidget.layout.x = config.layout.x
+    importedWidget.layout.y = config.layout.y
+    importedWidget.layout.h = config.layout.h
+    importedWidget.layout.w = config.layout.w
+  }
   return importedWidget
 }
 

--- a/core/client/types.d.ts
+++ b/core/client/types.d.ts
@@ -46,6 +46,28 @@ export interface WidgetsContainerProps {
 
 // eodash types:
 /**
+ * properties of EOxLayoutItem used for setting
+ * the position and size of panels
+ */
+export interface Layout {
+  /**
+     *  Horizontal start position. Integer between 1 and 12
+     */
+  x: number
+  /**
+   *  Vertical start position. Integer between 1 and 12
+   */
+  y: number
+  /**
+   *  Width. Integer between 1 and 12
+   */
+  w: number
+  /**
+   *  Height. Integer between 1 and 12
+   */
+  h: number
+}
+/**
  * Widget type: `web-component` API
  * @group Eodash
  */
@@ -55,24 +77,7 @@ export interface WebComponentWidget<T extends ExecutionTime = "compiletime"> {
   /**
    * Widget position and size.
    */
-  layout: {
-    /**
-     *  Horizontal start position. Integer between 1 and 12
-     */
-    x: number
-    /**
-     *  Vertical start position. Integer between 1 and 12
-     */
-    y: number
-    /**
-     *  Width. Integer between 1 and 12
-     */
-    w: number
-    /**
-     *  Height. Integer between 1 and 12
-     */
-    h: number
-  },
+  layout: Layout,
   widget: WebComponentProps<T>
   type: 'web-component'
 }
@@ -88,24 +93,7 @@ export interface InternalComponentWidget {
   /**
   * Widget position and size.
   */
-  layout: {
-    /**
-     *  Horizontal start position. Integer between 1 and 12
-     */
-    x: number
-    /**
-     *  Vertical start position. Integer between 1 and 12
-     */
-    y: number
-    /**
-     *  Width. Integer between 1 and 12
-     */
-    w: number
-    /**
-     *  Height. Integer between 1 and 12
-     */
-    h: number
-  }
+  layout: Layout
   widget: {
     /**
      * Internal Vue Components inside the [widgets](https://github.com/eodash/eodash/tree/main/widgets) folder. Referenced
@@ -133,24 +121,7 @@ export interface IFrameWidget {
   /**
   * Widget position and size.
   */
-  layout: {
-    /**
-     *  Horizontal start position. Integer between 1 and 12
-     */
-    x: number
-    /**
-     *  Vertical start position. Integer between 1 and 12
-     */
-    y: number
-    /**
-     *  Width. Integer between 1 and 12
-     */
-    w: number
-    /**
-     *  Height. Integer between 1 and 12
-     */
-    h: number
-  }
+  layout: Layout
   widget: {
     /**
      * The URL of the page to embed
@@ -170,25 +141,7 @@ export interface FunctionalWidget<T extends ExecutionTime = "compiletime"> {
    * @param selectedSTAC - Currently selected STAC object
    */
   defineWidget: (selectedSTAC: import("stac-ts").StacCatalog |
-    import("stac-ts").StacCollection | import("stac-ts").StacItem | null) => Omit<StaticWidget<T>, 'layout' | 'slidable'> | undefined | null
-  layout: {
-    /**
-     *  Horizontal start position. Integer between 1 and 12
-     */
-    x: number
-    /**
-     *  Vertical start position. Integer between 1 and 12
-     */
-    y: number
-    /**
-     *  Width. Integer between 1 and 12
-     */
-    w: number
-    /**
-     *  Height. Integer between 1 and 12
-     */
-    h: number
-  }
+    import("stac-ts").StacCollection | import("stac-ts").StacItem | null) => StaticWidget<T> | undefined | null
 }
 /**
  * @group Eodash


### PR DESCRIPTION
This introduces the ability to change the layout property of a functional widget on selection. API changes includes updating type `FunctionWidgets` to include the `layout` property inside the returned widget.