### PR TITLE
fix: layer id matching done properly

### DIFF
--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -361,7 +361,7 @@ export const findLayersByLayerPrefix = (layers, referenceLayer) => {
       matches.push(...findLayersByLayerPrefix(layer.layers, referenceLayer));
     } else {
       const id = layer?.properties?.id;
-      if (typeof id === "string" && id.split(";")[0] === prefix) {
+      if (typeof id === "string" && id.split(";:;")[0] === prefix) {
         matches.push(layer);
       }
     }


### PR DESCRIPTION
This fixes the rare case when one layer has ID which is a subset of another layer ID and on datetime switch this deleted all other layers:

close https://github.com/eodash/eodash/issues/339