### PR TITLE
Feat: Export map state 

### DIFF
--- a/core/client/composables/DefineWidgets.js
+++ b/core/client/composables/DefineWidgets.js
@@ -40,9 +40,9 @@ const internalWidgets = (() => {
  * @param {(
  *       | import("@/types").Widget
  *       | import("@/types").BackgroundWidget
+ *       | Omit<import("@/types").Widget, "layout">
  *       | undefined
  *     )[]
- *   | import("@/types").WidgetsContainerProps["widgets"]
  *   | undefined} widgetConfigs
  * @returns {ReactiveDefinedWidget[]}
  */

--- a/core/client/composables/index.js
+++ b/core/client/composables/index.js
@@ -122,3 +122,14 @@ export const useURLSearchParametersSync = () => {
     );
   });
 };
+
+/** @param {import("vue").Ref<HTMLElement|null>} root - components root element ref*/
+export const makePanelTransparent = (root) => {
+  onMounted(() => {
+    const eoxItem = root.value?.parentElement;
+    if (eoxItem?.tagName === "EOX-LAYOUT-ITEM") {
+      eoxItem.style.background = "transparent";
+      eoxItem.style.border = "transparent";
+    }
+  });
+};

--- a/core/client/eodash.js
+++ b/core/client/eodash.js
@@ -1,6 +1,6 @@
 import { reactive } from "vue";
 import { currentUrl } from "./store/States";
-
+// const exportState = ref(false);
 /**
  * Reactive Edoash Instance Object. provided globally in the app, and used as an
  * intermediate object to make user defined instances config reactive.
@@ -71,7 +71,6 @@ export const eodash = reactive({
                     styleOverride:
                       "#properties li > .value {font-weight: normal !important;}",
                     header: "[]",
-
                     subheader: "[]",
                     properties: '["description"]',
                     featured: "[]",
@@ -93,6 +92,21 @@ export const eodash = reactive({
                 title: "Datepicker",
                 widget: {
                   name: "EodashDatePicker",
+                },
+              }
+            : null;
+        },
+      },
+      {
+        defineWidget: (selected) => {
+          return selected
+            ? {
+                id: Symbol(),
+                layout: { x: 8, y: 0, w: 1, h: 1 },
+                title: "Buttons",
+                type: "internal",
+                widget: {
+                  name: "EodashMapBtns",
                 },
               }
             : null;

--- a/core/client/store/Actions.js
+++ b/core/client/store/Actions.js
@@ -1,0 +1,7 @@
+/**
+ * Returns the current layers of the `eox-map`
+ * @param {string} [el="eox-map"] - `eox-map` element selector
+ * @returns {object[]}
+ */
+//@ts-expect-error layers doesn't exist on type element
+export const getLayers = (el = "eox-map") => document.querySelector(el)?.layers

--- a/core/client/utils/index.js
+++ b/core/client/utils/index.js
@@ -37,3 +37,15 @@ export const loadFont = async (
   }
   return family;
 };
+
+/**
+ *  @param {string} text
+ *  @param {import("vue").Ref<boolean>} showIcon
+ **/
+export const copyToClipBoard = async (text,showIcon) =>{
+  await navigator.clipboard.writeText(text)
+  showIcon.value = true
+  setTimeout(()=>{
+    showIcon.value = false
+  },2000)
+}

--- a/widgets/EodashMapBtns.vue
+++ b/widgets/EodashMapBtns.vue
@@ -1,0 +1,34 @@
+<template>
+  <div ref="rootRef" class="d-flex align-end justify-end my-3 pa-2">
+    <v-btn
+      class="map-btn"
+      color="primary"
+      :icon="[mdiMapPlus]"
+      @click="showMapState = !showMapState"
+    />
+    <ExportState :header="header" :code="code" v-model="showMapState" />
+  </div>
+</template>
+<script setup>
+import { makePanelTransparent } from "@/composables";
+import { mdiMapPlus } from "@mdi/js";
+import ExportState from "^/ExportState.vue";
+import { ref } from "vue";
+const header = "Export Map";
+const code = `<h2>
+           code example
+         </h2>`;
+
+const showMapState = ref(false);
+
+/** @type {import("vue").Ref<HTMLDivElement|null>} */
+const rootRef = ref(null);
+makePanelTransparent(rootRef);
+</script>
+<style scoped>
+.map-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 25%;
+}
+</style>

