### PR TITLE
fix: support direct legends on links,

### DIFF
--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -9,6 +9,7 @@ import {
   createAssetID,
   mergeGeojsons,
   extractLayerConfig,
+  extractEoxLegendLink,
   addTooltipInteraction,
   fetchStyle,
 } from "./helpers";
@@ -152,6 +153,7 @@ export async function createLayersFromAssets(
         stacObject?.["eodash:merge_assets"] === false
           ? geoJsonSource
           : await mergeGeojsons(geoJsonSources);
+
       const layer = {
         type: "Vector",
         source: {
@@ -328,7 +330,6 @@ export const createLayersFromLinks = async (
 
   for (const wmsLink of wmsArray ?? []) {
     // Registering setting sub wms link projection
-
     const wmsLinkProjection =
       /** @type {number | string | {name: string, def: string} | undefined} */
       (wmsLink?.["proj:epsg"] || wmsLink?.["eodash:proj4_def"]);
@@ -386,7 +387,7 @@ export const createLayersFromLinks = async (
       json.source.params["STYLES"] = wmsLink["wms:styles"];
     }
     if (extraProperties !== null) {
-      json.properties = { ...json.properties, ...extraProperties };
+      json.properties = { ...json.properties, ...extraProperties, ...extractEoxLegendLink(wmsLink) };
     }
     jsonArray.push(json);
   }
@@ -491,7 +492,7 @@ export const createLayersFromLinks = async (
     }
     extractRoles(json.properties, wmtsLink);
     if (extraProperties !== null) {
-      json.properties = { ...json.properties, ...extraProperties };
+      json.properties = { ...json.properties, ...extraProperties, ...extractEoxLegendLink(wmtsLink) };
     }
     jsonArray.push(json);
   }
@@ -556,7 +557,7 @@ export const createLayersFromLinks = async (
 
     extractRoles(json.properties, xyzLink);
     if (extraProperties !== null) {
-      json.properties = { ...json.properties, ...extraProperties };
+      json.properties = { ...json.properties, ...extraProperties, ...extractEoxLegendLink(xyzLink) };
     }
     jsonArray.push(json);
   }
@@ -623,7 +624,7 @@ export const createLayersFromLinks = async (
     addTooltipInteraction(json, style);
     extractRoles(json.properties, vectorTileLink);
     if (extraProperties !== null) {
-      json.properties = { ...json.properties, ...extraProperties };
+      json.properties = { ...json.properties, ...extraProperties, ...extractEoxLegendLink(vectorTileLink) };
     }
     jsonArray.push(json);
   }

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -192,10 +192,8 @@ export const fetchStyle = async (
         /** @type {Array<string>} */ (link["asset:keys"]).includes(assetKey),
     );
   } else {
-    // legacy behavior for rasterform/api mode
-    styleLink = stacObject.links.find(
-      (link) => link.rel.includes("style")
-    );
+    log.debug("Neither link key, nor asset key input, can not match any style to layer.", stacObject.id);
+   return {};
   }
   if (styleLink) {
     /** @type {import("@/types").EodashStyleJson} */
@@ -846,6 +844,21 @@ export function extractLayerLegend(collection) {
   if (collection && collection["eox:colorlegend"]) {
     extraProperties = {
       layerLegend: collection["eox:colorlegend"],
+    };
+  }
+  return extraProperties;
+}
+
+
+/**
+ * @param { import ("stac-ts").StacLink } link
+ * @returns {object}
+ */
+export function extractEoxLegendLink(link) {
+  let extraProperties = {};
+  if (link["eox:colorlegend"]) {
+    extraProperties = {
+      layerLegend: link["eox:colorlegend"],
     };
   }
   return extraProperties;


### PR DESCRIPTION
- fix regression of fallback first style being fetched and applied when there are links with and without style being defined for them
- allow to read `eox:colorlegend` on xyz/wms/wmts/vector-tile links (`eodash_catalog` allows defining it)