### PR TITLE
several fixes for vector layer output of sync processing

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       comment:
-        description: "Optional comment"
+        description: "Optional comment (can not contain spaces)"
         required: false
         type: string
 

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -261,7 +261,6 @@ export const replaceLayer = (currentLayers, oldLayer, newLayers) => {
       newLayers.map((l) => l.properties.id),
     );
     currentLayers.splice(oldLayerIdx, 1, ...newLayers);
-    return currentLayers;
   }
 
   for (const l of currentLayers) {
@@ -269,12 +268,10 @@ export const replaceLayer = (currentLayers, oldLayer, newLayers) => {
       const updatedGroupLyrs = replaceLayer(l.layers, oldLayer, newLayers);
       if (updatedGroupLyrs?.length) {
         l.layers = updatedGroupLyrs;
-        return currentLayers;
       }
     }
   }
-  // we should have a fallback if layer to be replaced was not found
-  return [...newLayers, ...currentLayers];
+  return currentLayers;
 };
 
 /**

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -246,7 +246,7 @@ export const findLayer = (layers, layer) => {
  * @param {Record<string,any>[]} currentLayers
  * @param {string} oldLayer - id of the layer to be replaced
  * @param {Record<string,any>[]} newLayers - array of layers to replace the old layer
- * @returns {Record<string,any>[] | undefined}
+ * @returns {Record<string,any>[]}
  */
 export const replaceLayer = (currentLayers, oldLayer, newLayers) => {
   const oldLayerIdx = currentLayers.findIndex(
@@ -273,6 +273,8 @@ export const replaceLayer = (currentLayers, oldLayer, newLayers) => {
       }
     }
   }
+  // we should have a fallback if layer to be replaced was not found
+  return [...newLayers, ...currentLayers];
 };
 
 /**

--- a/widgets/EodashMapBtns.vue
+++ b/widgets/EodashMapBtns.vue
@@ -4,6 +4,7 @@
       v-if="exportMap"
       class="map-btn"
       :icon="[mdiMapPlus]"
+      v-tooltip:bottom="'Extract Storytelling configuration'"
       @click="showMapState = !showMapState"
     />
     <ExportState v-if="exportMap" v-model="showMapState" />
@@ -11,12 +12,14 @@
     <v-btn
       class="map-btn"
       :icon="[mdiEarthBox]"
+      v-tooltip:bottom="'Change map projection'"
       v-if="changeProjection && !!availableMapProjection"
       @click="changeMapProjection(availableMapProjection)"
     />
     <v-btn
       class="map-btn"
       :icon="[compareIcon]"
+      v-tooltip:bottom="'Compare mode'"
       v-if="compareIndicators"
       @click="onCompareClick"
     />

--- a/widgets/EodashProcess/methods/handling.js
+++ b/widgets/EodashProcess/methods/handling.js
@@ -188,10 +188,20 @@ export async function handleProcesses({
         ...(imageLayers ?? []),
       ];
       let currentLayers = [...getLayers()];
+      let analysisGroup = currentLayers.find((l) =>
+        l.properties.id.includes("AnalysisGroup"),
+      );
       // remove previous processing layer of the same id
       for (let i = newLayers.length - 1; i >= 0; i--) {
-        //@ts-expect-error Why?
+        //@ts-expect-error TODO
         currentLayers = replaceLayer(currentLayers, newLayers[i].properties.id, [newLayers[i]]);
+        
+        if (!(analysisGroup?.layers?.find(
+          //@ts-expect-error TODO
+          (l) => l.properties.id === newLayers[i]?.properties?.id,
+        ))) {
+          analysisGroup?.layers?.unshift(newLayers[i]);
+        }
       }
 
       if (mapEl.value) {

--- a/widgets/EodashProcess/methods/handling.js
+++ b/widgets/EodashProcess/methods/handling.js
@@ -186,10 +186,19 @@ export async function handleProcesses({
         ...(imageLayers ?? []),
       ];
       let currentLayers = [...getLayers()];
+      // do cleanup of previous processing layers
       let analysisGroup = currentLayers.find((l) =>
         l.properties.id.includes("AnalysisGroup"),
       );
-      analysisGroup?.layers.push(...layers);
+      // remove layers with Results in title
+      for (let i = analysisGroup?.layers.length - 1; i >= 0; i--) {
+        const title = analysisGroup?.layers[i]?.properties['title'];
+        if (typeof title === 'string' && title.startsWith('Results ')) {
+          analysisGroup?.layers.splice(i, 1);
+        }
+      }
+      // unshift because we intend to place the processing layers on top
+      analysisGroup?.layers.unshift(...layers);
 
       if (mapEl.value) {
         mapEl.value.layers = [...currentLayers];

--- a/widgets/EodashProcess/methods/outputs.js
+++ b/widgets/EodashProcess/methods/outputs.js
@@ -1,5 +1,5 @@
 import mustache from "mustache";
-import { extractLayerConfig } from "@/eodashSTAC/helpers";
+import { addTooltipInteraction, extractLayerConfig } from "@/eodashSTAC/helpers";
 import axios from "@/plugins/axios";
 import { createTiffLayerDefinition, separateEndpointLinks } from "./utils";
 
@@ -61,12 +61,11 @@ export async function processVector(links, jsonformValue, layerId) {
     /** @type {Record<string,any>|undefined} */
     let style;
     if (flatStyleJSON) {
-      const extracted = extractLayerConfig(flatStyleJSON);
+      const extracted = extractLayerConfig(layerId ?? "", flatStyleJSON);
       layerConfig = extracted.layerConfig;
       style = extracted.style;
     }