--- a/widgets/ExportState.vue
+++ b/widgets/ExportState.vue
@@ -1,0 +1,109 @@
+<template>
+  <PopUp v-model="dialog">
+    <v-card>
+      <v-card-title class="background-primary position-sticky">
+        <h4 class="text-headline text-white">
+          Storytelling map configuration
+        </h4>
+      </v-card-title>
+
+      <v-card-text class="py-5">
+        <p class="text-body-2">
+          Copy and paste this code into the map layers field of the storytelling editor:
+        </p>
+        <div class="pa-3 code-block text-body-2">
+          {{ getLayers(props.for) }}
+        </div>
+
+        <div style="position: absolute; bottom: 15px;">
+          <v-expand-transition>
+            <div v-if="copySuccess" class="success--text mr-3">
+              <v-icon color="success" left :icon="[mdiClipboardCheckOutline]" />
+              <small>copied!</small>
+            </div>
+          </v-expand-transition>
+        </div>
+        <v-row class="d-flex flex-column   pt-3">
+          <v-col class="align-center text-end">
+            <v-btn v-for="btn in copyBtns" class="text-body-1" @click="btn.copyFn" :key="btn.id" small variant="text"
+              :prepend-icon="[mdiContentCopy]">
+              copy as {{ btn.copyAs }}
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-card-text>
+
+      <v-divider></v-divider>
+
+      <v-card-actions>
+        <v-spacer></v-spacer>
+        <v-btn color="primary" variant="text" @click="dialog = !dialog">
+          Close
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </PopUp>
+</template>
+<script setup>
+import { mdiClipboardCheckOutline, mdiContentCopy } from "@mdi/js";
+import PopUp from "./PopUp.vue";
+import { copyToClipBoard } from "@/utils";
+import { computed, ref } from "vue";
+import { getLayers } from "@/store/Actions";
+import { mapPosition } from "@/store/States";
+
+const dialog = defineModel({ type: Boolean });
+
+const props = defineProps({
+  for: {
+    type: String,
+    default: "eox-map"
+  }
+});
+
+const copySuccess = ref(false)
+
+const copyBtns = [
+  {
+    id: Symbol(),
+    copyFn: async () => await copyToClipBoard(mapEntryCode.value, copySuccess),
+    copyAs: "simple map"
+  },
+  {
+    id: Symbol(),
+    copyFn: async () => await copyToClipBoard(JSON.stringify(getLayers(props?.for)), copySuccess),
+    copyAs: "layers configuration"
+  },
+  {
+    id: Symbol(),
+    copyFn: async () => await copyToClipBoard(mapStepCode.value, copySuccess),
+    copyAs: "map tour section"
+  }
+];
+
+const mapStepCode = computed(() => {
+  const [x, y, z] = mapPosition.value
+  const preTag = '### <!--{ layers=';
+  const endTag = `zoom="${z}" center=[${[x, y]}] animationOptions={duration:500}}-->
+#### Tour step title
+Text describing the current step of the tour and why it is interesting what the map shows currently
+`;
+  return `${preTag}${JSON.stringify(getLayers(props?.for))}' ${endTag}`
+})
+const mapEntryCode = computed(() => {
+  const [x, y, z] = mapPosition.value
+  const preTag = '## Map Example <!--{as="eox-map" style="width: 100%; height: 500px;" layers=';
+  const endTag = `zoom="${z}" center=[${[x, y]}] }-->`;
+  return `${preTag}${JSON.stringify(getLayers(props?.for))}' ${endTag}`;
+})
+</script>
+<style scoped>
+.background-primary {
+  background: rgb(var(--v-theme-primary));
+}
+
+.code-block {
+  background-color: #ddd;
+  font-family: monospace;
+}
+</style>

--- a/widgets/ExportState.vue
+++ b/widgets/ExportState.vue
@@ -1,31 +1,31 @@
 <template>
   <PopUp v-model="dialog">
     <v-card>
-      <v-card-title class="background-primary position-sticky">
-        <h4 class="text-headline text-white">
+      <v-card-title class="bg-primary">
+        <h5 class="text-h5">
           Storytelling map configuration
-        </h4>
+        </h5>
       </v-card-title>
 
       <v-card-text class="py-5">
         <p class="text-body-2">
           Copy and paste this code into the map layers field of the storytelling editor:
         </p>
-        <div class="pa-3 code-block text-body-2">
+        <div class="pa-3 code-block">
           {{ getLayers(props.for) }}
         </div>
 
         <div style="position: absolute; bottom: 15px;">
           <v-expand-transition>
-            <div v-if="copySuccess" class="success--text mr-3">
+            <div v-if="copySuccess" class="text-success mr-3">
               <v-icon color="success" left :icon="[mdiClipboardCheckOutline]" />
               <small>copied!</small>
             </div>
           </v-expand-transition>
         </div>
