### PR TITLE
fix: parquetItems read need to be awaited in veda statistics handler

### DIFF
--- a/widgets/EodashProcess/methods/custom-endpoints/chart/veda-endpoint.js
+++ b/widgets/EodashProcess/methods/custom-endpoints/chart/veda-endpoint.js
@@ -77,7 +77,7 @@ async function fetchVedaCOGsConfig(selectedStac, absoluteUrl) {
           axios
             .get(toAbsolute(link.href, absoluteUrl))
             .then((resp) => resp.data)
-            .then((collection) => {
+            .then(async (collection) => {
               // items in geoparquet handling specially to get item links
               const parquetAsset = Object.values(collection.assets ?? {}).find(
                 (asset) =>
@@ -86,7 +86,7 @@ async function fetchVedaCOGsConfig(selectedStac, absoluteUrl) {
               );
               if (parquetAsset) {
                 const parquetAbsoluteUrl = toAbsolute(parquetAsset.href, toAbsolute(link.href, absoluteUrl));
-                readParquetItems(parquetAbsoluteUrl).then((items) => {
+                await readParquetItems(parquetAbsoluteUrl).then((items) => {
                   collection.links.push(...generateLinksFromItems(items));
                 });
               }


### PR DESCRIPTION
... Otherwise function is exited earlier

Sorry for the oversight, now the fix is complete.