### PR TITLE
remove pa-4 from layercontrol

### DIFF
--- a/widgets/EodashLayerControl.vue
+++ b/widgets/EodashLayerControl.vue
@@ -1,5 +1,5 @@
 <template>
-  <span class="d-flex flex-column fill-height overflow-auto pa-4">
+  <span class="d-flex flex-column fill-height overflow-auto">
     <eox-layercontrol
       v-if="mapElement"
       :for="mapElement"


### PR DESCRIPTION
This way the layercontrol is scrollable correctly and can be shown fully below itemfilter in layout 8:4.
![image](https://github.com/user-attachments/assets/e71a14fe-ec63-44de-a545-b5ad26c2794b)
