### PR TITLE
fix: increase break by 1 pixel to not trigger on normal screen size

### DIFF
--- a/core/client/components/DashboardLayout.vue
+++ b/core/client/components/DashboardLayout.vue
@@ -1,7 +1,7 @@
 <template>
   <v-main class="pa-0">
     <eox-layout
-      :mediaBreakpoints="[0, 960, 1920]"
+      :mediaBreakpoints="[0, 960, 1921]"
       :gap="gap"
       :style="layoutStyle"
     >


### PR DESCRIPTION
I had the issue that on my left screen (which has the OS bar on the left) i was getting one panel size, and on the right without i was getting another panel size. I think the breakpoint should not be exactly 1920, so i increasing it to 1921 to solve the issue