-
-    layers.push({
+    const layer = {
       type: "Vector",
       source: {
         type: "Vector",
@@ -78,9 +77,13 @@ export async function processVector(links, jsonformValue, layerId) {
       properties: {
         id: layerId + "_vector_process",
         title: "Results " + layerId,
-        ...(layerConfig && { ...layerConfig, ...(style && { style: style }) }),
+        ...(layerConfig && { ...layerConfig }),
       },
-    });
+      ...(style && { style: style }),
+    }
+    // just adds the hover interaction, not the tooltip content itself - see https://github.com/eodash/eodash/issues/191
+    addTooltipInteraction(layer, style);
+    layers.push(layer);
   }
   return layers;
 }

--- a/widgets/EodashProcess/methods/outputs.js
+++ b/widgets/EodashProcess/methods/outputs.js
@@ -1,5 +1,8 @@
 import mustache from "mustache";
-import { addTooltipInteraction, extractLayerConfig } from "@/eodashSTAC/helpers";
+import {
+  addTooltipInteraction,
+  extractLayerConfig,
+} from "@/eodashSTAC/helpers";
 import axios from "@/plugins/axios";
 import { createTiffLayerDefinition, separateEndpointLinks } from "./utils";
 
@@ -18,7 +21,7 @@ export function processImage(links, jsonformValue, origBbox) {
     layers.push({
       type: "Image",
       properties: {
-        id: link.id,
+        id: link.id + "_process",
         title: "Results " + link.id,
       },
       source: {
@@ -75,12 +78,12 @@ export async function processVector(links, jsonformValue, layerId) {
         format: "GeoJSON",
       },
       properties: {
-        id: layerId + "_vector_process",
+        id: link.id + "_process",
         title: "Results " + layerId,
         ...(layerConfig && { ...layerConfig }),
       },
       ...(style && { style: style }),
-    }
+    };
     // just adds the hover interaction, not the tooltip content itself - see https://github.com/eodash/eodash/issues/191
     addTooltipInteraction(layer, style);
     layers.push(layer);
@@ -296,13 +299,14 @@ export async function processGeoTiff({
   for (const link of geotiffLinks ?? []) {
     urls.push(mustache.render(link.href, { ...(jsonformValue ?? {}) }));
   }
-  return [
+  const definitions = geotiffLinks.map((geotiffLink) =>
     createTiffLayerDefinition(
-      geotiffLinks[0],
+      geotiffLink,
       layerId,
       urls,
       projection,
       processId,
     ),
-  ];
+  );
+  return definitions;
 }

--- a/widgets/EodashProcess/methods/utils.js
+++ b/widgets/EodashProcess/methods/utils.js
@@ -95,7 +95,7 @@ export async function createTiffLayerDefinition(
             sources: urls.map((url) => ({ url })),
           },
           properties: {
-            id: layerId + "_geotiff_process" + processId,
+            id: link.id + "_process" + processId,
             title: "Results " + layerId,
             ...(layerConfig && { layerConfig: layerConfig }),
             layerControlToolsExpand: true,


### PR DESCRIPTION
- fix extraction of style from flatstyle def - missing func param
- add tooltips for core buttons
- pass vector style even if no special layer config defined
- remove past processing layer(s) when a new one is to be added
  - @santilland @A-Behairi This is changing behavior, please approve if this is ok to change.
    - before this PR, processing layers were added with each process execution (but they were not displayed in layercontrol, I guess due to a shared title?, so could not be interacted with)
    - now, past processing layers get removed from the list of layers to be passed to map
- add tooltip interaction to processing results - vector source (but not tooltip content itself [new issue](https://github.com/eodash/eodash/issues/191))