### PR TITLE
fix: use WMTSCapabilities source for non-marine WMTS layers

### DIFF
--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -455,7 +455,7 @@ export const createLayersFromLinks = async (
     const dimensions = /** @type { {style:any} & Record<string,any> } */ (
       wmtsLink["wmts:dimensions"] || {}
     );
-    let { style, ...dimensionsWithoutStyle } = { ...dimensions };
+    let { style, matrixSet, ...dimensionsWithoutStyle } = { ...dimensions };
     let extractedStyle = /** @type { string } */ (style || "default");
 
     // TODO, this does not yet work between layer time changes because we do not get
@@ -513,9 +513,7 @@ export const createLayersFromLinks = async (
           url: buildCapabilitiesUrl(wmtsLink.href),
           layer: wmtsLink["wmts:layer"],
           style: extractedStyle,
-          ...(wmtsLink["wmts:matrixSet"] && {
-            matrixSet: wmtsLink["wmts:matrixSet"],
-          }),
+          ...(matrixSet ? { matrixSet } : {}),
           attributions: wmtsLink.attribution,
           dimensions: dimensionsWithoutStyle,
         },


### PR DESCRIPTION
Replace the manual WMTS tileGrid construction with the existing WMTSCapabilities source type from EOxElements that auto-fetches and parses the capabilities document.

This removes hardcoded tile-grid parameters, prefixed TileMatrix logic, and lets OpenLayers derive correct resolutions, matrixIds, and encoding directly from the capabilities XML.

The marine.copernicus branch is untouched (still uses type: "WMTS").

Refs: #90