### PR TITLE
Fix: Adopt runtime styles into the shadowRoot

### DIFF
--- a/core/client/App.vue
+++ b/core/client/App.vue
@@ -13,7 +13,7 @@
 <script setup>
 import Dashboard from "@/views/Dashboard.vue";
 import ErrorAlert from "./components/ErrorAlert.vue";
-import { provideEodashInstance } from "@/composables";
+import { provideEodashInstance, useAdoptStyles } from "@/composables";
 import { onErrorCaptured, ref } from "vue";
 
 defineProps({
@@ -37,4 +37,8 @@ onErrorCaptured((e, inst, info) => {
   `;
 });
 provideEodashInstance();
+if (isWebComponent) {
+  // Adopt styles into the shadowRoot when running as web component
+  useAdoptStyles();
+}
 </script>

--- a/core/client/composables/index.js
+++ b/core/client/composables/index.js
@@ -16,7 +16,7 @@ import { inject, nextTick, onMounted, onUnmounted, watch } from "vue";
 import { useSTAcStore } from "@/store/stac";
 import log from "loglevel";
 import { eodashKey, eoxLayersKey } from "@/utils/keys";
-import { useEventBus } from "@vueuse/core";
+import { useEventBus, useMutationObserver } from "@vueuse/core";
 import { isFirstLoad } from "@/utils/states";
 import { setCollectionsPalette } from "@/utils";
 import mustache from "mustache";
@@ -409,3 +409,93 @@ export const useGetSubCodeId = (collection) => {
   }
   return /** @type {string} */ (collection.id);
 };
+
+/**
+ * Composable: Adopt Vuetify styles into eo-dash shadow root
+ * - Safe no-op outside Web Component context
+ * - Cleans up observers on unmount
+ */
+/**
+ * @param {string[]} [keyWords=["vuetify"]] - list of case-insensitive substrings to match against <style> element IDs
+ */
+export function useAdoptStyles(keyWords = ["vuetify"]) {
+  /** @type {Array<() => void>} */
+  let stops = [];
+
+  const eoDash =
+    /** @type {HTMLElement & { shadowRoot: ShadowRoot | null }} */ (
+      document.querySelector("eo-dash")
+    );
+  if (!eoDash || !eoDash.shadowRoot) return;
+  // Require Constructable Stylesheets support
+  if (typeof CSSStyleSheet === "undefined") return;
+
+  const head = document.head;
+  const shadow = eoDash.shadowRoot;
+  /** @type {Map<string, CSSStyleSheet>} */
+  const sheetsById = new Map();
+
+  /**
+   * @param {string} id
+   * @param {string} cssText
+   */
+  const updateSheet = (id, cssText) => {
+    let sheet = sheetsById.get(id);
+    if (!sheet) {
+      sheet = new CSSStyleSheet();
+      sheet.replaceSync(cssText);
+      sheetsById.set(id, sheet);
+      shadow.adoptedStyleSheets = [...shadow.adoptedStyleSheets, sheet];
+    } else {
+      sheet.replaceSync(cssText);
+    }
+  };
+
+  /**
+   * @param {HTMLStyleElement} el
+   */
+  const handleStyleEl = (el) => {
+    const id = el.id || "";
+    const idLc = id.toLowerCase();
+    if (!keyWords.some((s) => idLc.includes(String(s).toLowerCase()))) return;
+    const cssText = (el.textContent || "").replaceAll(":root", ":host");
+    if (!cssText) return;
+
+    updateSheet(id, cssText);
+
+    const observer = useMutationObserver(
+      el,
+      () => {
+        const nextCss = (el.textContent || "").replaceAll(":root", ":host");
+        if (nextCss) updateSheet(id, nextCss);
+      },
+      { childList: true, characterData: true, subtree: true },
+    );
+    if (observer?.stop) stops.push(() => observer.stop());
+  };
+
+  /**
+   * @param {Node} node
+   */
+  const handleNode = (node) => {
+    if (node instanceof HTMLStyleElement) handleStyleEl(node);
+  };
+
+  head.childNodes.forEach(handleNode);
+
+  const headObserver = useMutationObserver(
+    head,
+    (mutations) => {
+      mutations?.forEach((m) => {
+        m.addedNodes?.forEach(handleNode);
+      });
+    },
+    { childList: true },
+  );
+  if (headObserver?.stop) stops.push(() => headObserver.stop());
+
+  onUnmounted(() => {
+    stops.forEach((stop) => stop());
+    stops = [];
+  });
+}

--- a/tests/cypress/components/widgets/EodashDatePicker.cy.js
+++ b/tests/cypress/components/widgets/EodashDatePicker.cy.js
@@ -18,7 +18,7 @@ describe("<EodashDatePicker/>", () => {
     });
 
     it("click date", () => {
-      cy.get(".vc-day-content").eq(2).click();
+      cy.get(".vc-day-content").eq(10).click();
     });
   });
 });


### PR DESCRIPTION
Observing the mutations in the head and the styles inside the targeted style elements, this ensures that that the styles are mirrored inside the shadow root. Fixing the issue of applying and updating the theme's css variables 