### PR TITLE
chore: update eox-layout and adjust gap size

### DIFF
--- a/core/client/components/DashboardLayout.vue
+++ b/core/client/components/DashboardLayout.vue
@@ -1,9 +1,13 @@
 <template>
   <v-main>
-    <eox-layout :gap="eodash.template.gap ?? 2">
+    <eox-layout
+      :gap="eodash.template.gap ?? 16"
+      :style="`padding: ${eodash.template.gap || 16}px`"
+    >
       <eox-layout-item
         v-if="bgWidget.component"
         class="bg-panel bg-surface"
+        :style="`margin: -${eodash.template.gap ?? 16}px;`"
         x="0"
         y="0"
         h="12"

--- a/core/client/composables/index.js
+++ b/core/client/composables/index.js
@@ -194,8 +194,6 @@ export const makePanelTransparent = (root) => {
     const eoxItem = root.value?.parentElement;
     if (eoxItem?.tagName === "EOX-LAYOUT-ITEM") {
       eoxItem.classList.remove("bg-surface");
-      eoxItem.style.background = "transparent";
-      eoxItem.style.border = "transparent";
     }
   });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@eox/itemfilter": "^1.1.1",
         "@eox/jsonform": "^0.8.2",
         "@eox/layercontrol": "^0.22.0",
-        "@eox/layout": "^0.1.0",
+        "@eox/layout": "^0.3.0",
         "@eox/map": "^1.13.1",
         "@eox/stacinfo": "^0.3.3",
         "@eox/timecontrol": "^0.8.0",
@@ -605,9 +605,9 @@
       }
     },
     "node_modules/@eox/layout": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@eox/layout/-/layout-0.1.0.tgz",
-      "integrity": "sha512-FkcpjZ0uT6Dj5RVoWmtEEPUU/l1QGULEAdR/O120NH3JyjGxke1uU1GMmTDJRnOzdsUyl6YD+W9W+RY1ltpsug=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@eox/layout/-/layout-0.3.0.tgz",
+      "integrity": "sha512-9fTTJCdgxuuoEyThl/ys1cw6RcienEtIBP6KQmzRd+7qCCw/o2WiusEVGZvt+cqwE8eBInRlHIA3UjzAXwnCvw=="
     },
     "node_modules/@eox/map": {
       "version": "1.13.1",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@eox/itemfilter": "^1.1.1",
     "@eox/jsonform": "^0.8.2",
     "@eox/layercontrol": "^0.22.0",
-    "@eox/layout": "^0.1.0",
+    "@eox/layout": "^0.3.0",
     "@eox/map": "^1.13.1",
     "@eox/stacinfo": "^0.3.3",
     "@eox/timecontrol": "^0.8.0",


### PR DESCRIPTION
This PR updates `eox-layout` to `v0.3.0` and removes not necessary code for this version in `core/client/composables/index.js`. Also, the default layout gap is increased to `16px`. Additional styling was required since the Vuetify global padding reset overrode the padding set by `eox-layout`:
 ```js
:style="`padding: ${eodash.template.gap || 16}px`"
```

## Before
![image](https://github.com/user-attachments/assets/cbe6ee47-0939-41e7-b6ee-8225072c34ec)

## After
![image](https://github.com/user-attachments/assets/1169f89e-ca4e-4159-8dfb-4120a92968d8)
