### PR TITLE
Minor adjustments and props options

### DIFF
--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -148,6 +148,111 @@ export async function createLayersFromAssets(
     }
   }
 
+  if (geoTIFFSources.length) {
+    for (const [i, geotiffSource] of geoTIFFSources.entries()) {
+      const assetName = assetIds[geoTIFFIdx[i]];
+      const styles = await fetchStyle(stacObject, undefined, assetName);
+      // get the correct style which is not attached to a link
+      let { layerConfig, style } = extractLayerConfig(collectionId, styles);
+      let assetLayerId = createAssetID(
+        collectionId,
+        stacObject.id,
+        geoTIFFIdx[i],
+      );
+      if (
+        assets[assetName]?.roles?.includes("overlay") ||
+        assets[assetName]?.roles?.includes("baselayer")
+      ) {
+        // to prevent them being removed by date change on main dataset
+        assetLayerId = assetName;
+      }
+      log.debug("Creating WebGLTile layer from GeoTIFF", assetLayerId);
+      log.debug("Configured Sources", geoTIFFSources);
+      const sources =
+        stacObject?.["eodash:merge_assets"] !== false
+          ? geoTIFFSources
+          : [geotiffSource];
+      const layer = {
+        type: "WebGLTile",
+        source: {
+          type: "GeoTIFF",
+          normalize: !style,
+          interpolate: false,
+          sources,
+        },
+        properties: {
+          id: assetLayerId,
+          title: assets[assetName]?.title || title,
+          layerConfig,
+          layerDatetime,
+        },
+        style,
+      };
+      if (extraProperties) {
+        layer.properties = { ...layer.properties, ...extraProperties };
+      }
+      extractRoles(layer.properties, assets[assetName]);
+      addTooltipInteraction(layer, style);
+      jsonArray.push(layer);
+      if (stacObject?.["eodash:merge_assets"] !== false) break;
+    }
+  }
+
+  if (zarrAssetIds.length) {
+    for (const [i, assetName] of zarrAssetIds.entries()) {
+      const availableBands =
+        /** @type {{name:String, [key: string]: any}[]} */ (
+          assets[assetName]["bands"] ?? []
+        ).map((band) => band.name);
+
+      const fetchedStyle = await fetchStyle(stacObject, undefined, assetName);
+      let { layerConfig, style } = extractLayerConfig(
+        collectionId,
+        fetchedStyle,
+      );
+      const defaultBands = layerConfig?.schema?.bands?.default ?? [
+        "b04",
+        "b03",
+        "b02",
+      ];
+      if (!layerConfig && !style) {
+        const generated = generateGeoZarrStyle(availableBands, defaultBands);
+        ({ layerConfig, style } = extractLayerConfig(collectionId, generated));
+      }
+
+      let assetLayerId = createAssetID(collectionId, stacObject.id, zarrIdx[i]);
+      if (
+        assets[assetName]?.roles?.includes("overlay") ||
+        assets[assetName]?.roles?.includes("baselayer")
+      ) {
+        assetLayerId = assetName;
+      }
+
+      log.debug("Creating WebGLTile layer from GeoZarr", assetLayerId);
+
+      const layer = {
+        type: "WebGLTile",
+        properties: {
+          id: assetLayerId,
+          title: assets[assetName]?.title || title,
+          layerConfig,
+          layerDatetime,
+        },
+        source: {
+          type: "GeoZarr",
+          url: assets[assetName].href,
+          bands: defaultBands,
+        },
+        ...(style ? { style } : {}),
+      };
+      if (extraProperties) {
+        layer.properties = { ...layer.properties, ...extraProperties };
+      }
+      extractRoles(layer.properties, assets[assetName]);
+      jsonArray.push(layer);
+    }
+  }
+
   if (geoJsonSources.length) {
     for (const [i, geoJsonSource] of geoJsonSources.entries()) {
       // fetch styles and separate them by their mapping between links and assets
@@ -271,111 +376,6 @@ export async function createLayersFromAssets(
       jsonArray.push(layer);
       // if we merged assets (default yes), then we can break from this loop
       if (stacObject?.["eodash:merge_assets"] !== false) break;
-    }
-  }
-
-  if (geoTIFFSources.length) {
-    for (const [i, geotiffSource] of geoTIFFSources.entries()) {
-      const assetName = assetIds[geoTIFFIdx[i]];
-      const styles = await fetchStyle(stacObject, undefined, assetName);
-      // get the correct style which is not attached to a link
-      let { layerConfig, style } = extractLayerConfig(collectionId, styles);
-      let assetLayerId = createAssetID(
-        collectionId,
-        stacObject.id,
-        geoTIFFIdx[i],
-      );
-      if (
-        assets[assetName]?.roles?.includes("overlay") ||
-        assets[assetName]?.roles?.includes("baselayer")
-      ) {
-        // to prevent them being removed by date change on main dataset
-        assetLayerId = assetName;
-      }
-      log.debug("Creating WebGLTile layer from GeoTIFF", assetLayerId);
-      log.debug("Configured Sources", geoTIFFSources);
-      const sources =
-        stacObject?.["eodash:merge_assets"] !== false
-          ? geoTIFFSources
-          : [geotiffSource];
-      const layer = {
-        type: "WebGLTile",
-        source: {
-          type: "GeoTIFF",
-          normalize: !style,
-          interpolate: false,
-          sources,
-        },
-        properties: {
-          id: assetLayerId,
-          title: assets[assetName]?.title || title,
-          layerConfig,
-          layerDatetime,
-        },
-        style,
-      };
-      if (extraProperties) {
-        layer.properties = { ...layer.properties, ...extraProperties };
-      }
-      extractRoles(layer.properties, assets[assetName]);
-      addTooltipInteraction(layer, style);
-      jsonArray.push(layer);
-      if (stacObject?.["eodash:merge_assets"] !== false) break;
-    }
-  }
-
-  if (zarrAssetIds.length) {
-    for (const [i, assetName] of zarrAssetIds.entries()) {
-      const availableBands =
-        /** @type {{name:String, [key: string]: any}[]} */ (
-          assets[assetName]["bands"] ?? []
-        ).map((band) => band.name);
-
-      const fetchedStyle = await fetchStyle(stacObject, undefined, assetName);
-      let { layerConfig, style } = extractLayerConfig(
-        collectionId,
-        fetchedStyle,
-      );
-      const defaultBands = layerConfig?.schema?.bands?.default ?? [
-        "b04",
-        "b03",
-        "b02",
-      ];
-      if (!layerConfig && !style) {
-        const generated = generateGeoZarrStyle(availableBands, defaultBands);
-        ({ layerConfig, style } = extractLayerConfig(collectionId, generated));
-      }
-
-      let assetLayerId = createAssetID(collectionId, stacObject.id, zarrIdx[i]);
-      if (
-        assets[assetName]?.roles?.includes("overlay") ||
-        assets[assetName]?.roles?.includes("baselayer")
-      ) {
-        assetLayerId = assetName;
-      }
-
-      log.debug("Creating WebGLTile layer from GeoZarr", assetLayerId);
-
-      const layer = {
-        type: "WebGLTile",
-        properties: {
-          id: assetLayerId,
-          title: assets[assetName]?.title || title,
-          layerConfig,
-          layerDatetime,
-        },
-        source: {
-          type: "GeoZarr",
-          url: assets[assetName].href,
-          bands: defaultBands,
-        },
-        ...(style ? { style } : {}),
-      };
-      if (extraProperties) {
-        layer.properties = { ...layer.properties, ...extraProperties };
-      }
-      extractRoles(layer.properties, assets[assetName]);
-      jsonArray.push(layer);
     }
   }
 

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -351,6 +351,7 @@ export const extractLayerTimeValues = (items, currentStep) => {
     play: false,
     displayFormat: "DD.MM.YYYY HH:mm",
     animateOnClickInterval: false,
+    showUTC: true,
   };
 
   return {

--- a/templates/expert.js
+++ b/templates/expert.js
@@ -180,7 +180,7 @@ export default {
           id: "Processes",
           type: "internal",
           title: "Processes",
-          layout: { x: "9/9/10", y: 5, w: "3/3/2", h: 5 },
+          layout: { x: "9/9/10", y: 6, w: "3/3/2", h: 5 },
           widget: {
             name: "EodashProcess",
           },

--- a/widgets/EodashItemCatalog/index.vue
+++ b/widgets/EodashItemCatalog/index.vue
@@ -195,6 +195,10 @@ const props = defineProps({
     type: String,
     default: null,
   },
+  searchLimit: {
+    type: Number,
+    default: 100,
+  }
 });
 
 const itemfilterEl = useTemplateRef("itemfilter");
@@ -271,7 +275,7 @@ const items = currentItems.value;
 
 if (catalogEndpoint.value) {
   await axios
-    .get(catalogEndpoint.value + "/search?limit=100")
+    .get(catalogEndpoint.value + `/search?limit=${props.searchLimit}`)
     .then((res) => (currentItems.value = res.data.features));
 }
 
@@ -288,6 +292,7 @@ const externalFilterHandler = createExternalFilter(
   props.datetimeFilter,
   currentItems,
   sortByParam,
+  props.searchLimit,
   activeSelectedItem,
   catalogEndpoint,
 );

--- a/widgets/EodashItemCatalog/index.vue
+++ b/widgets/EodashItemCatalog/index.vue
@@ -191,6 +191,10 @@ const props = defineProps({
     type: Array,
     required: false,
   },
+  stacEndpoint: {
+    type: String,
+    default: null,
+  },
 });
 
 const itemfilterEl = useTemplateRef("itemfilter");
@@ -229,6 +233,8 @@ function selectSort(option) {
 const store = useSTAcStore();
 const { selectedItem, selectedCompareItem } = storeToRefs(store);
 
+const catalogEndpoint = computed(() => props.stacEndpoint || store.stacEndpoint);
+
 const isMosaicEnabled = computed(
   () => props.useMosaic && !!store.mosaicEndpoint,
 );
@@ -262,9 +268,10 @@ const currentItems = ref([]);
 const items = currentItems.value;
 
 // Initial data fetch
-if (store.stacEndpoint) {
+
+if (catalogEndpoint.value) {
   await axios
-    .get(store.stacEndpoint + "/search?limit=100")
+    .get(catalogEndpoint.value + "/search?limit=100")
     .then((res) => (currentItems.value = res.data.features));
 }
 
@@ -282,6 +289,7 @@ const externalFilterHandler = createExternalFilter(
   currentItems,
   sortByParam,
   activeSelectedItem,
+  catalogEndpoint,
 );
 
 watch(activeSelectedItem, (item) => {

--- a/widgets/EodashItemCatalog/index.vue
+++ b/widgets/EodashItemCatalog/index.vue
@@ -1,7 +1,9 @@
 <template>
   <div class="d-flex flex-column">
-    <v-row class="title align-center justify-space-between flex-shrink-0"
-    v-if="showTitleBlock">
+    <v-row
+      class="title align-center justify-space-between flex-shrink-0"
+      v-if="showTitleBlock"
+    >
       <h4>Catalog Items</h4>
       <div class="d-flex align-center">
         <v-menu v-if="sortBy?.length" v-model="sortMenu" offset-y>

--- a/widgets/EodashItemCatalog/index.vue
+++ b/widgets/EodashItemCatalog/index.vue
@@ -1,6 +1,7 @@
 <template>
   <div class="d-flex flex-column">
-    <v-row class="title align-center justify-space-between flex-shrink-0">
+    <v-row class="title align-center justify-space-between flex-shrink-0"
+    v-if="showTitleBlock">
       <h4>Catalog Items</h4>
       <div class="d-flex align-center">
         <v-menu v-if="sortBy?.length" v-model="sortMenu" offset-y>
@@ -157,6 +158,10 @@ const props = defineProps({
   imageProperty: {
     type: String,
     default: "assets.thumbnail.href",
+  },
+  showTitleBlock: {
+    type: Boolean,
+    default: true,
   },
   filters: {
     /** @type {import("vue").PropType<import("./types").FiltersConfig>} */

--- a/widgets/EodashItemCatalog/index.vue
+++ b/widgets/EodashItemCatalog/index.vue
@@ -198,7 +198,15 @@ const props = defineProps({
   searchLimit: {
     type: Number,
     default: 100,
-  }
+  },
+  stacItemsStyle: {
+    type: Object,
+    required: false,
+  },
+  stacItemsInteractionStyle: {
+    type: Object,
+    required: false,
+  },
 });
 
 const itemfilterEl = useTemplateRef("itemfilter");
@@ -237,7 +245,9 @@ function selectSort(option) {
 const store = useSTAcStore();
 const { selectedItem, selectedCompareItem } = storeToRefs(store);
 
-const catalogEndpoint = computed(() => props.stacEndpoint || store.stacEndpoint);
+const catalogEndpoint = computed(
+  () => props.stacEndpoint || store.stacEndpoint,
+);
 
 const isMosaicEnabled = computed(
   () => props.useMosaic && !!store.mosaicEndpoint,
@@ -314,6 +324,8 @@ watch(activeSelectedItem, (item) => {
       currentItems.value,
       props.enableCompare ? mapCompareEl : mapEl,
       props.hoverProperties,
+      props.stacItemsStyle,
+      props.stacItemsInteractionStyle,
     );
     nextTick(() => {
       const z = mapPosition.value[2] ?? 0;
@@ -334,6 +346,8 @@ watch(
       currentItems.value,
       props.enableCompare ? mapCompareEl : mapEl,
       props.hoverProperties,
+      props.stacItemsStyle,
+      props.stacItemsInteractionStyle,
     );
   },
 );
@@ -343,6 +357,8 @@ const onFilter = createOnFilterHandler({
   currentItems,
   mapElement: props.enableCompare ? mapCompareEl : mapEl,
   hoverProperties: props.hoverProperties,
+  stacItemsStyle: props.stacItemsStyle,
+  stacItemsInteractionStyle: props.stacItemsInteractionStyle,
   itemfilterEl,
   selectedItemRef: activeSelectedItem,
   mosaicOptions: isMosaicEnabled.value
@@ -366,6 +382,8 @@ useRenderItemsFeatures(
   currentItems,
   props.enableCompare ? mapCompareEl : mapEl,
   props.hoverProperties,
+  props.stacItemsStyle,
+  props.stacItemsInteractionStyle,
 );
 // Search on map move logic
 useSearchOnMapMove(

--- a/widgets/EodashItemCatalog/methods/filters.js
+++ b/widgets/EodashItemCatalog/methods/filters.js
@@ -61,7 +61,7 @@ export const createFilterProperties = (filtersConfig, datetimeFilter) => {
       type: "multiselect",
       placeholder: "Select collections",
       inline: false,
-      filterKeys: store.stac?.map((col) => col.id) || [],
+      filterKeys: store.stac?.filter((col) => col.id).map((col) => col.id) || [],
       ...(indicator.value && { state: { [indicator.value]: true } }),
     },
     ...((datetimeFilter && [
@@ -126,10 +126,18 @@ export const createFilterProperties = (filtersConfig, datetimeFilter) => {
  * @param {boolean} bboxFilter
  * @param {boolean} datetimeFilter
  * @param {string} [sortBy]
+ * @param {string} [stacEndpoint]
  * @returns {string}
  */
-export const buildSearchUrl = (filters, bboxFilter, datetimeFilter, sortBy) => {
+export const buildSearchUrl = (
+  filters,
+  bboxFilter,
+  datetimeFilter,
+  sortBy,
+  stacEndpoint,
+) => {
   const store = useSTAcStore();
+  const endpoint = stacEndpoint || store.stacEndpoint;
   const params = new URLSearchParams();
 
   if (filters.collection?.stringifiedState) {
@@ -165,7 +173,7 @@ export const buildSearchUrl = (filters, bboxFilter, datetimeFilter, sortBy) => {
 
   params.append("limit", "100");
 
-  return `${store.stacEndpoint}/search?${params.toString()}`;
+  return `${endpoint}/search?${params.toString()}`;
 };
 
 /**
@@ -176,6 +184,7 @@ export const buildSearchUrl = (filters, bboxFilter, datetimeFilter, sortBy) => {
  * @param {import("vue").Ref<import("@/types").GeoJsonFeature[]>} currentItems
  * @param {import("vue").Ref<string>} sortBy
  * @param {import("vue").Ref<import("stac-ts").StacItem | null>} [selectedItemRef]
+ * @param {import("vue").Ref<string> | string} [stacEndpoint]
  */
 export const createExternalFilter = (
   propsFilters,
@@ -184,6 +193,7 @@ export const createExternalFilter = (
   currentItems,
   sortBy,
   selectedItemRef,
+  stacEndpoint,
 ) => {
   let controller = new AbortController();
   /**
@@ -191,7 +201,13 @@ export const createExternalFilter = (
    * @param {Record<string,any>} filters
    */
   return (_items, filters) => ({
-    url: buildSearchUrl(filters, bboxFilter, datetimeFilter, sortBy.value),
+    url: buildSearchUrl(
+      filters,
+      bboxFilter,
+      datetimeFilter,
+      sortBy.value,
+      typeof stacEndpoint === "object" ? stacEndpoint?.value : stacEndpoint,
+    ),
     /** @param {string} url */
     fetchFn: async (url) => {
       controller.abort();

--- a/widgets/EodashItemCatalog/methods/filters.js
+++ b/widgets/EodashItemCatalog/methods/filters.js
@@ -125,6 +125,7 @@ export const createFilterProperties = (filtersConfig, datetimeFilter) => {
  * @param {import("@/types").ItemFilterFilters} filters
  * @param {boolean} bboxFilter
  * @param {boolean} datetimeFilter
+ * @param {Number} searchLimit
  * @param {string} [sortBy]
  * @param {string} [stacEndpoint]
  * @returns {string}
@@ -133,6 +134,7 @@ export const buildSearchUrl = (
   filters,
   bboxFilter,
   datetimeFilter,
+  searchLimit,
   sortBy,
   stacEndpoint,
 ) => {
@@ -171,7 +173,7 @@ export const buildSearchUrl = (
     params.append("sortby", sortBy);
   }
 
-  params.append("limit", "100");
+  params.append("limit", searchLimit.toString());
 
   return `${endpoint}/search?${params.toString()}`;
 };
@@ -183,6 +185,7 @@ export const buildSearchUrl = (
  * @param {boolean} datetimeFilter
  * @param {import("vue").Ref<import("@/types").GeoJsonFeature[]>} currentItems
  * @param {import("vue").Ref<string>} sortBy
+ * @param {Number} searchLimit
  * @param {import("vue").Ref<import("stac-ts").StacItem | null>} [selectedItemRef]
  * @param {import("vue").Ref<string> | string} [stacEndpoint]
  */
@@ -192,6 +195,7 @@ export const createExternalFilter = (
   datetimeFilter,
   currentItems,
   sortBy,
+  searchLimit,
   selectedItemRef,
   stacEndpoint,
 ) => {
@@ -205,6 +209,7 @@ export const createExternalFilter = (
       filters,
       bboxFilter,
       datetimeFilter,
+      searchLimit,
       sortBy.value,
       typeof stacEndpoint === "object" ? stacEndpoint?.value : stacEndpoint,
     ),

--- a/widgets/EodashItemCatalog/methods/filters.js
+++ b/widgets/EodashItemCatalog/methods/filters.js
@@ -128,7 +128,7 @@ export const createFilterProperties = (filtersConfig, datetimeFilter) => {
  * @param {boolean} datetimeFilter
  * @param {Number} searchLimit
  * @param {string} [sortBy]
- * @param {string} [stacEndpoint]
+ * @param {string | null} [stacEndpoint]
  * @returns {string}
  */
 export const buildSearchUrl = (
@@ -188,7 +188,7 @@ export const buildSearchUrl = (
  * @param {import("vue").Ref<string>} sortBy
  * @param {Number} searchLimit
  * @param {import("vue").Ref<import("stac-ts").StacItem | null>} [selectedItemRef]
- * @param {import("vue").Ref<string> | string} [stacEndpoint]
+ * @param {import("vue").Ref<string | null> | string | null} [stacEndpoint]
  */
 export const createExternalFilter = (
   propsFilters,

--- a/widgets/EodashItemCatalog/methods/filters.js
+++ b/widgets/EodashItemCatalog/methods/filters.js
@@ -61,7 +61,8 @@ export const createFilterProperties = (filtersConfig, datetimeFilter) => {
       type: "multiselect",
       placeholder: "Select collections",
       inline: false,
-      filterKeys: store.stac?.filter((col) => col.id).map((col) => col.id) || [],
+      filterKeys:
+        store.stac?.filter((col) => col.id).map((col) => col.id) || [],
       ...(indicator.value && { state: { [indicator.value]: true } }),
     },
     ...((datetimeFilter && [

--- a/widgets/EodashItemCatalog/methods/handlers.js
+++ b/widgets/EodashItemCatalog/methods/handlers.js
@@ -20,6 +20,8 @@ const getFiltersSignature = (filters) => {
  *  currentItems: import("vue").Ref<import("@/types").GeoJsonFeature[]>,
  *  mapElement: import("vue").Ref<import("@eox/map").EOxMap | null>,
  *  hoverProperties: string[] | undefined,
+ *  stacItemsStyle?: object,
+ *  stacItemsInteractionStyle?: object,
  *  itemfilterEl?: import("vue").Ref<any>,
  *  selectedItemRef?: import("vue").Ref<import("stac-ts").StacItem | null>,
  *  mosaicOptions?: {
@@ -32,6 +34,8 @@ export const createOnFilterHandler = ({
   currentItems,
   mapElement,
   hoverProperties,
+  stacItemsStyle,
+  stacItemsInteractionStyle,
   itemfilterEl,
   selectedItemRef,
   mosaicOptions = null,
@@ -41,7 +45,13 @@ export const createOnFilterHandler = ({
   /** @param {CustomEvent} evt */
   return (evt) => {
     currentItems.value = evt.detail.results;
-    renderItemsFeatures(currentItems.value, mapElement, hoverProperties);
+    renderItemsFeatures(
+      currentItems.value,
+      mapElement,
+      hoverProperties,
+      stacItemsStyle,
+      stacItemsInteractionStyle,
+    );
 
     const selected = selectedItemRef?.value;
     if (selected && itemfilterEl?.value) {

--- a/widgets/EodashItemCatalog/methods/map.js
+++ b/widgets/EodashItemCatalog/methods/map.js
@@ -8,8 +8,16 @@ import { tooltipAdapter } from "@/store/states";
  * @param {import("@/types").GeoJsonFeature[]} features
  * @param {import("vue").Ref<import("@eox/map").EOxMap | null>} mapElement
  * @param {string[] | undefined} hoverProperties
+ * @param {object} [stacItemsStyle]
+ * @param {object} [stacItemsInteractionStyle]
  */
-export function renderItemsFeatures(features, mapElement, hoverProperties) {
+export function renderItemsFeatures(
+  features,
+  mapElement,
+  hoverProperties,
+  stacItemsStyle,
+  stacItemsInteractionStyle,
+) {
   const currentMap = mapElement.value;
   let analysisLayers =
     /** @type {import("@eox/map/src/layers").EOxLayerTypeGroup} */ (
@@ -45,9 +53,9 @@ export function renderItemsFeatures(features, mapElement, hoverProperties) {
           JSON.stringify({ type: "FeatureCollection", features }),
         ),
       format: "GeoJSON",
-      projection: "EPSG:3857",
+      projection: "EPSG:4326",
     },
-    style: {
+    style: stacItemsStyle || {
       "fill-color": "transparent",
       "stroke-color": "#003170",
     },
@@ -58,7 +66,7 @@ export function renderItemsFeatures(features, mapElement, hoverProperties) {
           id: "stac-item-hover",
           condition: "pointermove",
           tooltip: hoverProperties?.length,
-          style: {
+          style: stacItemsInteractionStyle || {
             "stroke-color": "white",
             "stroke-width": 3,
           },
@@ -70,7 +78,7 @@ export function renderItemsFeatures(features, mapElement, hoverProperties) {
           id: "stac-items",
           condition: "click",
           tooltip: false,
-          style: {
+          style: stacItemsInteractionStyle || {
             "stroke-color": "white",
             "stroke-width": 3,
           },
@@ -122,19 +130,35 @@ export const useSearchOnMapMove = (itemFilter, bboxFilter, mapElement) => {
  * @param {import("vue").Ref<import("@/types").GeoJsonFeature[]>} currentItems
  * @param {import("vue").Ref<import("@eox/map").EOxMap | null>} mapElement
  * @param {string[] | undefined} hoverProperties
+ * @param {object} [stacItemsStyle]
+ * @param {object} [stacItemsInteractionStyle]
  */
 export const useRenderItemsFeatures = (
   currentItems,
   mapElement,
   hoverProperties,
+  stacItemsStyle,
+  stacItemsInteractionStyle,
 ) => {
   onMounted(() => {
-    renderItemsFeatures(currentItems.value, mapElement, hoverProperties);
+    renderItemsFeatures(
+      currentItems.value,
+      mapElement,
+      hoverProperties,
+      stacItemsStyle,
+      stacItemsInteractionStyle,
+    );
   });
 
   useOnLayersUpdate(() => {
     // consider cases where this is not needed
-    renderItemsFeatures(currentItems.value, mapElement, hoverProperties);
+    renderItemsFeatures(
+      currentItems.value,
+      mapElement,
+      hoverProperties,
+      stacItemsStyle,
+      stacItemsInteractionStyle,
+    );
   });
 };
 /**


### PR DESCRIPTION
- switch order of assets so that raster assets are below vector assets
- minor updates of EodashItemCatalog - filter out blank ids of collections (happens in catalog-powered instances)
- add props for EodashItemCatalog:
  - searchLimit
  - searchEndpoint (makes it therefore usable for catalog powered instances) via conditional inclusion of the widget
  - configurable style of footprint geometries and their interactions styled version
  - allows to hide the top sort/title block in the widget via `showTitleBlock` boolean