### PR TITLE
fix: bring eodash:merge_assets to item root in parquet mode

### DIFF
--- a/core/client/eodashSTAC/parquet.js
+++ b/core/client/eodashSTAC/parquet.js
@@ -95,7 +95,8 @@ function moveItemProperties(item) {
     "id",
     "collection",
     "properties",
-    "auth:schemes"
+    "auth:schemes",
+    "eodash:merge_assets"
   ];
   for (const key in item) {
     if (!stacProperties.includes(key)) {


### PR DESCRIPTION
Forgot to bring the key to item. Up to now ended up in properties.