### PR TITLE
chore: update timecontrol to 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@eox/layout": "^1.0.0",
         "@eox/map": "^2.2.0",
         "@eox/stacinfo": "^1.1.0",
-        "@eox/timecontrol": "^2.1.1",
+        "@eox/timecontrol": "^2.1.2",
         "@eox/timeslider": "https://pkg.pr.new/EOX-A/EOxElements/@eox/timeslider@9873028",
         "@eox/ui": "^0.6.0",
         "@mdi/js": "^7.4.47",
@@ -1648,12 +1648,12 @@
       }
     },
     "node_modules/@eox/timecontrol": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@eox/timecontrol/-/timecontrol-2.1.1.tgz",
-      "integrity": "sha512-HpXFzt7V6aL0M8TsvaGwNl0Ime7GrSNtM4dLTEYi+SQIz8nsZfkf+bnz8ieFMgt4cyeUeFHH3Jj5cUeLMyO0aw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@eox/timecontrol/-/timecontrol-2.1.2.tgz",
+      "integrity": "sha512-6yd842web8nW9E30KQ1YS7vM8O7BmxByx2W6usTkpi8MihWgjBIAkOub6ueIZJphC9+fV/Btxy6wFOLTDvz2Kw==",
       "dependencies": {
         "@eox/elements-utils": "^1.1.0",
-        "@eox/ui": "^0.5.0",
+        "@eox/ui": "^0.6.0",
         "@ffmpeg/ffmpeg": "^0.12.15",
         "@ffmpeg/util": "^0.12.2",
         "dayjs": "^1.11.9",
@@ -1671,24 +1671,6 @@
       "engines": {
         "node": ">=18.0.0",
         "npm": ">=8.0.0"
-      }
-    },
-    "node_modules/@eox/timecontrol/node_modules/@eox/ui": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@eox/ui/-/ui-0.5.1.tgz",
-      "integrity": "sha512-ggvB9nPcD2DuqO+UPOpIAE8S6V/lNHOwdxZLBiMleXa00Rc57r5hzTc5+R3GuhoRuepERvHGw3bLez6Sr7LTew==",
-      "license": "MIT",
-      "dependencies": {
-        "beercss": "3.12.13"
-      }
-    },
-    "node_modules/@eox/timecontrol/node_modules/beercss": {
-      "version": "3.12.13",
-      "resolved": "https://registry.npmjs.org/beercss/-/beercss-3.12.13.tgz",
-      "integrity": "sha512-zsg15us8pSLTupIOzFFJqpJ7eJDLV6whsxT6GcRYGnYaF0ka45+HQ/u3+ldSUkCeyA5J24g6csEuMW8tqrI/0w==",
-      "license": "MIT",
-      "dependencies": {
-        "material-dynamic-colors": "^1.1.2"
       }
     },
     "node_modules/@eox/timeslider": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@eox/layout": "^1.0.0",
     "@eox/map": "^2.2.0",
     "@eox/stacinfo": "^1.1.0",
-    "@eox/timecontrol": "^2.1.1",
+    "@eox/timecontrol": "^2.1.2",
     "@eox/timeslider": "https://pkg.pr.new/EOX-A/EOxElements/@eox/timeslider@9873028",
     "@eox/ui": "^0.6.0",
     "@mdi/js": "^7.4.47",


### PR DESCRIPTION
manual update to eox-timecontrol 2.1.2