### PR TITLE
chore(style): fix datepicker arrows on low widths

### DIFF
--- a/core/client/eodash.js
+++ b/core/client/eodash.js
@@ -145,10 +145,9 @@ export const eodash = reactive({
                   widget: {
                     name: "EodashDatePicker",
                     properties: {
-                      hideArrows: true,
-                      hideInputField: true,
                       hintText: `<b>Hint:</b> closest available date is displayed <br />
                             on map (see Analysis Layers)`,
+                      toggleCalendar: true,
                     },
                   },
                 }

--- a/widgets/EodashDatePicker.vue
+++ b/widgets/EodashDatePicker.vue
@@ -8,7 +8,45 @@
       class="bg-surface overflow-auto"
       style="background-color: transparent; max-width: 100%"
     >
-      <template #footer>
+      <template v-if="toggleCalendar" #default="{ inputValue, inputEvents }">
+        <div class="d-flex flex-row align-center justify-center pb-1" style="overflow: hidden; width: 100%;">
+          <v-btn
+            v-if="!hideArrows"
+            density="compact"
+            :size="lgAndDown ? 'x-small' : 'medium'"
+            v-tooltip:bottom="'Set date to oldest available dataset'"
+            variant="text"
+            @click="jumpDate(true)"
+            style="flex-shrink: 1;"
+          >
+            <v-icon :icon="[mdiRayEndArrow]" />
+          </v-btn>
+          <div
+            class="flex rounded-lg border border-gray-300 dark:border-gray-600"
+            style="margin: 2px; min-width: 0;"
+          >
+            <input
+              v-if="!hideInputField"
+              :value="inputValue"
+              v-on="inputEvents"
+              class="flex-grow px-1 py-1 dark:bg-gray-700"
+              style="margin: 1px; width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"
+            />
+          </div>
+          <v-btn
+            v-if="!hideArrows"
+            density="compact"
+            :size="lgAndDown ? 'x-small' : 'medium'"
+            variant="text"
+            v-tooltip:bottom="'Set date to latest available dataset'"
+            @click="jumpDate(false)"
+            style="flex-shrink: 1;"
+          >
+            <v-icon :icon="[mdiRayStartArrow]" />
+          </v-btn>
+        </div>
+      </template>
+      <template v-else #footer>
         <div class="d-flex flex-row align-center justify-center pb-1" style="overflow: hidden; width: 100%;">
           <v-btn
             v-if="!hideArrows"
@@ -93,6 +131,10 @@ defineProps({
     type: Boolean,
     default: false,
   },
+  toggleCalendar: {
+    type: Boolean,
+    default: false
+  }
 });
 
 /**

--- a/widgets/EodashDatePicker.vue
+++ b/widgets/EodashDatePicker.vue
@@ -9,7 +9,7 @@
       style="background-color: transparent; max-width: 100%"
     >
       <template v-if="toggleCalendar" #default="{ inputValue, inputEvents }">
-        <div class="d-flex flex-row align-center justify-center pb-1" style="overflow: hidden; width: 100%;">
+        <div class="bg-surface d-flex flex-row align-center justify-center pb-1" style="overflow: hidden; width: 100%;">
           <v-btn
             v-if="!hideArrows"
             density="compact"
@@ -17,6 +17,7 @@
             v-tooltip:bottom="'Set date to oldest available dataset'"
             variant="text"
             @click="jumpDate(true)"
+            class="py-2"
             style="flex-shrink: 1;"
           >
             <v-icon :icon="[mdiRayEndArrow]" />
@@ -40,6 +41,7 @@
             variant="text"
             v-tooltip:bottom="'Set date to latest available dataset'"
             @click="jumpDate(false)"
+            class="py-2"
             style="flex-shrink: 1;"
           >
             <v-icon :icon="[mdiRayStartArrow]" />
@@ -55,6 +57,7 @@
             v-tooltip:bottom="'Set date to oldest available dataset'"
             variant="text"
             @click="jumpDate(true)"
+            class="py-2"
             style="flex-shrink: 1;"
           >
             <v-icon :icon="[mdiRayEndArrow]" />
@@ -77,6 +80,7 @@
             variant="text"
             v-tooltip:bottom="'Set date to latest available dataset'"
             @click="jumpDate(false)"
+            class="py-2"
             style="flex-shrink: 1;"
           >
             <v-icon :icon="[mdiRayStartArrow]" />

--- a/widgets/EodashDatePicker.vue
+++ b/widgets/EodashDatePicker.vue
@@ -9,33 +9,37 @@
       style="background-color: transparent; max-width: 100%"
     >
       <template #footer>
-        <div class="d-flex flex-row align-center justify-center pb-1">
+        <div class="d-flex flex-row align-center justify-center pb-1" style="overflow: hidden; width: 100%;">
           <v-btn
             v-if="!hideArrows"
             density="compact"
+            :size="lgAndDown ? 'x-small' : 'large'"
             v-tooltip:bottom="'Set date to oldest available dataset'"
             variant="text"
             @click="jumpDate(true)"
+            style="flex-shrink: 1;"
           >
             <v-icon :icon="[mdiRayEndArrow]" />
           </v-btn>
           <div
             class="flex rounded-lg border border-gray-300 dark:border-gray-600"
-            style="margin: 2px"
+            style="margin: 2px; min-width: 0;"
           >
             <input
               v-if="!hideInputField"
               :value="new Date(currentDate).toLocaleDateString()"
-              style="margin: 1px"
               class="flex-grow px-1 py-1 dark:bg-gray-700"
+              style="margin: 1px; width: 100%; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;"
             />
           </div>
           <v-btn
             v-if="!hideArrows"
             density="compact"
+            :size="lgAndDown ? 'x-small' : 'large'"
             variant="text"
             v-tooltip:bottom="'Set date to latest available dataset'"
             @click="jumpDate(false)"
+            style="flex-shrink: 1;"
           >
             <v-icon :icon="[mdiRayStartArrow]" />
           </v-btn>
@@ -46,6 +50,7 @@
 </template>
 <script setup>
 import { DatePicker as VCDatePicker } from "v-calendar";
+import { useDisplay } from 'vuetify'
 import "v-calendar/style.css";
 import { watch, reactive, ref, customRef, toRef } from "vue";
 import { useSTAcStore } from "@/store/stac";
@@ -54,6 +59,8 @@ import { mdiRayStartArrow, mdiRayEndArrow } from "@mdi/js";
 import { eodashCollections } from "@/utils/states";
 import log from "loglevel";
 import { makePanelTransparent } from "@/composables";
+
+const { lgAndDown } = useDisplay()
 
 // holds the number value of the datetime
 const currentDate = customRef((track, trigger) => ({

--- a/widgets/EodashDatePicker.vue
+++ b/widgets/EodashDatePicker.vue
@@ -13,7 +13,7 @@
           <v-btn
             v-if="!hideArrows"
             density="compact"
-            :size="lgAndDown ? 'x-small' : 'medium'"
+            :size="lgAndDown ? 'x-small' : 'large'"
             v-tooltip:bottom="'Set date to oldest available dataset'"
             variant="text"
             @click="jumpDate(true)"
@@ -37,7 +37,7 @@
           <v-btn
             v-if="!hideArrows"
             density="compact"
-            :size="lgAndDown ? 'x-small' : 'medium'"
+            :size="lgAndDown ? 'x-small' : 'large'"
             variant="text"
             v-tooltip:bottom="'Set date to latest available dataset'"
             @click="jumpDate(false)"

--- a/widgets/EodashDatePicker.vue
+++ b/widgets/EodashDatePicker.vue
@@ -94,7 +94,7 @@
 import { DatePicker as VCDatePicker } from "v-calendar";
 import { useDisplay } from 'vuetify'
 import "v-calendar/style.css";
-import { watch, reactive, ref, customRef, toRef } from "vue";
+import { watch, reactive, ref, customRef, toRef, onMounted } from "vue";
 import { useSTAcStore } from "@/store/stac";
 import { datetime } from "@/store/states";
 import { mdiRayStartArrow, mdiRayEndArrow } from "@mdi/js";
@@ -235,6 +235,14 @@ function jumpDate(reverse) {
   }
 }
 
+// fixes calendar dispalcement on lib mode
+const transform = ref("");
+onMounted(() => {
+  transform.value = document.querySelector("eo-dash")
+    ? "translate3d(50px,-80px,0)"
+    : "translate3d(0px,-80px,0)";
+});
+
 makePanelTransparent(rootRef);
 </script>
 <style>
@@ -252,5 +260,9 @@ makePanelTransparent(rootRef);
 
 .vc-highlight-content-solid {
   color: white !important;
+}
+
+.vc-popover-content-wrapper {
+  transform: v-bind("transform") !important;
 }
 </style>


### PR DESCRIPTION
In this PR we fix the visibility of the datepicker arrows on smaller screen widths, there is still some overflow due to the calendar being quite space needy

TODO:

- [x] fix footer arrows
- [ ] ~fix header arrows~
- [ ] ~fix calendar overflow~
- [x] add capability to have a "toggle calendar" mode via DatePicker properties (https://github.com/eodash/eodash/pull/158/commits/e5d3b9615ffe9af21ee27f0d0d4b9d10267274ad)

Screenshots:
- 994px (smallest width that doesn't activate the mobile layout)
<img width="994" alt="image" src="https://github.com/user-attachments/assets/40c8507c-f6a3-4c8a-a0ef-ec27622ecca1" />
- 1440px
<img width="1443" alt="image" src="https://github.com/user-attachments/assets/648ef387-6a23-4dbc-b87c-d6687cced9c8" />
- 2560px
<img width="1970" alt="image" src="https://github.com/user-attachments/assets/b51aaf6b-b9b4-4e0b-8d76-205516f0fd10" />

