### PR TITLE
feat: Process panel chart height calculation

### DIFF
--- a/templates/expert.js
+++ b/templates/expert.js
@@ -73,7 +73,7 @@ export default {
       id: "Layercontrol",
       type: "internal",
       title: "Layers",
-      layout: { x: 0, y: 1, w: "3/3/2", h: 11 },
+      layout: { x: 0, y: 1, w: "3/3/2", h: 10 },
       widget: {
         name: "EodashLayerControl",
         properties: {

--- a/templates/expert.js
+++ b/templates/expert.js
@@ -124,7 +124,7 @@ export default {
           id: "Processes",
           type: "internal",
           title: "Processes",
-          layout: { x: "9/9/10", y: 6, w: "3/3/2", h: 5 },
+          layout: { x: "9/9/10", y: 6, w: "3/3/2", h: 6 },
           widget: {
             name: "EodashProcess",
           },

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -1,6 +1,9 @@
 <template>
-  <div ref="container">
-    <div class="chart-frame">
+  <div ref="container" class="eodash-chart-wrapper">
+    <div
+      class="chart-frame"
+      :style="{ paddingBottom: hasBindings ? '25px' : '0px' }"
+    >
       <button
         v-if="usedChartData && usedChartSpec"
         class="chart-toggle"
@@ -12,9 +15,8 @@
         </svg>
       </button>
       <eox-chart
-        class="pa-2"
-        v-if="usedChartData && usedChartSpec"
-        .spec="toRaw(usedChartSpec)"
+        v-if="usedChartData && renderedChartSpec"
+        .spec="toRaw(renderedChartSpec)"
         :key="chartRenderKey"
         .dataValues="toRaw(usedChartData)"
         @click:item="onChartClick"
@@ -69,134 +71,136 @@ const usedChartSpec = computed(() => {
   return enableCompare ? compareChartSpec.value : chartSpec.value;
 });
 
+const hasBindings = computed(() => {
+  const spec = usedChartSpec.value;
+  if (!spec) return false;
+
+  // Recursively search for any object with a 'bind' key that represents a physical UI input
+  let found = false;
+  /** @param {any} obj */
+  const searchBindings = (obj) => {
+    if (found || !obj || typeof obj !== "object") return;
+
+    // UI bindings that take up physical DOM space are objects with an 'input' property.
+    if (
+      "bind" in obj &&
+      typeof obj.bind === "object" &&
+      obj.bind !== null &&
+      "input" in obj.bind
+    ) {
+      found = true;
+      return;
+    }
+    Object.values(obj).forEach(searchBindings);
+  };
+  searchBindings(spec);
+  return found;
+});
+
+const renderedChartSpec = ref(null);
+
+watch(
+  usedChartSpec,
+  (newSpec) => {
+    if (!newSpec) {
+      renderedChartSpec.value = null;
+      return;
+    }
+
+    // Create a deep copy so we can safely mutate it
+    const adjustedSpec = JSON.parse(JSON.stringify(newSpec));
+
+    // Force the chart to be fully responsive to its CSS container
+    adjustedSpec.height = "container";
+    adjustedSpec.width = "container";
+
+    // Delay passing the spec to eox-chart until the next DOM update cycle.
+    // This ensures the dynamic chartStyles are physically applied
+    // to the container BEFORE Vega calculates its canvas size.
+    nextTick(() => {
+      renderedChartSpec.value = adjustedSpec;
+      chartRenderKey.value = Math.random(); // Force eox-chart to completely remount
+
+      // Force a browser-level resize event after the chart mounts.
+      // This tells Vega to re-read the container dimensions once the CSS has finished painting.
+      setTimeout(() => {
+        window.dispatchEvent(new Event("resize"));
+      }, 150);
+    });
+  },
+  { immediate: true },
+);
+
 const chartRenderKey = ref(0);
-const frameHeight = ref(225);
 const containerEl = useTemplateRef("container");
 
-/**
-@type { MutationObserver | null}
-*/
-let observer = null;
-/** @type {ResizeObserver | null} */
-let resizeObserver = null;
 /** @type {MutationObserver | null} */
-let childMutationObserver = null;
+let observer = null;
+/** @type {number | null} */
+let styleInterval = null;
 
 onMounted(() => {
   const el = containerEl.value;
   if (!el) return;
 
-  const directParent = el.parentElement;
-  const grandParent = directParent?.parentElement;
-
-  const calculateHeight = () => {
-    if (!grandParent) return;
-    let availableHeight = grandParent.getBoundingClientRect().height;
-
-    if (
-      directParent &&
-      directParent.classList.contains("eodash-process-container")
-    ) {
-      const styles = window.getComputedStyle(directParent);
-      availableHeight -=
-        (parseFloat(styles.paddingTop) || 0) +
-        (parseFloat(styles.paddingBottom) || 0);
-
-      Array.from(directParent.children).forEach((child) => {
-        if (child !== el) {
-          const childHeight = child.getBoundingClientRect().height;
-          const childStyles = window.getComputedStyle(child);
-          const margins =
-            (parseFloat(childStyles.marginTop) || 0) +
-            (parseFloat(childStyles.marginBottom) || 0);
-          availableHeight -= childHeight + margins;
-        }
-      });
-
-      // Subtract height of vega-bindings if they exist inside the web component
+  // Continuously inject basic styling for the bindings form to make it look decent
+  styleInterval = window.setInterval(() => {
+    if (el) {
       const eoxChart = el.querySelector("eox-chart");
       if (eoxChart && eoxChart.shadowRoot) {
-        const bindingsForm =
-          eoxChart.shadowRoot.querySelector(".vega-bindings");
-        if (bindingsForm) {
-          const formHeight = bindingsForm.getBoundingClientRect().height;
-          availableHeight -= formHeight + 12; // Add 12px extra padding for the form
+        if (!eoxChart.shadowRoot.querySelector("#eodash-chart-styles")) {
+          const style = document.createElement("style");
+          style.id = "eodash-chart-styles";
+          style.innerHTML = `
+            * {
+              box-sizing: border-box !important;
+            }
+            #vis {
+              min-height: 100px !important;
+              flex: 1 1 auto !important;
+            }
+            :host, .vega-embed {
+              display: flex !important;
+              flex-direction: column !important;
+              height: 100% !important;
+              padding: 0 !important;
+              margin: 0 !important;
+            }
+            .vega-bindings {
+              flex: 0 0 auto !important;
+              display: flex !important;
+              flex-wrap: wrap;
+              gap: 2px !important;
+              background: rgba(255, 255, 255, 0.85);
+              padding: 6px 12px !important;
+              border-radius: 6px;
+              box-shadow: 0 2px 5px rgba(0,0,0,0.15);
+              margin: 0 !important;
+              margin-top: -10px !important;
+              z-index: 10;
+            }
+            .vega-bindings:empty {
+              display: none !important;
+            }
+            .vega-embed > canvas, .vega-embed > svg {
+              height: 100% !important;
+              max-width: 100% !important;
+              object-fit: contain;
+            }
+            .vega-bind {
+              display: flex;
+              align-items: center;
+              gap: 6px;
+              margin-bottom: 0 !important;
+            }
+          `;
+          eoxChart.shadowRoot.appendChild(style);
         }
       }
-
-      // small buffer to prevent border scrollbars
-      availableHeight -= 12;
-    } else {
-      // If maximized or in another panel
-      if (directParent) {
-        const styles = window.getComputedStyle(directParent);
-        availableHeight -=
-          (parseFloat(styles.paddingTop) || 0) +
-          (parseFloat(styles.paddingBottom) || 0);
-      }
-      availableHeight -= 12;
     }
+  }, 200);
 
-    if (availableHeight > 0) {
-      frameHeight.value = Math.max(150, Math.floor(availableHeight));
-    }
-  };
-
-  const setupShadowObserver = () => {
-    const eoxChart = el.querySelector("eox-chart");
-    if (eoxChart && eoxChart.shadowRoot && !eoxChart.hasAttribute("data-observed")) {
-      const shadowObserver = new MutationObserver(() => calculateHeight());
-      shadowObserver.observe(eoxChart.shadowRoot, {
-        childList: true,
-        subtree: true,
-      });
-      eoxChart.setAttribute("data-observed", "true");
-    }
-  };
-
-  // Initial calculation after layout
-  nextTick(() => {
-    calculateHeight();
-    setupShadowObserver();
-  });
-
-  // Watch for data changes which might trigger form re-rendering
-  watch(
-    [usedChartData, usedChartSpec],
-    () => {
-      nextTick(() => {
-        calculateHeight();
-        setupShadowObserver();
-      });
-    },
-    { deep: true },
-  );
-
-  if (grandParent) {
-    resizeObserver = new ResizeObserver(() => {
-      calculateHeight();
-    });
-    resizeObserver.observe(grandParent);
-
-    if (directParent) {
-      resizeObserver.observe(directParent);
-      Array.from(directParent.children).forEach((child) => {
-        if (child !== el) resizeObserver?.observe(child);
-      });
-
-      childMutationObserver = new MutationObserver(() => {
-        calculateHeight();
-        Array.from(directParent.children).forEach((child) => {
-          if (child !== el) resizeObserver?.observe(child);
-        });
-        setupShadowObserver();
-      });
-      childMutationObserver.observe(directParent, { childList: true });
-    }
-  }
-
-  // for mobile view, the overlay panel containing chart is initially hidden
-  // we create an observer when display of overlay is not none anymore
+  // For mobile view, handle overlay display changes
   const overlay = getOverlayParent(el);
   if (!overlay) return;
 
@@ -204,7 +208,6 @@ onMounted(() => {
     const style = getComputedStyle(overlay);
     const visible = style.display !== "none";
     if (visible) {
-      // forcibly rerender chart, otherwise size of canvas is 0
       chartRenderKey.value = Math.random();
     }
   });
@@ -217,15 +220,14 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   observer?.disconnect();
-  resizeObserver?.disconnect();
-  childMutationObserver?.disconnect();
+  if (styleInterval) window.clearInterval(styleInterval);
 });
 
 const chartStyles = computed(() => {
-  const styles = {
-    height: `${frameHeight.value}px`,
+  return {
+    height: "100%",
+    width: "100%",
   };
-  return styles;
 });
 
 const toggleIcon = computed(() =>
@@ -236,14 +238,41 @@ function toggleLayout() {
   areChartsSeparateLayout.value = !areChartsSeparateLayout.value;
 }
 </script>
+
+<style>
+/* Force the outer dashboard panel wrapping this component to utilize 100% height in fullscreen mode */
+.bg-surface:has(.eodash-chart-wrapper) {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+</style>
+
 <style scoped>
+.eodash-chart-wrapper {
+  height: 100%; /* Force full height in fullscreen layout */
+  flex-grow: 1;
+  min-height: 180px; /* Prevent chart from becoming unusably small */
+  display: flex;
+  flex-direction: column;
+}
+
 .chart-frame {
   position: relative;
+  flex-grow: 1;
+  min-height: 180px; /* Prevent chart from becoming unusably small */
+  display: flex;
+  flex-direction: column;
+}
+
+eox-chart {
+  flex-grow: 1;
+  min-height: 0;
 }
 
 .chart-toggle {
   position: absolute;
-  top: 18px;
+  top: 8px;
   right: 46px;
   z-index: 2;
   cursor: pointer;

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -75,15 +75,91 @@ const containerEl = useTemplateRef("container");
 @type { MutationObserver | null}
 */
 let observer = null;
+/** @type {ResizeObserver | null} */
+let resizeObserver = null;
+/** @type {MutationObserver | null} */
+let childMutationObserver = null;
 
 onMounted(() => {
   const el = containerEl.value;
   if (!el) return;
 
-  const parent = el.parentElement?.parentElement;
-  if (parent) {
-    const parentHeight = parent.getBoundingClientRect().height;
-    frameHeight.value = Math.max(225, Math.floor(parentHeight));
+  const directParent = el.parentElement;
+  const grandParent = directParent?.parentElement;
+
+  const calculateHeight = () => {
+    if (!grandParent) return;
+    let availableHeight = grandParent.getBoundingClientRect().height;
+    
+    if (directParent && directParent.classList.contains('eodash-process-container')) {
+       const styles = window.getComputedStyle(directParent);
+       availableHeight -= (parseFloat(styles.paddingTop) || 0) + (parseFloat(styles.paddingBottom) || 0);
+       
+       Array.from(directParent.children).forEach(child => {
+         if (child !== el) {
+           const childHeight = child.getBoundingClientRect().height;
+           const childStyles = window.getComputedStyle(child);
+           const margins = (parseFloat(childStyles.marginTop) || 0) + (parseFloat(childStyles.marginBottom) || 0);
+           availableHeight -= (childHeight + margins);
+         }
+       });
+       
+       // Subtract height of vega-bindings if they exist inside the web component
+       const eoxChart = el.querySelector('eox-chart');
+       if (eoxChart && eoxChart.shadowRoot) {
+         const bindingsForm = eoxChart.shadowRoot.querySelector('.vega-bindings');
+         if (bindingsForm) {
+            const formHeight = bindingsForm.getBoundingClientRect().height;
+            availableHeight -= (formHeight + 12); // Add 12px extra padding for the form
+         }
+       }
+
+       // small buffer to prevent border scrollbars
+       availableHeight -= 12;
+    } else {
+       // If maximized or in another panel
+       if (directParent) {
+           const styles = window.getComputedStyle(directParent);
+           availableHeight -= (parseFloat(styles.paddingTop) || 0) + (parseFloat(styles.paddingBottom) || 0);
+       }
+       availableHeight -= 12; 
+    }
+    
+    if (availableHeight > 0) {
+      frameHeight.value = Math.max(150, Math.floor(availableHeight));
+    }
+  };
+
+  calculateHeight();
+
+  if (grandParent) {
+     resizeObserver = new ResizeObserver(() => {
+       calculateHeight();
+     });
+     resizeObserver.observe(grandParent);
+     
+     if (directParent) {
+       resizeObserver.observe(directParent);
+       Array.from(directParent.children).forEach(child => {
+         if (child !== el) resizeObserver.observe(child);
+       });
+       
+       childMutationObserver = new MutationObserver(() => {
+         calculateHeight();
+         Array.from(directParent.children).forEach(child => {
+           if (child !== el) resizeObserver.observe(child);
+         });
+         
+         // Also check for vega-bindings in shadow dom if not already observing
+         const eoxChart = el.querySelector('eox-chart');
+         if (eoxChart && eoxChart.shadowRoot && !eoxChart.dataset.observed) {
+            const shadowObserver = new MutationObserver(() => calculateHeight());
+            shadowObserver.observe(eoxChart.shadowRoot, { childList: true, subtree: true });
+            eoxChart.dataset.observed = 'true';
+         }
+       });
+       childMutationObserver.observe(directParent, { childList: true });
+     }
   }
 
   // for mobile view, the overlay panel containing chart is initially hidden
@@ -108,6 +184,8 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   observer?.disconnect();
+  resizeObserver?.disconnect();
+  childMutationObserver?.disconnect();
 });
 
 const chartStyles = computed(() => {

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -33,6 +33,8 @@ import {
   ref,
   onMounted,
   onBeforeUnmount,
+  watch,
+  nextTick
 } from "vue";
 import { onChartClick } from "./EodashProcess/methods/handling";
 import {
@@ -130,7 +132,28 @@ onMounted(() => {
     }
   };
 
-  calculateHeight();
+  const setupShadowObserver = () => {
+    const eoxChart = el.querySelector('eox-chart');
+    if (eoxChart && eoxChart.shadowRoot && !eoxChart.dataset.observed) {
+       const shadowObserver = new MutationObserver(() => calculateHeight());
+       shadowObserver.observe(eoxChart.shadowRoot, { childList: true, subtree: true });
+       eoxChart.dataset.observed = 'true';
+    }
+  };
+
+  // Initial calculation after layout
+  nextTick(() => {
+    calculateHeight();
+    setupShadowObserver();
+  });
+
+  // Watch for data changes which might trigger form re-rendering
+  watch([usedChartData, usedChartSpec], () => {
+    nextTick(() => {
+      calculateHeight();
+      setupShadowObserver();
+    });
+  }, { deep: true });
 
   if (grandParent) {
      resizeObserver = new ResizeObserver(() => {
@@ -149,14 +172,7 @@ onMounted(() => {
          Array.from(directParent.children).forEach(child => {
            if (child !== el) resizeObserver.observe(child);
          });
-         
-         // Also check for vega-bindings in shadow dom if not already observing
-         const eoxChart = el.querySelector('eox-chart');
-         if (eoxChart && eoxChart.shadowRoot && !eoxChart.dataset.observed) {
-            const shadowObserver = new MutationObserver(() => calculateHeight());
-            shadowObserver.observe(eoxChart.shadowRoot, { childList: true, subtree: true });
-            eoxChart.dataset.observed = 'true';
-         }
+         setupShadowObserver();
        });
        childMutationObserver.observe(directParent, { childList: true });
      }

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -34,7 +34,7 @@ import {
   onMounted,
   onBeforeUnmount,
   watch,
-  nextTick
+  nextTick,
 } from "vue";
 import { onChartClick } from "./EodashProcess/methods/handling";
 import {
@@ -92,52 +92,65 @@ onMounted(() => {
   const calculateHeight = () => {
     if (!grandParent) return;
     let availableHeight = grandParent.getBoundingClientRect().height;
-    
-    if (directParent && directParent.classList.contains('eodash-process-container')) {
-       const styles = window.getComputedStyle(directParent);
-       availableHeight -= (parseFloat(styles.paddingTop) || 0) + (parseFloat(styles.paddingBottom) || 0);
-       
-       Array.from(directParent.children).forEach(child => {
-         if (child !== el) {
-           const childHeight = child.getBoundingClientRect().height;
-           const childStyles = window.getComputedStyle(child);
-           const margins = (parseFloat(childStyles.marginTop) || 0) + (parseFloat(childStyles.marginBottom) || 0);
-           availableHeight -= (childHeight + margins);
-         }
-       });
-       
-       // Subtract height of vega-bindings if they exist inside the web component
-       const eoxChart = el.querySelector('eox-chart');
-       if (eoxChart && eoxChart.shadowRoot) {
-         const bindingsForm = eoxChart.shadowRoot.querySelector('.vega-bindings');
-         if (bindingsForm) {
-            const formHeight = bindingsForm.getBoundingClientRect().height;
-            availableHeight -= (formHeight + 12); // Add 12px extra padding for the form
-         }
-       }
 
-       // small buffer to prevent border scrollbars
-       availableHeight -= 12;
+    if (
+      directParent &&
+      directParent.classList.contains("eodash-process-container")
+    ) {
+      const styles = window.getComputedStyle(directParent);
+      availableHeight -=
+        (parseFloat(styles.paddingTop) || 0) +
+        (parseFloat(styles.paddingBottom) || 0);
+
+      Array.from(directParent.children).forEach((child) => {
+        if (child !== el) {
+          const childHeight = child.getBoundingClientRect().height;
+          const childStyles = window.getComputedStyle(child);
+          const margins =
+            (parseFloat(childStyles.marginTop) || 0) +
+            (parseFloat(childStyles.marginBottom) || 0);
+          availableHeight -= childHeight + margins;
+        }
+      });
+
+      // Subtract height of vega-bindings if they exist inside the web component
+      const eoxChart = el.querySelector("eox-chart");
+      if (eoxChart && eoxChart.shadowRoot) {
+        const bindingsForm =
+          eoxChart.shadowRoot.querySelector(".vega-bindings");
+        if (bindingsForm) {
+          const formHeight = bindingsForm.getBoundingClientRect().height;
+          availableHeight -= formHeight + 12; // Add 12px extra padding for the form
+        }
+      }
+
+      // small buffer to prevent border scrollbars
+      availableHeight -= 12;
     } else {
-       // If maximized or in another panel
-       if (directParent) {
-           const styles = window.getComputedStyle(directParent);
-           availableHeight -= (parseFloat(styles.paddingTop) || 0) + (parseFloat(styles.paddingBottom) || 0);
-       }
-       availableHeight -= 12; 
+      // If maximized or in another panel
+      if (directParent) {
+        const styles = window.getComputedStyle(directParent);
+        availableHeight -=
+          (parseFloat(styles.paddingTop) || 0) +
+          (parseFloat(styles.paddingBottom) || 0);
+      }
+      availableHeight -= 12;
     }
-    
+
     if (availableHeight > 0) {
       frameHeight.value = Math.max(150, Math.floor(availableHeight));
     }
   };
 
   const setupShadowObserver = () => {
-    const eoxChart = el.querySelector('eox-chart');
+    const eoxChart = el.querySelector("eox-chart");
     if (eoxChart && eoxChart.shadowRoot && !eoxChart.dataset.observed) {
-       const shadowObserver = new MutationObserver(() => calculateHeight());
-       shadowObserver.observe(eoxChart.shadowRoot, { childList: true, subtree: true });
-       eoxChart.dataset.observed = 'true';
+      const shadowObserver = new MutationObserver(() => calculateHeight());
+      shadowObserver.observe(eoxChart.shadowRoot, {
+        childList: true,
+        subtree: true,
+      });
+      eoxChart.dataset.observed = "true";
     }
   };
 
@@ -148,34 +161,38 @@ onMounted(() => {
   });
 
   // Watch for data changes which might trigger form re-rendering
-  watch([usedChartData, usedChartSpec], () => {
-    nextTick(() => {
-      calculateHeight();
-      setupShadowObserver();
-    });
-  }, { deep: true });
+  watch(
+    [usedChartData, usedChartSpec],
+    () => {
+      nextTick(() => {
+        calculateHeight();
+        setupShadowObserver();
+      });
+    },
+    { deep: true },
+  );
 
   if (grandParent) {
-     resizeObserver = new ResizeObserver(() => {
-       calculateHeight();
-     });
-     resizeObserver.observe(grandParent);
-     
-     if (directParent) {
-       resizeObserver.observe(directParent);
-       Array.from(directParent.children).forEach(child => {
-         if (child !== el) resizeObserver.observe(child);
-       });
-       
-       childMutationObserver = new MutationObserver(() => {
-         calculateHeight();
-         Array.from(directParent.children).forEach(child => {
-           if (child !== el) resizeObserver.observe(child);
-         });
-         setupShadowObserver();
-       });
-       childMutationObserver.observe(directParent, { childList: true });
-     }
+    resizeObserver = new ResizeObserver(() => {
+      calculateHeight();
+    });
+    resizeObserver.observe(grandParent);
+
+    if (directParent) {
+      resizeObserver.observe(directParent);
+      Array.from(directParent.children).forEach((child) => {
+        if (child !== el) resizeObserver.observe(child);
+      });
+
+      childMutationObserver = new MutationObserver(() => {
+        calculateHeight();
+        Array.from(directParent.children).forEach((child) => {
+          if (child !== el) resizeObserver.observe(child);
+        });
+        setupShadowObserver();
+      });
+      childMutationObserver.observe(directParent, { childList: true });
+    }
   }
 
   // for mobile view, the overlay panel containing chart is initially hidden

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -144,13 +144,13 @@ onMounted(() => {
 
   const setupShadowObserver = () => {
     const eoxChart = el.querySelector("eox-chart");
-    if (eoxChart && eoxChart.shadowRoot && !eoxChart.dataset.observed) {
+    if (eoxChart && eoxChart.shadowRoot && !eoxChart.hasAttribute("data-observed")) {
       const shadowObserver = new MutationObserver(() => calculateHeight());
       shadowObserver.observe(eoxChart.shadowRoot, {
         childList: true,
         subtree: true,
       });
-      eoxChart.dataset.observed = "true";
+      eoxChart.setAttribute("data-observed", "true");
     }
   };
 
@@ -181,13 +181,13 @@ onMounted(() => {
     if (directParent) {
       resizeObserver.observe(directParent);
       Array.from(directParent.children).forEach((child) => {
-        if (child !== el) resizeObserver.observe(child);
+        if (child !== el) resizeObserver?.observe(child);
       });
 
       childMutationObserver = new MutationObserver(() => {
         calculateHeight();
         Array.from(directParent.children).forEach((child) => {
-          if (child !== el) resizeObserver.observe(child);
+          if (child !== el) resizeObserver?.observe(child);
         });
         setupShadowObserver();
       });

--- a/widgets/EodashProcess/index.vue
+++ b/widgets/EodashProcess/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="container" class="py-1">
+  <div ref="container" class="py-1 eodash-process-container">
     <ProcessList :map-element="mapElement" :enable-compare="enableCompare" />
     <eox-jsonform
       v-if="jsonformSchema"
@@ -191,5 +191,15 @@ useAutoExec(autoExec, jsonformEl, jsonformSchema, startProcess);
 eox-jsonform {
   padding: 0.7em;
   min-height: 0px;
+}
+
+/* Force the specific panel wrapping this component to utilize 100% height */
+.bg-surface:has(.eodash-process-container) {
+  height: 100%;
+}
+
+/* Make sure this container also takes up that height */
+.eodash-process-container {
+  height: 100%;
 }
 </style>

--- a/widgets/EodashProcess/index.vue
+++ b/widgets/EodashProcess/index.vue
@@ -1,19 +1,24 @@
 <template>
-  <div ref="container" class="py-1 eodash-process-container">
-    <ProcessList :map-element="mapElement" :enable-compare="enableCompare" />
-    <eox-jsonform
-      v-if="jsonformSchema"
-      :key="jsonformKey"
-      ref="jsonformEl"
-      .schema="jsonformSchema"
-    ></eox-jsonform>
-    <EodashChart
-      v-if="!areChartsSeparateLayout"
-      :vega-embed-options="vegaEmbedOptions"
-      :enable-compare="enableCompare"
+  <div ref="container" class="eodash-process-container">
+    <div class="eodash-process-content">
+      <ProcessList :map-element="mapElement" :enable-compare="enableCompare" />
+      <eox-jsonform
+        v-if="jsonformSchema"
+        :key="jsonformKey"
+        ref="jsonformEl"
+        .schema="jsonformSchema"
+      ></eox-jsonform>
+      <EodashChart
+        v-if="!areChartsSeparateLayout"
+        :vega-embed-options="vegaEmbedOptions"
+        :enable-compare="enableCompare"
+      >
+      </EodashChart>
+    </div>
+    <div
+      class="eodash-process-actions"
+      v-if="showExecBtn || (processResults.length && isProcessed && !isAsync)"
     >
-    </EodashChart>
-    <div class="text-right">
       <v-btn
         v-if="showExecBtn"
         :loading="loading"
@@ -45,7 +50,7 @@ import "@eox/drawtools";
 import "@eox/jsonform";
 import { useSTAcStore } from "@/store/stac";
 import { storeToRefs } from "pinia";
-import { computed, ref, useTemplateRef } from "vue";
+import { computed, ref, useTemplateRef, watch } from "vue";
 import ProcessList from "./ProcessList.vue";
 import EodashChart from "../EodashChart.vue";
 import { handleProcesses } from "./methods/handling";
@@ -87,6 +92,79 @@ const jsonformEl =
   /** @type {Readonly<import("vue").ShallowRef<import("@eox/jsonform").EOxJSONForm | null>>} */ (
     useTemplateRef("jsonformEl")
   );
+
+// Inject custom styles into the eox-jsonform shadow DOM to make eox-drawtools inline
+watch(jsonformEl, (el) => {
+  if (el && el.shadowRoot) {
+    const styleId = "eodash-drawtools-inline-style";
+    if (!el.shadowRoot.getElementById(styleId)) {
+      const style = document.createElement("style");
+      style.id = styleId;
+      style.textContent = `
+        .form-control:has(eox-drawtools) {
+          position: relative;
+          padding: 8px 12px !important;
+          border: none !important;
+          background: transparent !important;
+        }
+        .form-control:has(eox-drawtools) > label {
+          position: absolute;
+          left: 12px;
+          top: 8px;
+          margin: 0 !important;
+          width: calc(100% - 180px); /* Give label maximum available width */
+          line-height: 1.2;
+          display: flex;
+          align-items: flex-start;
+          padding-top: 8px;
+          pointer-events: none; /* Let clicks pass through to buttons if they overlap slightly */
+        }
+        .form-control:has(eox-drawtools) > eox-drawtools {
+          display: block;
+          width: 100%;
+        }
+      `;
+      el.shadowRoot.appendChild(style);
+    }
+
+    const injectDrawtoolsStyle = () => {
+      const drawtools = el?.shadowRoot?.querySelector('eox-drawtools');
+      if (drawtools && drawtools.shadowRoot) {
+        if (
+          !drawtools.shadowRoot.getElementById("eodash-drawtools-indent-style")
+        ) {
+          const dtStyle = document.createElement("style");
+          dtStyle.id = "eodash-drawtools-indent-style";
+          dtStyle.textContent = `
+            eox-drawtools-controller {
+              display: flex;
+              justify-content: flex-end; /* Push buttons to the right */
+              min-height: 40px;
+              width: 100%;
+            }
+            eox-drawtools-list {
+              display: block;
+              margin-top: 10px;
+              width: 100%;
+            }
+          `;
+          drawtools.shadowRoot.appendChild(dtStyle);
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (!injectDrawtoolsStyle()) {
+      const observer = new MutationObserver(() => {
+        if (injectDrawtoolsStyle()) {
+          observer.disconnect();
+        }
+      });
+      observer.observe(el.shadowRoot, { childList: true, subtree: true });
+    }
+  }
+});
 
 const isAsync = computed(
   () =>
@@ -189,17 +267,37 @@ useAutoExec(autoExec, jsonformEl, jsonformSchema, startProcess);
 </script>
 <style>
 eox-jsonform {
-  padding: 0.7em;
+  padding: 0;
   min-height: 0px;
+  flex-shrink: 0;
 }
 
 /* Force the specific panel wrapping this component to utilize 100% height */
 .bg-surface:has(.eodash-process-container) {
-  height: 100%;
+  height: calc(100% - 30px);
+  overflow: hidden;
 }
 
-/* Make sure this container also takes up that height */
+/* Make sure this container takes up full height and acts as a flex column */
 .eodash-process-container {
   height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.eodash-process-content {
+  flex-grow: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.eodash-process-actions {
+  text-align: right;
+  padding: 4px 12px;
+  flex-shrink: 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  background: inherit;
 }
 </style>

--- a/widgets/EodashProcess/index.vue
+++ b/widgets/EodashProcess/index.vue
@@ -101,11 +101,22 @@ watch(jsonformEl, (el) => {
       const style = document.createElement("style");
       style.id = styleId;
       style.textContent = `
+        /* Compact standard form elements */
+        .form-control, .form-group {
+          margin-bottom: 8px !important;
+        }
+        .form-control > label, .form-group > label {
+          margin-bottom: 2px !important;
+          font-size: 0.9em;
+        }
+        
+        /* Specific layout for drawtools */
         .form-control:has(eox-drawtools) {
           position: relative;
           padding: 8px 12px !important;
           border: none !important;
           background: transparent !important;
+          margin-bottom: 8px !important;
         }
         .form-control:has(eox-drawtools) > label {
           position: absolute;
@@ -128,7 +139,7 @@ watch(jsonformEl, (el) => {
     }
 
     const injectDrawtoolsStyle = () => {
-      const drawtools = el?.shadowRoot?.querySelector('eox-drawtools');
+      const drawtools = el?.shadowRoot?.querySelector("eox-drawtools");
       if (drawtools && drawtools.shadowRoot) {
         if (
           !drawtools.shadowRoot.getElementById("eodash-drawtools-indent-style")
@@ -267,7 +278,7 @@ useAutoExec(autoExec, jsonformEl, jsonformSchema, startProcess);
 </script>
 <style>
 eox-jsonform {
-  padding: 0;
+  padding: 0 12px;
   min-height: 0px;
   flex-shrink: 0;
 }


### PR DESCRIPTION
## Description

Ok, i have been fighting this more then i would like to accept, its like a house of cards styling challenge because there are so many options. I have tried to find as best balance of things as i could, the main points are:
* trying to utilize as much height as possible in the process panel (height 6 but cut off pixels so map info still accessible
* find out if embedings are used in vega chart, if yes, reduce the chart height to give space for the embeddings
* chart tries to fill as much as possible but also has a min size that will make the panel scrollable when for example many features are selected
* introduced a dedicated footer for execute and download that is always visible so it does not fly around somewhere in the panel
* moved the draw tool icons to the same line as the label to gain some height

I think that is a summary of what is happening, here are some screenshots:
Chart with embedings:
<img width="455" height="427" alt="image" src="https://github.com/user-attachments/assets/b64e6878-9b78-46bd-bb48-6dcffe2f3e77" />

Chart with download footer:
<img width="455" height="427" alt="image" src="https://github.com/user-attachments/assets/81315826-f792-445f-9a07-c195cc1201a4" />

Chart with download and execute:
<img width="455" height="427" alt="image" src="https://github.com/user-attachments/assets/55473f7b-ea4a-42f8-9fbd-2bf4ae671281" />

Chart with multiselect, embeddings, and download:
<img width="455" height="427" alt="image" src="https://github.com/user-attachments/assets/0dab8599-15ac-4745-a66d-69f3f68f7a31" />

Execute whit form of many parameters:
<img width="455" height="427" alt="image" src="https://github.com/user-attachments/assets/bd91c801-c257-4b53-aeed-afb2d7bf1256" />

Chart with longer form and execute:
<img width="455" height="427" alt="image" src="https://github.com/user-attachments/assets/a0c6856f-5f62-4d38-858e-406b25512c03" />





--- 
---

**previous changes, no longer apply**

This PR introduces a computation for the chart height. It tries to take into account:
* the height of the form on top (user inputs)
* the possible height of the form below the chart (vega form)
and calculates the rest of the height it can occupy based on that in order to not scroll.

Also the height of the layers panel was reduced by 1 to not clip coordinates or watermark.

Here are some examples:
* No form below
<img width="477" height="400" alt="image" src="https://github.com/user-attachments/assets/6d3eb0fd-0089-4614-9ffd-3bb05f2b154f" />

* With Form below
<img width="477" height="400" alt="image" src="https://github.com/user-attachments/assets/3f203135-4e64-489b-87a5-e0006daadbc6" />

* also seems to better make sure the buttons are within the panel without scrolling
<img width="477" height="400" alt="image" src="https://github.com/user-attachments/assets/660238ec-1aca-43c6-8cec-b162acc71c3b" />


## Checklist

- [x] ran `npm run format` and `npm run check` pass
- [ ] ~~Docs under `docs/` updated for any public API, config, or behavior change~~
- [ ] ~~New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](../docs/eodash-store.md) reference is generated from it~~
- [ ] ~~New widget props use the appropriate `/** @type {import("vue").PropType<T>} */` and they appear typed in the API reference~~
