### PR TITLE
Fix: Merge item assets geojsons into one vector layer

### DIFF
--- a/core/client/eodash.js
+++ b/core/client/eodash.js
@@ -13,9 +13,9 @@ export const eodash = reactive({
     // "https://eurodatacube.github.io/eodash-catalog/RACE/catalog.json",
     // "https://gtif-cerulean.github.io/catalog/cerulean/catalog.json",
     // "https://eodashcatalog.eox.at/samplecatalog/samples/catalog.json",
-    // "https://eodashcatalog.eox.at/test-style/trilateral/catalog.json",
+    "https://eodashcatalog.eox.at/test-style/trilateral/catalog.json",
     // "https://gtif-cerulean.github.io/catalog/cerulean/catalog.json",
-    "https://gtif-cerulean.github.io/deside-catalog/deside/catalog.json",
+    // "https://gtif-cerulean.github.io/deside-catalog/deside/catalog.json",
   brand: {
     noLayout: true,
     name: "Demo",

--- a/core/client/eodash.js
+++ b/core/client/eodash.js
@@ -14,8 +14,8 @@ export const eodash = reactive({
     // "https://gtif-cerulean.github.io/catalog/cerulean/catalog.json",
     // "https://eodashcatalog.eox.at/samplecatalog/samples/catalog.json",
     "https://eodashcatalog.eox.at/test-style/trilateral/catalog.json",
-    // "https://gtif-cerulean.github.io/catalog/cerulean/catalog.json",
-    // "https://gtif-cerulean.github.io/deside-catalog/deside/catalog.json",
+  // "https://gtif-cerulean.github.io/catalog/cerulean/catalog.json",
+  // "https://gtif-cerulean.github.io/deside-catalog/deside/catalog.json",
   brand: {
     noLayout: true,
     name: "Demo",

--- a/core/client/eodash.js
+++ b/core/client/eodash.js
@@ -12,9 +12,10 @@ export const eodash = reactive({
   stacEndpoint:
     // "https://eurodatacube.github.io/eodash-catalog/RACE/catalog.json",
     // "https://gtif-cerulean.github.io/catalog/cerulean/catalog.json",
-    "https://eodashcatalog.eox.at/samplecatalog/samples/catalog.json",
-  // "https://eodashcatalog.eox.at/test-style/trilateral/catalog.json",
-  // "https://gtif-cerulean.github.io/catalog/cerulean/catalog.json",
+    // "https://eodashcatalog.eox.at/samplecatalog/samples/catalog.json",
+    // "https://eodashcatalog.eox.at/test-style/trilateral/catalog.json",
+    // "https://gtif-cerulean.github.io/catalog/cerulean/catalog.json",
+    "https://gtif-cerulean.github.io/deside-catalog/deside/catalog.json",
   brand: {
     noLayout: true,
     name: "Demo",

--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -51,13 +51,12 @@ export async function createLayersFromAssets(
       extractRoles(geoJsonRoles, assets[ast]);
     } else if (assets[ast]?.type === "application/vnd.flatgeobuf") {
       const assetId = createAssetID(collectionId, item.id, idx);
-      const sourceType = "FlatGeoBuf";
-      log.debug(`Creating Vector layer from ${sourceType}`, assetId);
+      log.debug(`Creating Vector layer from FlatGeoBuf`, assetId);
 
       const layer = {
         type: "Vector",
         source: {
-          type: sourceType,
+          type: "FlatGeoBuf",
           url: assets[ast].href,
           format: "GeoJSON",
         },
@@ -88,7 +87,7 @@ export async function createLayersFromAssets(
 
   if (geoJsonSources.length) {
     const assetId = createAssetID(collectionId, item.id, geoJsonIdx);
-    log.debug(`Creating Vector layer`, assetId);
+    log.debug(`Creating Vector layer from GeoJsons`, assetId);
 
     const layer = {
       type: "Vector",

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -378,6 +378,13 @@ export const removeUnneededProperties = (layers) => {
  * @param {string[]} geojsonUrls
  */
 export async function mergeGeojsons(geojsonUrls) {
+  if (!geojsonUrls.length) {
+    return undefined;
+  }
+  if (geojsonUrls.length === 1) {
+    return geojsonUrls[0];
+  }
+
   const merged = {
     type: "FeatureCollection",
     /** @type {import("ol").Feature[]} */

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -383,12 +383,14 @@ export async function mergeGeojsons(geojsonUrls) {
     /** @type {import("ol").Feature[]} */
     features: [],
   };
-  for (const url of geojsonUrls) {
-    /** @type {import("ol/format/GeoJSON.js").GeoJSONFeatureCollection} */
-    const goejson = await axios.get(url).then((resp) => resp.data);
-    //@ts-expect-error TODO
-    merged.features.push(...(goejson.features ?? []));
-  }
+  await Promise.all(
+    geojsonUrls.map((url) =>
+      axios.get(url).then((resp) => {
+        const geojson = resp.data;
+        merged.features.push(...(geojson.features ?? []));
+      }),
+    ),
+  );
 
   return encodeURI(
     "data:application/json;charset=utf-8," + JSON.stringify(merged),

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -373,3 +373,24 @@ export const removeUnneededProperties = (layers) => {
   });
   return cloned;
 };
+
+/**
+ * @param {string[]} geojsonUrls
+ */
+export async function mergeGeojsons(geojsonUrls) {
+  const merged = {
+    type: "FeatureCollection",
+    /** @type {import("ol").Feature[]} */
+    features: [],
+  };
+  for (const url of geojsonUrls) {
+    /** @type {import("ol/format/GeoJSON.js").GeoJSONFeatureCollection} */
+    const goejson = await axios.get(url).then((resp) => resp.data);
+    //@ts-expect-error TODO
+    merged.features.push(...(goejson.features ?? []));
+  }
+
+  return encodeURI(
+    "data:application/json;charset=utf-8," + JSON.stringify(merged),
+  );
+}


### PR DESCRIPTION
This pull request includes changes to the `core/client/eodashSTAC` files by  merging of GeoJSON assets. The most important changes include adding a new helper function for merging GeoJSONs, updating the `createLayersFromAssets` function to utilize this new helper, and modifying the `stacEndpoint` in `eodash.js`.

Enhancements to GeoJSON handling:

* [`core/client/eodashSTAC/helpers.js`](diffhunk://#diff-2a1339b24967b259a493b76ca5ad4c3932a32bd314c1b87a351d9ba34418803dR376-R398): Added a new `mergeGeojsons` function to merge multiple GeoJSON URLs into a single GeoJSON object.
* [`core/client/eodashSTAC/createLayers.js`](diffhunk://#diff-d08eda3ee247def372f9aac5f7a0d8ccb118ec557f3fbe68cc19a7eb531e4d7aR8): Imported the new `mergeGeojsons` function from `helpers.js`.
* [`core/client/eodashSTAC/createLayers.js`](diffhunk://#diff-d08eda3ee247def372f9aac5f7a0d8ccb118ec557f3fbe68cc19a7eb531e4d7aR35-R37): Updated the `createLayersFromAssets` function to handle GeoJSON assets separately, merge them using the new helper function, and create a single vector layer from the merged GeoJSON. [[1]](diffhunk://#diff-d08eda3ee247def372f9aac5f7a0d8ccb118ec557f3fbe68cc19a7eb531e4d7aR35-R37) [[2]](diffhunk://#diff-d08eda3ee247def372f9aac5f7a0d8ccb118ec557f3fbe68cc19a7eb531e4d7aL44-R56) [[3]](diffhunk://#diff-d08eda3ee247def372f9aac5f7a0d8ccb118ec557f3fbe68cc19a7eb531e4d7aR89-R119)