### PR TITLE
Fix: handling errors of eoapi/sh statistics

### DIFF
--- a/widgets/EodashProcess/methods/custom-endpoints/chart/sentinelhub-endpoint.js
+++ b/widgets/EodashProcess/methods/custom-endpoints/chart/sentinelhub-endpoint.js
@@ -58,7 +58,7 @@ export async function handleSentinelHubProcess({
   );
 
   // fetch data from sentinel hub
-  return await Promise.all(
+  const results = await Promise.all(
     timePairs.map(([to, from]) => {
       return fetchSentinelHubData({
         url: endpoint,
@@ -67,14 +67,18 @@ export async function handleSentinelHubProcess({
         from,
         to,
         exampleLink: evalScriptLink,
-      }).catch((err) =>
+      }).catch((err) => {
         console.error(
           "[eodash] Error while fetching data from sentinel hub endpoint:",
           err,
-        ),
-      );
+        );
+        return [];
+      });
     }),
-  ).then((data) => data.flat().map((data) => data.outputs.data));
+  )
+    .then((data) => data.filter((result) => result.length > 0))
+    .then((data) => data.flat().map((data) => data.outputs.data));
+  return results;
 }
 
 /**

--- a/widgets/EodashProcess/methods/custom-endpoints/chart/veda-endpoint.js
+++ b/widgets/EodashProcess/methods/custom-endpoints/chart/veda-endpoint.js
@@ -37,7 +37,7 @@ export async function handleVedaEndpoint({
     vedaLink,
   );
   // TODO: convert jsonform bbox type to geojson in the schema to avoid the conversion here
-  return await Promise.all(
+  const results = await Promise.all(
     configs.map(({ endpoint, datetime }) => {
       const url = new URL(vedaEndpoint);
       const key = vedaLink.endpoint === "veda_stac" ? "ids" : "url";
@@ -56,14 +56,17 @@ export async function handleVedaEndpoint({
           fetchedSats.date = datetime;
           return fetchedSats;
         })
-        .catch((resp) =>
+        .catch((resp) => {
           console.error(
             "[eodash] Error while fetching data from veda endpoint:",
             resp,
-          ),
-        );
+          );
+          return null;
+        });
     }),
   );
+  // Filter out the nulls (failed requests) before returning
+  return results.filter((result) => result !== null);
 }
 
 /**


### PR DESCRIPTION
handling partial errors of eoapi/sh statistics apis permitting loading of charts of partial response set - coming from non-failing requests