### PR TITLE
Support eox:colorlegend from collection config for process results and add support for flatgeobuf as eoxhub process result

### DIFF
--- a/core/client/eodashSTAC/EodashCollection.js
+++ b/core/client/eodashSTAC/EodashCollection.js
@@ -9,6 +9,7 @@ import {
   generateFeatures,
   getDatetimeProperty,
   replaceLayer,
+  getLegendInfoFromStac,
 } from "./helpers";
 import {
   getLayers,
@@ -184,20 +185,7 @@ export class EodashCollection {
 
     if (isSupported) {
       // Checking for potential legend asset
-      let extraProperties = null;
-      if (this.#collectionStac?.assets?.legend?.href) {
-        extraProperties = {
-          description: `<div style="width: 100%">
-            <img src="${this.#collectionStac.assets.legend.href}" style="max-height:70px; margin-top:-15px; margin-bottom:-20px;" />
-          </div>`,
-        };
-      }
-      // Check if collection has eox:colorlegend definition, if yes overwrite legend description
-      if (this.#collectionStac && this.#collectionStac["eox:colorlegend"]) {
-        extraProperties = {
-          layerLegend: this.#collectionStac["eox:colorlegend"],
-        };
-      }
+      let extraProperties = getLegendInfoFromStac(this.#collectionStac);
       extraProperties = {
         ...extraProperties,
         ...(this.color && { color: this.color }),

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -550,3 +550,25 @@ export function getDatetimeProperty(links) {
     return prop;
   }
 }
+
+/**
+ * @param {import ("stac-ts").StacCollection | undefined | null} collection
+ * @returns {object}
+ */
+export function getLegendInfoFromStac(collection) {
+  let extraProperties = {};
+  if (collection?.assets?.legend?.href) {
+    extraProperties = {
+      description: `<div style="width: 100%">
+          <img src="${collection.assets.legend.href}" style="max-height:70px; margin-top:-15px; margin-bottom:-20px;" />
+        </div>`,
+    };
+  }
+  // Check if collection has eox:colorlegend definition, if yes overwrite legend description
+  if (collection && collection["eox:colorlegend"]) {
+    extraProperties = {
+      layerLegend: collection["eox:colorlegend"],
+    };
+  }
+  return extraProperties;
+}

--- a/widgets/EodashProcess/methods/utils.js
+++ b/widgets/EodashProcess/methods/utils.js
@@ -3,6 +3,7 @@ import {
   extractLayerConfig,
   mergeGeojsons,
   replaceLayer,
+  getLegendInfoFromStac,
 } from "@/eodashSTAC/helpers";
 import axios from "@/plugins/axios";
 import { getCompareLayers, getLayers } from "@/store/actions";
@@ -294,7 +295,6 @@ export async function creatAsyncProcessLayerDefinitions(
     let style;
     /** @type {Record<string, unknown> | undefined}  */
     let layerConfig;
-    let extraProperties = {};
     if (flatStyleJSON) {
       const extracted = extractLayerConfig(
         selectedStac?.id ?? "",
@@ -305,11 +305,7 @@ export async function creatAsyncProcessLayerDefinitions(
     }
 
     // Check if collection has eox:colorlegend definition, if yes overwrite legend description
-    if (selectedStac && selectedStac["eox:colorlegend"]) {
-      extraProperties = {
-        layerLegend: selectedStac["eox:colorlegend"],
-      };
-    }
+    let extraProperties = getLegendInfoFromStac(selectedStac);
 
     switch (resultItem.type) {
       case "image/tiff": {

--- a/widgets/EodashProcess/methods/utils.js
+++ b/widgets/EodashProcess/methods/utils.js
@@ -291,6 +291,7 @@ export async function creatAsyncProcessLayerDefinitions(
   for (const resultItem of processResults) {
     const flatStyleJSON = extractStyleFromResult(resultItem, flatStyles);
     let style, layerConfig;
+    let extraProperties = {};
     if (flatStyleJSON) {
       const extracted = extractLayerConfig(
         selectedStac?.id ?? "",
@@ -298,6 +299,13 @@ export async function creatAsyncProcessLayerDefinitions(
       );
       layerConfig = extracted.layerConfig;
       style = extracted.style;
+    }
+
+    // Check if collection has eox:colorlegend definition, if yes overwrite legend description
+    if (selectedStac && selectedStac["eox:colorlegend"]) {
+      extraProperties = {
+        layerLegend: selectedStac["eox:colorlegend"],
+      };
     }
 
     switch (resultItem.type) {
@@ -313,6 +321,7 @@ export async function creatAsyncProcessLayerDefinitions(
               (resultItem.id ?? ""),
             layerControlToolsExpand: true,
             ...(layerConfig && { layerConfig }),
+            ...extraProperties,
           },
           source: {
             type: "GeoTIFF",
@@ -350,6 +359,7 @@ export async function creatAsyncProcessLayerDefinitions(
                 style,
               },
             }),
+            ...extraProperties,
           },
           ...(!style?.variables && { style }),
           interactions: [],


### PR DESCRIPTION
- 1) can be tested against https://gtif-cerulean.github.io/cerulean-catalog/cerulean/catalog.json
- 2) flatgeobuf as eoxhub process result is untested, because we do not have a workflow generating it yet