### PR TITLE
Fix: Extend Itemfilter properties

### DIFF
--- a/core/node/cli/globals.js
+++ b/core/node/cli/globals.js
@@ -32,13 +32,14 @@ const pkg = JSON.parse(
 
 cli.version(pkg.version, "-v, --version", "output the current version");
 
-cli.option("--publicDir <path>", "path to statically served assets folder")
+cli
+  .option("--publicDir <path>", "path to statically served assets folder")
   .option("--no-publicDir", "stop serving static assets")
   .option("--outDir <path>", "minified output folder")
   .option("-e, --entryPoint <path>", "file exporting `createEodash`")
   .option(
     "-w, --widgets <path>",
-    "folder that contains vue components as internal widgets"
+    "folder that contains vue components as internal widgets",
   )
   .option("--cacheDir <path>", "cache folder")
   .option("-r, --runtime <path>", "file exporting eodash client runtime config")
@@ -47,11 +48,11 @@ cli.option("--publicDir <path>", "path to statically served assets folder")
   .option("-o, --open", "open default browser when the server starts")
   .option(
     "-c, --config <path>",
-    "path to eodash server and build configuration file"
+    "path to eodash server and build configuration file",
   )
   .option(
     "--host [IP address]",
-    "specify which IP addresses the server should listen on"
+    "specify which IP addresses the server should listen on",
   )
   .option("-l, --lib", "builds eodash as a web component library")
   .option("--no-lib", "builds eodash as an SPA")

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -12,6 +12,13 @@ export default [
     rules: {
       "vue/no-deprecated-html-element-is": "warn",
       "vue/multi-word-component-names": "off",
+      "vue/no-deprecated-slot-attribute": [
+        "error",
+        {
+          // used for the `eox-itemfilter` titles
+          ignore: ["h4"],
+        },
+      ],
     },
   },
 ];

--- a/widgets/EodashItemFilter.vue
+++ b/widgets/EodashItemFilter.vue
@@ -1,44 +1,36 @@
 <template>
-  <DynamicWebComponent
-    :link="link"
-    tag-name="eox-itemfilter"
-    :properties="properties"
-    :on-mounted="onMounted"
-  />
+  <eox-itemfilter :config="config" ref="eoxItemFilter"></eox-itemfilter>
 </template>
 <script setup>
-import DynamicWebComponent from "@/components/DynamicWebComponent.vue";
+import { useSTAcStore } from "@/store/stac";
+import "@eox/itemfilter";
+import { onMounted, ref } from "vue";
 
-const link = () => import("@eox/itemfilter");
-
-const properties = {
-  config: {
-    titleProperty: "title",
-    filterProperties: [
-      {
-        keys: ["title", "themes"],
-        title: "Search",
-        type: "text",
-        // expanded: true,
-      },
-      {
-        key: "themes",
-        title: "Theme Filter",
-        type: "multiselect",
-        // featured: true,
-        // expanded: true
-      },
-    ],
-    aggregateResults: "themes",
-    enableHighlighting: true,
-    expandMultipleFilters: false,
-    expandMultipleResults: false,
-  },
+/** @type {import("vue").Ref<HTMLElement & Record<string,any> | null>} */
+const eoxItemFilter = ref(null);
+const config = {
+  titleProperty: "title",
+  filterProperties: [
+    {
+      keys: ["title", "themes"],
+      title: "Search",
+      type: "text",
+    },
+    {
+      key: "themes",
+      title: "Theme Filter",
+      type: "multiselect",
+    },
+  ],
+  aggregateResults: "themes",
+  enableHighlighting: true,
+  expandMultipleFilters: false,
+  expandMultipleResults: false,
 };
 
-/** @type {import("@/types").WebComponentProps["onMounted"]} */
-const onMounted = (el, store) => {
-  /** @type {any} */ (el).style.height = "100%";
+const store = useSTAcStore();
+onMounted(() => {
+  /** @type {any} */ (eoxItemFilter.value).style.height = "100%";
 
   const style = document.createElement("style");
   style.innerHTML = `
@@ -51,29 +43,29 @@ const onMounted = (el, store) => {
       right: 8px;
     }
   `;
-  el?.shadowRoot?.appendChild(style);
+  eoxItemFilter.value?.shadowRoot?.appendChild(style);
 
   const filterstitle = document.createElement("div");
   filterstitle.setAttribute("slot", "filterstitle");
   filterstitle.innerHTML = `<h4 style="margin: 14px 8px">Indicators</h4>`;
-  /** @type {any} */ (el).appendChild(filterstitle);
+  /** @type {any} */ (eoxItemFilter.value).appendChild(filterstitle);
   const resultstitle = document.createElement("div");
   resultstitle.setAttribute("slot", "resultstitle");
-  /** @type {any} */ (el).appendChild(resultstitle);
+  /** @type {any} */ (eoxItemFilter.value).appendChild(resultstitle);
 
   /**
    * @typedef {object} Item
    * @property {string} href
    */
-  /** @type {any} */ (el).apply(
+  /** @type {any} */ (eoxItemFilter.value).apply(
     // Only list child elements in list
     store.stac?.filter((item) => item.rel === "child"),
   );
-  /** @type {any} */ (el).config.onSelect =
+  /** @type {any} */ (eoxItemFilter.value).config.onSelect =
     /** @param {Item} item */
     async (item) => {
       console.log(item);
       await store.loadSelectedSTAC(item.href);
     };
-};
+});
 </script>

--- a/widgets/EodashItemFilter.vue
+++ b/widgets/EodashItemFilter.vue
@@ -13,7 +13,7 @@ import { onMounted, ref } from "vue";
 const props = defineProps({
   filtersTitle: {
     type: String,
-    default: "Indicator",
+    default: "Indicators",
   },
   resultsTitle: {
     type: String,


### PR DESCRIPTION
refactored  `EodashItemFilter` and added the following props with default values:
```js 
defineProps({
  filtersTitle: {
    type: String,
    default: "Indicator",
  },
  resultsTitle: {
    type: String,
    default: "",
  },
  titleProperty: {
    type: String,
    default: "title",
  },

  aggregateResults: {
    type: String,
    default: "themes",
  },
  enableHighlighting: { type: Boolean, default: true },
  expandMultipleFilters: { type: Boolean, default: false },
  expandMultipleResults: { type: Boolean, default: false },
  filterProperties: {
    type: Array,
    default: () => [
      {
        keys: ["title", "themes", "description"],
        title: "Search",
        type: "text",
      },
      {
        key: "themes",
        title: "Theme Filter",
        type: "multiselect",
      },
    ],
  },
});
```