### PR TITLE
fix: correctly apply style if no eox-jsonform to be included

### DIFF
--- a/core/client/utils/createLayers.js
+++ b/core/client/utils/createLayers.js
@@ -41,6 +41,7 @@ export async function createLayersFromDataAssets(
             },
           }),
         },
+        style,
       };
       extractRoles(layer.properties, assets[ast]?.roles ?? []);
       jsonArray.push(layer);
@@ -54,7 +55,7 @@ export async function createLayersFromDataAssets(
       type: "WebGLTile",
       source: {
         type: "GeoTIFF",
-        normalize: !style?.variables,
+        normalize: !style,
         sources: geoTIFFSources,
       },
       properties: {

--- a/core/client/utils/createLayers.js
+++ b/core/client/utils/createLayers.js
@@ -41,7 +41,7 @@ export async function createLayersFromDataAssets(
             },
           }),
         },
-        style,
+        ...(!style?.variables && {style}),
       };
       extractRoles(layer.properties, assets[ast]?.roles ?? []);
       jsonArray.push(layer);


### PR DESCRIPTION
This fixes visualisation of COGs and GeoJSON styling on the cif dashboard because we do not have LayerControl (JSONForm) there integrated yet, so the styles are static (not considering user input).