### PR TITLE
Fix: issues with map and comparison map race conditions

### DIFF
--- a/core/client/composables/EodashMap.js
+++ b/core/client/composables/EodashMap.js
@@ -297,23 +297,26 @@ export const useInitMap = (
           datetime.value = endInterval.toISOString();
         }
 
-        // Try to move map view to extent
-        // Sanitize extent,
-        const b = updatedStac.extent?.spatial.bbox[0];
-        const sanitizedExtent = [
-          b[0] > -180 ? b[0] : -180,
-          b[1] > -90 ? b[1] : -90,
-          b[2] < 180 ? b[2] : 180,
-          b[3] < 90 ? b[3] : 90,
-        ];
+        // Try to move map view to extent only when main
+        // indicator and map changes
+        if (mapElement?.value?.id === "main") {
+          // Sanitize extent,
+          const b = updatedStac.extent?.spatial.bbox[0];
+          const sanitizedExtent = [
+            b[0] > -180 ? b[0] : -180,
+            b[1] > -90 ? b[1] : -90,
+            b[2] < 180 ? b[2] : 180,
+            b[3] < 90 ? b[3] : 90,
+          ];
 
-        const reprojExtent = mapElement.value?.transformExtent(
-          sanitizedExtent,
-          "EPSG:4326",
-          mapElement.value?.map?.getView().getProjection(),
-        );
-        /** @type {any} */
-        (mapElement.value).zoomExtent = reprojExtent;
+          const reprojExtent = mapElement.value?.transformExtent(
+            sanitizedExtent,
+            "EPSG:4326",
+            mapElement.value?.map?.getView().getProjection(),
+          );
+          /** @type {any} */
+          (mapElement.value).zoomExtent = reprojExtent;
+        }
 
         log.debug(
           "Assigned layers",

--- a/core/client/composables/EodashMap.js
+++ b/core/client/composables/EodashMap.js
@@ -2,7 +2,6 @@ import { EodashCollection } from "@/utils/eodashSTAC";
 import { setMapProjFromCol } from "@/utils/helpers";
 import { onMounted, onUnmounted, watch } from "vue";
 import log from "loglevel";
-import { datetime } from "@/store/States";
 import { useSTAcStore } from "@/store/stac";
 import { storeToRefs } from "pinia";
 

--- a/core/client/eodash.js
+++ b/core/client/eodash.js
@@ -10,7 +10,8 @@ import { currentUrl } from "./store/States";
 export const eodash = reactive({
   id: "demo",
   stacEndpoint:
-    "https://eodashcatalog.eox.at/test-style/trilateral/catalog.json",
+    // "https://eodashcatalog.eox.at/test-style/trilateral/catalog.json",
+    "https://gtif-cerulean.github.io/catalog/cerulean/catalog.json",
   brand: {
     noLayout: true,
     name: "Demo",
@@ -45,7 +46,7 @@ export const eodash = reactive({
       widget: {
         name: "EodashMap",
         properties: {
-          // enableCompare: true,
+          enableCompare: true,
         },
       },
     },
@@ -58,7 +59,7 @@ export const eodash = reactive({
         widget: {
           name: "EodashItemFilter",
           properties: {
-            // enableCompare: true,
+            enableCompare: true,
             aggregateResults: "collection_group",
           },
         },
@@ -72,13 +73,33 @@ export const eodash = reactive({
           name: "EodashLayerControl",
         },
       },
+      /*
+      {
+        defineWidget: (selectedCompareStac) => {
+          return selectedCompareStac
+            ? {
+                id: Symbol(),
+                title: "Layer Control Comparison",
+                layout: { x: 9, y: 6, w: 3, h: 6 },
+                type: "internal",
+                widget: {
+                  name: "EodashLayerControl",
+                  properties: {
+                    map: "second",
+                  },
+                },
+              }
+            : null;
+        },
+      },
+      */
       {
         defineWidget: (selectedSTAC) => {
           return selectedSTAC
             ? {
                 id: "Information",
                 title: "Information",
-                layout: { x: 9, y: 0, w: 3, h: 12 },
+                layout: { x: 9, y: 0, w: 3, h: 6 },
                 type: "web-component",
                 widget: {
                   link: async () => await import("@eox/stacinfo"),

--- a/core/client/store/Actions.js
+++ b/core/client/store/Actions.js
@@ -9,6 +9,12 @@ import log from "loglevel";
 export const getLayers = () => mapEl.value?.layers.toReversed();
 
 /**
+ * Returns the current layers of {@link mapCompareEl}
+ * @returns {Record<string,any>[]}
+ */
+export const getCompareLayers = () => mapCompareEl.value?.layers.toReversed();
+
+/**
  * Register EPSG projection in `eox-map`
  * @param {string|number|{name: string, def: string, extent?:number[]}} [projection]*/
 export const registerProjection = async (projection) => {

--- a/core/client/utils/createLayers.js
+++ b/core/client/utils/createLayers.js
@@ -126,9 +126,10 @@ export const createLayersFromLinks = async (
       (wmsLink?.["proj:epsg"] || wmsLink?.["eodash:proj4_def"]);
 
     await registerProjection(wmsLinkProjection);
+
+    const linkProjectionCode = getProjectionCode(wmsLinkProjection) || "EPSG:4326";
     // Projection code need to be based on map view projection to make sure
     // tiles are reloaded when changing projection
-    debugger;
     const linkId = createLayerID(
       collectionId,
       item.id,
@@ -146,7 +147,7 @@ export const createLayersFromLinks = async (
       source: {
         type: "TileWMS",
         url: wmsLink.href,
-        projection: projectionCode,
+        projection: linkProjectionCode,
         tileGrid: {
           tileSize: [512, 512],
         },
@@ -185,7 +186,7 @@ export const createLayersFromLinks = async (
       collectionId,
       item.id,
       wmtsLink,
-      projectionCode,
+      viewProjectionCode,
     );
     if (wmtsLink.title === "wmts capabilities") {
       log.debug(
@@ -255,7 +256,7 @@ export const createLayersFromLinks = async (
       collectionId,
       item.id,
       xyzLink,
-      projectionCode,
+      viewProjectionCode,
     );
     log.debug("XYZ Layer added", linkId);
     let json = {

--- a/core/client/utils/createLayers.js
+++ b/core/client/utils/createLayers.js
@@ -1,4 +1,5 @@
 import { registerProjection } from "@/store/Actions";
+import { mapEl } from "@/store/States";
 import {
   extractRoles,
   getProjectionCode,
@@ -99,14 +100,12 @@ export async function createLayersFromAssets(
  * @param {string} collectionId
  * @param {import('stac-ts').StacItem} item
  * @param {string} title
- * @param {string} viewProjectionCode
  * @param {Record<string,any>} [layerDatetime]
  * @param {string | null} [legendInfo]
  */
 export const createLayersFromLinks = async (
   collectionId,
   title,
-  viewProjectionCode,
   item,
   layerDatetime,
   legendInfo,
@@ -117,6 +116,10 @@ export const createLayersFromLinks = async (
   const wmsArray = item.links.filter((l) => l.rel === "wms");
   const wmtsArray = item.links.filter((l) => l.rel === "wmts");
   const xyzArray = item.links.filter((l) => l.rel === "xyz") ?? [];
+
+  // Taking projection code from main map view, as main view defines
+  // projection for comparison map
+  const viewProjectionCode = mapEl?.value?.projection || "EPSG:3857";
 
   for (const wmsLink of wmsArray ?? []) {
     // Registering setting sub wms link projection

--- a/core/client/utils/createLayers.js
+++ b/core/client/utils/createLayers.js
@@ -127,7 +127,8 @@ export const createLayersFromLinks = async (
 
     await registerProjection(wmsLinkProjection);
 
-    const linkProjectionCode = getProjectionCode(wmsLinkProjection) || "EPSG:4326";
+    const linkProjectionCode =
+      getProjectionCode(wmsLinkProjection) || "EPSG:4326";
     // Projection code need to be based on map view projection to make sure
     // tiles are reloaded when changing projection
     const linkId = createLayerID(

--- a/core/client/utils/createLayers.js
+++ b/core/client/utils/createLayers.js
@@ -99,12 +99,14 @@ export async function createLayersFromAssets(
  * @param {string} collectionId
  * @param {import('stac-ts').StacItem} item
  * @param {string} title
+ * @param {string} viewProjectionCode
  * @param {Record<string,any>} [layerDatetime]
  * @param {string | null} [legendInfo]
  */
 export const createLayersFromLinks = async (
   collectionId,
   title,
+  viewProjectionCode,
   item,
   layerDatetime,
   legendInfo,
@@ -124,12 +126,14 @@ export const createLayersFromLinks = async (
       (wmsLink?.["proj:epsg"] || wmsLink?.["eodash:proj4_def"]);
 
     await registerProjection(wmsLinkProjection);
-    const projectionCode = getProjectionCode(wmsLinkProjection || "EPSG:4326");
+    // Projection code need to be based on map view projection to make sure
+    // tiles are reloaded when changing projection
+    debugger;
     const linkId = createLayerID(
       collectionId,
       item.id,
       wmsLink,
-      projectionCode,
+      viewProjectionCode,
     );
     log.debug("WMS Layer added", linkId);
     let json = {

--- a/core/client/utils/eodashSTAC.js
+++ b/core/client/utils/eodashSTAC.js
@@ -9,7 +9,11 @@ import {
   generateFeatures,
   replaceLayer,
 } from "./helpers";
-import { getLayers, registerProjection } from "@/store/Actions";
+import {
+  getLayers,
+  getCompareLayers,
+  registerProjection,
+} from "@/store/Actions";
 import { createLayersFromAssets, createLayersFromLinks } from "./createLayers";
 import axios from "@/plugins/axios";
 import log from "loglevel";
@@ -305,8 +309,9 @@ export class EodashCollection {
    *
    * @param {string} datetime
    * @param {string} layer
+   * @param {string} map
    */
-  async updateLayerJson(datetime, layer) {
+  async updateLayerJson(datetime, layer, map) {
     await this.fetchCollection();
 
     // get the link of the specified date
@@ -327,12 +332,15 @@ export class EodashCollection {
     // create json layers from the item
     const newLayers = await this.createLayersJson(specifiedLink);
 
-    const curentLayers = getLayers();
+    let currentLayers = getLayers();
+    if (map === "second") {
+      currentLayers = getCompareLayers();
+    }
 
-    const oldLayer = findLayer(curentLayers, layer);
+    const oldLayer = findLayer(currentLayers, layer);
 
     const updatedLayers = replaceLayer(
-      curentLayers,
+      currentLayers,
       /** @type {Record<string,any> & { properties:{ id:string; title:string } } } */
       (oldLayer),
       newLayers,

--- a/core/client/utils/eodashSTAC.js
+++ b/core/client/utils/eodashSTAC.js
@@ -369,11 +369,19 @@ export class EodashCollection {
       /** @type {Record<string,import('stac-ts').StacAsset>} */ ({}),
     );
 
+    const viewProjection =
+      /** @type {number | string | {name: string, def: string} | undefined} */
+      (
+        indicator["eodash:mapProjection"] ||
+        indicator["proj:epsg"] ||
+        indicator["eodash:proj4_def"]
+      );
+      const viewProjectionCode = getProjectionCode(viewProjection || "EPSG:4326");
     return [
       ...(await createLayersFromLinks(
         indicator?.id ?? "",
         indicator?.title || indicator.id,
-        "",
+        viewProjectionCode,
         //@ts-expect-error indicator instead of item
         indicator,
         // layerDatetime,

--- a/core/client/utils/eodashSTAC.js
+++ b/core/client/utils/eodashSTAC.js
@@ -193,13 +193,15 @@ export class EodashCollection {
           </div>`;
       }
       const viewProjection =
-      /** @type {number | string | {name: string, def: string} | undefined} */
-      (
-        this.#collectionStac?.["eodash:mapProjection"] ||
-          this.#collectionStac?.["proj:epsg"] ||
-          this.#collectionStac?.["eodash:proj4_def"]
+        /** @type {number | string | {name: string, def: string} | undefined} */
+        (
+          this.#collectionStac?.["eodash:mapProjection"] ||
+            this.#collectionStac?.["proj:epsg"] ||
+            this.#collectionStac?.["eodash:proj4_def"]
+        );
+      const viewProjectionCode = getProjectionCode(
+        viewProjection || "EPSG:4326",
       );
-      const viewProjectionCode = getProjectionCode(viewProjection || "EPSG:4326");
       const links = await createLayersFromLinks(
         this.#collectionStac?.id ?? "",
         title,
@@ -373,10 +375,10 @@ export class EodashCollection {
       /** @type {number | string | {name: string, def: string} | undefined} */
       (
         indicator["eodash:mapProjection"] ||
-        indicator["proj:epsg"] ||
-        indicator["eodash:proj4_def"]
+          indicator["proj:epsg"] ||
+          indicator["eodash:proj4_def"]
       );
-      const viewProjectionCode = getProjectionCode(viewProjection || "EPSG:4326");
+    const viewProjectionCode = getProjectionCode(viewProjection || "EPSG:4326");
     return [
       ...(await createLayersFromLinks(
         indicator?.id ?? "",

--- a/core/client/utils/eodashSTAC.js
+++ b/core/client/utils/eodashSTAC.js
@@ -7,7 +7,6 @@ import {
   fetchStyle,
   findLayer,
   generateFeatures,
-  getProjectionCode,
   replaceLayer,
 } from "./helpers";
 import { getLayers, registerProjection } from "@/store/Actions";
@@ -192,20 +191,9 @@ export class EodashCollection {
             <img src="${this.#collectionStac.assets.legend.href}" style="max-height:70px; margin-top:-15px; margin-bottom:-20px;" />
           </div>`;
       }
-      const viewProjection =
-        /** @type {number | string | {name: string, def: string} | undefined} */
-        (
-          this.#collectionStac?.["eodash:mapProjection"] ||
-            this.#collectionStac?.["proj:epsg"] ||
-            this.#collectionStac?.["eodash:proj4_def"]
-        );
-      const viewProjectionCode = getProjectionCode(
-        viewProjection || "EPSG:4326",
-      );
       const links = await createLayersFromLinks(
         this.#collectionStac?.id ?? "",
         title,
-        viewProjectionCode,
         item,
         layerDatetime,
         legendInfo,
@@ -371,19 +359,10 @@ export class EodashCollection {
       /** @type {Record<string,import('stac-ts').StacAsset>} */ ({}),
     );
 
-    const viewProjection =
-      /** @type {number | string | {name: string, def: string} | undefined} */
-      (
-        indicator["eodash:mapProjection"] ||
-          indicator["proj:epsg"] ||
-          indicator["eodash:proj4_def"]
-      );
-    const viewProjectionCode = getProjectionCode(viewProjection || "EPSG:4326");
     return [
       ...(await createLayersFromLinks(
         indicator?.id ?? "",
         indicator?.title || indicator.id,
-        viewProjectionCode,
         //@ts-expect-error indicator instead of item
         indicator,
         // layerDatetime,

--- a/core/client/utils/eodashSTAC.js
+++ b/core/client/utils/eodashSTAC.js
@@ -7,6 +7,7 @@ import {
   fetchStyle,
   findLayer,
   generateFeatures,
+  getProjectionCode,
   replaceLayer,
 } from "./helpers";
 import { getLayers, registerProjection } from "@/store/Actions";
@@ -191,9 +192,18 @@ export class EodashCollection {
             <img src="${this.#collectionStac.assets.legend.href}" style="max-height:70px; margin-top:-15px; margin-bottom:-20px;" />
           </div>`;
       }
+      const viewProjection =
+      /** @type {number | string | {name: string, def: string} | undefined} */
+      (
+        this.#collectionStac?.["eodash:mapProjection"] ||
+          this.#collectionStac?.["proj:epsg"] ||
+          this.#collectionStac?.["eodash:proj4_def"]
+      );
+      const viewProjectionCode = getProjectionCode(viewProjection || "EPSG:4326");
       const links = await createLayersFromLinks(
         this.#collectionStac?.id ?? "",
         title,
+        viewProjectionCode,
         item,
         layerDatetime,
         legendInfo,
@@ -363,6 +373,7 @@ export class EodashCollection {
       ...(await createLayersFromLinks(
         indicator?.id ?? "",
         indicator?.title || indicator.id,
+        "",
         //@ts-expect-error indicator instead of item
         indicator,
         // layerDatetime,

--- a/core/client/utils/helpers.js
+++ b/core/client/utils/helpers.js
@@ -141,9 +141,9 @@ export const extractRoles = (properties, linkOrAsset) => {
       properties.group = role;
       //remove all the properties and replace the random ID with baselayer
       // provided ID
-      const [_colId, _itemId, _isAsset, _random, proj] =
-        properties.id.split(";:;");
-      properties.id = ["", "", "", "", linkOrAsset.id, proj].join(";:;");
+      // const [_colId, _itemId, _isAsset, _random, proj] =
+      //   properties.id.split(";:;");
+      // properties.id = ["", "", "", "", linkOrAsset.id, proj].join(";:;");
     }
 
     return properties;

--- a/widgets/EodashLayerControl.vue
+++ b/widgets/EodashLayerControl.vue
@@ -1,7 +1,7 @@
 <template>
   <span class="d-flex flex-column fill-height overflow-auto">
     <eox-layercontrol
-      v-if="mapElement"
+      v-if="showControls"
       :for="mapElement"
       .tools="['datetime', 'info', 'config', 'opacity']"
       @datetime:updated="debouncedHandleDateTime"
@@ -16,16 +16,29 @@ import "@eox/layercontrol";
 import "@eox/jsonform";
 import "@eox/timecontrol";
 
-import { ref } from "vue";
+import { computed, ref } from "vue";
 import { mapEl, mapCompareEl } from "@/store/States";
 import { getColFromLayer } from "@/utils/helpers";
 import { eodashCollections, eodashCompareCollections } from "@/utils/states";
+import { storeToRefs } from "pinia";
+import { useSTAcStore } from "@/store/stac";
 
 const props = defineProps({
   map: {
     type: String,
     default: "first",
   },
+});
+
+const showControls = computed(() => {
+  const { selectedCompareStac, selectedStac } = storeToRefs(useSTAcStore());
+  if (props.map === "second") {
+    return mapCompareEl && selectedCompareStac.value !== null;
+  }
+  if (mapEl && selectedStac) {
+    return true;
+  }
+  return false;
 });
 
 const eodashCols =

--- a/widgets/EodashLayerControl.vue
+++ b/widgets/EodashLayerControl.vue
@@ -33,9 +33,9 @@ const props = defineProps({
 const showControls = computed(() => {
   const { selectedCompareStac, selectedStac } = storeToRefs(useSTAcStore());
   if (props.map === "second") {
-    return mapCompareEl && selectedCompareStac.value !== null;
+    return mapCompareEl.value !== null && selectedCompareStac.value !== null;
   }
-  if (mapEl && selectedStac) {
+  if (mapEl.value !== null && selectedStac.value !== null) {
     return true;
   }
   return false;

--- a/widgets/EodashLayerControl.vue
+++ b/widgets/EodashLayerControl.vue
@@ -46,7 +46,11 @@ const handleDatetimeUpdate = async (evt) => {
 
   if (ec) {
     await ec.fetchCollection();
-    updatedLayers = await ec.updateLayerJson(datetime, layer.get("id"));
+    updatedLayers = await ec.updateLayerJson(
+      datetime,
+      layer.get("id"),
+      props.map,
+    );
   }
   /** @type {Record<String,any>[] | undefined} */
   const dataLayers = updatedLayers?.find(


### PR DESCRIPTION
* removed update config concept as it created synchronous dependency to initial configuration being created, this conflicted with comparison map being configured on change
* made sure to use main map projection as layer identifier as compare map will use the same projection which made wrongly projected tiles from cache being loaded
* fixes for compare map layer controls
* there is still an ordering issue maybe related to assets (noted in #120)