### PR TITLE
feat: minor rendering tweaks

### DIFF
--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -15,6 +15,7 @@ import {
 } from "./helpers";
 import { handleAuthenticationOfLink } from "./auth";
 import log from "loglevel";
+import { useSTAcStore } from "@/store/stac";
 
 /**
  * @param {string} collectionId
@@ -375,6 +376,11 @@ export const createLayersFromLinks = async (
         },
       },
     };
+    // @ts-expect-error missing type definition, can be accessed like this
+    if (wmsLink.roles?.includes("baselayer") || wmsLink.roles?.includes("overlay")) {
+      // @ts-expect-error no type for eox-map
+      json.preload = Infinity;
+    }
     if ("wms:version" in wmsLink) {
       // @ts-expect-error no type for eox-map
       json.source.params["VERSION"] = wmsLink["wms:version"];
@@ -556,6 +562,16 @@ export const createLayersFromLinks = async (
       xyzUrl = `${base}?${params.toString()}`;
     }
 
+    const { supportedUpscalingEndpoints } = useSTAcStore();
+    const isUpscalingSupported = supportedUpscalingEndpoints.some(
+      (/** @type {string} */ endpoint) => xyzUrl.includes(endpoint),
+    );
+
+    // Add sharding for s2maps automatically
+    if (xyzUrl.includes("s2maps-tiles.eu")) {
+      xyzUrl = xyzUrl.replace("s2maps-tiles.eu", "{a-e}.s2maps-tiles.eu");
+    }
+
     log.debug("XYZ Layer added", linkId);
     let json = {
       type: "Tile",
@@ -568,11 +584,22 @@ export const createLayersFromLinks = async (
       },
       source: {
         type: "XYZ",
-        url: xyzUrl,
+        url: isUpscalingSupported ? xyzUrl.replace("{y}", "{y}@2x") : xyzUrl,
         projection: projectionCode,
         attributions: xyzLink.attribution,
       },
     };
+    if (isUpscalingSupported) {
+      // @ts-expect-error tileGrid is added here and supported in eox-map layer definition
+      json.source.tileGrid = {
+        "tileSize" : [512, 512]
+      };
+    }
+    // @ts-expect-error missing type definition, can be accessed like this
+    if (xyzLink.roles?.includes("baselayer") || xyzLink.roles?.includes("overlay")) {
+      // @ts-expect-error no type for eox-map
+      json.preload = Infinity;
+    }
 
     extractRoles(json.properties, xyzLink);
     if (extraProperties !== null) {

--- a/core/client/store/stac.js
+++ b/core/client/store/stac.js
@@ -30,6 +30,12 @@ export const useSTAcStore = defineStore("stac", () => {
   const isApi = ref(false);
 
   /**
+   * List of supported endpoints for upscaling
+   * @type {import("vue").Ref<string[]>}
+   */
+  const supportedUpscalingEndpoints = ref([]);
+
+  /**
    * Links of the root STAC catalog
    *
    * @type {import("vue").Ref<import("stac-ts").StacLink[] | null>}
@@ -77,6 +83,8 @@ export const useSTAcStore = defineStore("stac", () => {
     stacEndpoint.value = endpoint.endpoint;
     isApi.value = endpoint.api ?? false;
     rasterEndpoint.value = endpoint.rasterEndpoint ?? null;
+    supportedUpscalingEndpoints.value =
+      endpoint.supportedUpscalingEndpoints ?? [];
   }
 
   /**
@@ -249,5 +257,6 @@ export const useSTAcStore = defineStore("stac", () => {
     selectedStac,
     selectedCompareStac,
     selectedItem,
+    supportedUpscalingEndpoints,
   };
 });

--- a/core/client/types.ts
+++ b/core/client/types.ts
@@ -331,6 +331,7 @@ export type StacEndpoint =
       api?: boolean;
       rasterEndpoint?: string;
       vectorEndpoint?: string;
+      supportedUpscalingEndpoints?: string[];
     };
 
 /** @group Eodash */

--- a/templates/baseConfig.js
+++ b/templates/baseConfig.js
@@ -15,6 +15,7 @@ const baseConfig = {
       "https://esa-eodashboards.github.io/eodashboard-catalog/trilateral/catalog.json",
     // "https://api.explorer.eopf.copernicus.eu/stac",
     // api: true,
+    supportedUpscalingEndpoints: ["openveda.cloud", "api.explorer.eopf.copernicus.eu"],
   },
   brand: {
     noLayout: true,


### PR DESCRIPTION
* automatic sharding of s2-maps endpoint
* adding preload config for base and overlay layers to prioritize loading base and overlays (not 100% sure it is really applied)
* upscaling based tilesize increase
  - in the stacEndpoint config possible to define `supportedUpscalingEndpoints`, if domain listed tileSize will be increased to 512 and  upscale @2x will be added to requests
 