### PR TITLE
Fix: configure templates for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ RUN chmod +x /entrypoint.sh
 ENV STAC_ENDPOINT=
 ENV API=false
 ENV BRAND=
+ENV TEMPLATES=
+
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/core/client/types.ts
+++ b/core/client/types.ts
@@ -465,7 +465,12 @@ export type EodashStyleJson = import("ol/style/flat").FlatStyleLike & {
   variables?: Record<string, string | number | boolean | null | undefined>;
   legend?: import("@eox/layercontrol/src/components/layer-config.js").EOxLayerControlLayerConfig["layerConfig"]["legend"];
   jsonform?: import("json-schema").JSONSchema7;
-  tooltip?: { id: string; title?: string; appendix?: string, decimals?: number, }[];
+  tooltip?: {
+    id: string;
+    title?: string;
+    appendix?: string;
+    decimals?: number;
+  }[];
 };
 export type EodashRasterJSONForm = {
   jsonform: Record<string, any>;

--- a/core/client/utils/states.js
+++ b/core/client/utils/states.js
@@ -144,5 +144,5 @@ export const dataThemesBrands = {
   industry: {
     icon: mdiWrench,
     color: "#8d845cff",
-  }
+  },
 };

--- a/widgets/EodashMap/index.vue
+++ b/widgets/EodashMap/index.vue
@@ -355,7 +355,9 @@ const tooltipPropertyTransform = (map) => {
       param.value = JSON.stringify(param.value);
     }
     if (!isNaN(Number(param.value))) {
-      const decimals = !isNaN(Number(tooltipProp.decimals)) ? Number(tooltipProp.decimals) : 4;
+      const decimals = !isNaN(Number(tooltipProp.decimals))
+        ? Number(tooltipProp.decimals)
+        : 4;
       param.value = Number(param.value).toFixed(decimals).toString();
     }
 

--- a/widgets/EodashProcess/ProcessList.vue
+++ b/widgets/EodashProcess/ProcessList.vue
@@ -24,7 +24,8 @@
               :href="getJobStatusUrl(item.jobID, currentIndicator)"
               >{{
                 new Date(item.job_start_datetime).toISOString().slice(0, 16)
-              }} <v-icon>mdi-open-in-new</v-icon></a
+              }}
+              <v-icon>mdi-open-in-new</v-icon></a
             >
           </td>
           <td>{{ item.status }}</td>
@@ -73,7 +74,12 @@
 </template>
 <script setup>
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import { mdiUploadBox, mdiDownloadBox, mdiTrashCanOutline, mdiOpenInNew } from "@mdi/js";
+import {
+  mdiUploadBox,
+  mdiDownloadBox,
+  mdiTrashCanOutline,
+  mdiOpenInNew,
+} from "@mdi/js";
 import { onMounted, toRef, toRefs } from "vue";
 import { useSTAcStore } from "@/store/stac";
 import { compareIndicator, indicator } from "@/store/states";


### PR DESCRIPTION
This pull request adds the possibility to add an optional `TEMPLATES` variable to the docker container to allow dynamic selection of templates when building it, the variable should be a string with keys of the desired base templates separated by a comma for e.g `explore,expert,lite,compare`, the first template in the string will be set as the default and is rendered when the user first visits the instance.