-        <v-row class="d-flex flex-column   pt-3">
-          <v-col class="align-center text-end">
-            <v-btn v-for="btn in copyBtns" class="text-body-1" @click="btn.copyFn" :key="btn.id" small variant="text"
+        <v-row class="d-flex pt-3 justify-end">
+          <v-col cols="6" class="flex-column align-center text-end">
+            <v-btn v-for="btn in copyBtns" class="text-body-2" @click="btn.copyFn" :key="btn.id" small variant="text"
               :prepend-icon="[mdiContentCopy]">
               copy as {{ btn.copyAs }}
             </v-btn>
@@ -37,7 +37,7 @@
 
       <v-card-actions>
         <v-spacer></v-spacer>
-        <v-btn color="primary" variant="text" @click="dialog = !dialog">
+        <v-btn variant="text" @click="dialog = !dialog">
           Close
         </v-btn>
       </v-card-actions>
@@ -52,7 +52,7 @@ import { computed, ref } from "vue";
 import { getLayers } from "@/store/Actions";
 import { mapPosition } from "@/store/States";
 
-const dialog = defineModel({ type: Boolean });
+const dialog = defineModel({ type: Boolean,required:true,default:false });
 
 const props = defineProps({
   for: {
@@ -88,22 +88,19 @@ const mapStepCode = computed(() => {
 #### Tour step title
 Text describing the current step of the tour and why it is interesting what the map shows currently
 `;
-  return `${preTag}${JSON.stringify(getLayers(props?.for))}' ${endTag}`
+  return `${preTag}'${JSON.stringify(getLayers(props?.for))}' ${endTag}`
 })
 const mapEntryCode = computed(() => {
   const [x, y, z] = mapPosition.value
   const preTag = '## Map Example <!--{as="eox-map" style="width: 100%; height: 500px;" layers=';
   const endTag = `zoom="${z}" center=[${[x, y]}] }-->`;
-  return `${preTag}${JSON.stringify(getLayers(props?.for))}' ${endTag}`;
+  return `${preTag}'${JSON.stringify(getLayers(props?.for))}' ${endTag}`;
 })
 </script>
 <style scoped>
-.background-primary {
-  background: rgb(var(--v-theme-primary));
-}
-
 .code-block {
   background-color: #ddd;
   font-family: monospace;
+  font-size: small;
 }
 </style>

--- a/widgets/PopUp.vue
+++ b/widgets/PopUp.vue
@@ -1,0 +1,40 @@
+<template>
+  <span>
+    <v-dialog
+      max-width="500px"
+      max-height="500px"
+      absolute
+      scrollable
+      scroll-strategy="block"
+      close-on-back
+      v-model="dialog"
+    >
+      <v-sheet>
+        <component
+          v-if="widget"
+          :is="definedWidget.component"
+          :key="definedWidget.id"
+          v-bind="definedWidget.props"
+        />
+        <span v-if="$slots.default">
+          <slot />
+        </span>
+      </v-sheet>
+    </v-dialog>
+  </span>
+</template>
+<script setup>
+import { useDefineWidgets } from "@/composables/DefineWidgets";
+
+const dialog = defineModel({ type: Boolean, required: true, default: false });
+
+const props = defineProps({
+  widget: {
+    /** @type {import("vue").PropType<import("@/types").Widget>} */
+    type: Object,
+    default: undefined,
+  },
+});
+
+const [definedWidget] = useDefineWidgets([props?.widget]);
+</script>


### PR DESCRIPTION
Addresses #48. Introducing an `eox-map` layers getter as an action and suggests a composite approach for the following components (internal widgets):
1. `PopUp`: base dialog component that takes in a widget prop to be rendered and a show/hide trigger `v-model`, this can come in handy for creating markdown-based popups using `eox-storytelling` for example.
2. `ExportState`:  this is an interface for exporting `eox-map` state utilizing the `PopUp` component, and it can also be extended for other types of maps in the future.
3. `EodashMapBtns`: this is meant to be the central location for `EodashMap` related buttons. Controls showing `ExportState`

### Example of configuring the `PopUp` widget with markdown content using `v-model` elaborate syntax:
```js
const show = ref(false);
export default createEodash({
...
 widgets:
  ...
      {
        id: 1,
        type: 'internal',
        layout: { x: 0, y: 0, w: 0, h: 0 },
        title: "Welcome",
        widget: {
          name: "PopUp",
          properties: {
            class: 'pa-5 ma-5',
            modelValue: show,
            "onUpdate:modelValue": (newVal) => show.value = newVal,
            /** @type{import('@/types').Widget} */
            widget: {
              id: 2,
              type: 'web-component',
              layout: { x: 0, y: 0, w: 0, h: 0 },
              title: "Welcome",
              widget: {
                link: 'https://cdn.jsdelivr.net/npm/@eox/storytelling',
                tagName: 'eox-storytelling',
                properties: {
                  markdown: "## Welcome to eodash"
                }
              }
            }
          }
        }
      }
  })
```