### PR TITLE
Processpanelheight v2

### DIFF
--- a/templates/expert.js
+++ b/templates/expert.js
@@ -124,7 +124,7 @@ export default {
           id: "Processes",
           type: "internal",
           title: "Processes",
-          layout: { x: "9/9/10", y: 6, w: "3/3/2", h: 5 },
+          layout: { x: "9/9/10", y: 6, w: "3/3/2", h: 6 },
           widget: {
             name: "EodashProcess",
           },

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -78,11 +78,13 @@ const hasBindings = computed(() => {
   const spec = usedChartSpec.value;
   if (!spec) return false;
   
-  // Recursively search for any object with a 'bind' key
+  // Recursively search for any object with a 'bind' key that represents a physical UI input
   let found = false;
   const searchBindings = (obj) => {
     if (found || !obj || typeof obj !== 'object') return;
-    if ('bind' in obj) {
+    
+    // UI bindings that take up physical DOM space are objects with an 'input' property.
+    if ('bind' in obj && typeof obj.bind === 'object' && obj.bind !== null && 'input' in obj.bind) {
       found = true;
       return;
     }
@@ -243,7 +245,7 @@ function toggleLayout() {
 .eodash-chart-wrapper {
   height: 100%; /* Force full height in fullscreen layout */
   flex-grow: 1;
-  min-height: 80px; /* Prevent chart from becoming unusably small */
+  min-height: 180px; /* Prevent chart from becoming unusably small */
   display: flex;
   flex-direction: column;
 }
@@ -251,7 +253,7 @@ function toggleLayout() {
 .chart-frame {
   position: relative;
   flex-grow: 1;
-  min-height: 80px; /* Prevent chart from becoming unusably small */
+  min-height: 180px; /* Prevent chart from becoming unusably small */
   display: flex;
   flex-direction: column;
 }

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -92,6 +92,10 @@ onMounted(() => {
             * {
               box-sizing: border-box !important;
             }
+            #vis {
+              
+              min-height: 200px !important;
+            }
             :host, .vega-embed {
               display: flex !important;
               flex-direction: column !important;
@@ -103,12 +107,13 @@ onMounted(() => {
               flex: 0 0 auto !important;
               display: flex !important;
               flex-wrap: wrap;
-              gap: 10px;
+              gap: 2px !important;
               background: rgba(255, 255, 255, 0.85);
               padding: 6px 12px !important;
               border-radius: 6px;
               box-shadow: 0 2px 5px rgba(0,0,0,0.15);
               margin: 0 !important;
+              margin-top: -25px !important;
             }
             .vega-bindings:empty {
               display: none !important;
@@ -182,7 +187,7 @@ function toggleLayout() {
 .eodash-chart-wrapper {
   height: 100%; /* Force full height in fullscreen layout */
   flex-grow: 1;
-  min-height: 180px; /* Prevent chart from becoming unusably small */
+  min-height: 80px; /* Prevent chart from becoming unusably small */
   display: flex;
   flex-direction: column;
 }
@@ -190,7 +195,7 @@ function toggleLayout() {
 .chart-frame {
   position: relative;
   flex-grow: 1;
-  min-height: 250px; /* Prevent chart from becoming unusably small */
+  min-height: 80px; /* Prevent chart from becoming unusably small */
   display: flex;
   flex-direction: column;
 }

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -12,7 +12,6 @@
         </svg>
       </button>
       <eox-chart
-        class="pa-2"
         v-if="usedChartData && usedChartSpec"
         .spec="toRaw(usedChartSpec)"
         :key="chartRenderKey"
@@ -81,7 +80,7 @@ onMounted(() => {
   const el = containerEl.value;
   if (!el) return;
 
-  // Continuously enforce the layout structure and the form offset
+  // Continuously inject basic styling for the bindings form to make it look decent
   styleInterval = window.setInterval(() => {
     if (el) {
       const eoxChart = el.querySelector("eox-chart");
@@ -90,57 +89,43 @@ onMounted(() => {
           const style = document.createElement("style");
           style.id = "eodash-chart-styles";
           style.innerHTML = `
-            .vega-embed {
-              position: relative !important;
+            * {
+              box-sizing: border-box !important;
+            }
+            :host, .vega-embed {
               display: flex !important;
               flex-direction: column !important;
               height: 100% !important;
+              padding: 0 !important;
+              margin: 0 !important;
             }
             .vega-bindings {
-              position: absolute !important;
-              top: 0 !important;
-              left: 10px !important;
+              flex: 0 0 auto !important;
               display: flex !important;
               flex-wrap: wrap;
               gap: 10px;
               background: rgba(255, 255, 255, 0.85);
-              padding: 6px 12px;
+              padding: 6px 12px !important;
               border-radius: 6px;
               box-shadow: 0 2px 5px rgba(0,0,0,0.15);
-              z-index: 100 !important;
-              max-width: calc(100% - 90px) !important;
+              margin: 0 !important;
             }
             .vega-bindings:empty {
               display: none !important;
+            }
+            .vega-embed > canvas, .vega-embed > svg {
+              max-height: 100% !important;
+              max-width: 100% !important;
+              object-fit: contain;
             }
             .vega-bind {
               display: flex;
               align-items: center;
               gap: 6px;
+              margin-bottom: 0 !important;
             }
           `;
           eoxChart.shadowRoot.appendChild(style);
-        }
-
-        // Dynamically pull the form up by its own height and pad the container
-        const bindingsEl = eoxChart.shadowRoot.querySelector('.vega-bindings');
-        const embedEl = eoxChart.shadowRoot.querySelector('.vega-embed');
-        
-        if (bindingsEl && bindingsEl.children.length > 0) {
-          const height = bindingsEl.getBoundingClientRect().height;
-          // Apply a smaller negative margin to pull it up slightly, 
-          // and a matching padding to the container to push the chart down.
-          const newMargin = `-${height + 5}px`;
-          const newPadding = `${height + 5}px`;
-          if (bindingsEl.style.marginTop !== newMargin) {
-             bindingsEl.style.marginTop = newMargin;
-             if (embedEl) embedEl.style.paddingTop = newPadding;
-          }
-        } else if (bindingsEl) {
-          if (bindingsEl.style.marginTop !== '') {
-             bindingsEl.style.marginTop = '';
-             if (embedEl) embedEl.style.paddingTop = '';
-          }
         }
       }
     }
@@ -166,7 +151,6 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   observer?.disconnect();
-  if (styleInterval) window.clearInterval(styleInterval);
 });
 
 const chartStyles = computed(() => {
@@ -184,11 +168,21 @@ function toggleLayout() {
   areChartsSeparateLayout.value = !areChartsSeparateLayout.value;
 }
 </script>
+
+<style>
+/* Force the outer dashboard panel wrapping this component to utilize 100% height in fullscreen mode */
+.bg-surface:has(.eodash-chart-wrapper) {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+</style>
+
 <style scoped>
 .eodash-chart-wrapper {
   height: 100%; /* Force full height in fullscreen layout */
   flex-grow: 1;
-  min-height: 0; /* Critical for flex shrinking */
+  min-height: 180px; /* Prevent chart from becoming unusably small */
   display: flex;
   flex-direction: column;
 }
@@ -196,10 +190,9 @@ function toggleLayout() {
 .chart-frame {
   position: relative;
   flex-grow: 1;
-  min-height: 0;
+  min-height: 250px; /* Prevent chart from becoming unusably small */
   display: flex;
   flex-direction: column;
-  margin-top: 10px;
 }
 
 eox-chart {
@@ -209,7 +202,7 @@ eox-chart {
 
 .chart-toggle {
   position: absolute;
-  top: -4px;
+  top: 8px;
   right: 46px;
   z-index: 2;
   cursor: pointer;

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -1,9 +1,6 @@
 <template>
-  <div 
-    ref="container" 
-    class="eodash-chart-wrapper"
-  >
-    <div 
+  <div ref="container" class="eodash-chart-wrapper">
+    <div
       class="chart-frame"
       :style="{ paddingBottom: hasBindings ? '25px' : '0px' }"
     >
@@ -77,14 +74,20 @@ const usedChartSpec = computed(() => {
 const hasBindings = computed(() => {
   const spec = usedChartSpec.value;
   if (!spec) return false;
-  
+
   // Recursively search for any object with a 'bind' key that represents a physical UI input
   let found = false;
+  /** @param {any} obj */
   const searchBindings = (obj) => {
-    if (found || !obj || typeof obj !== 'object') return;
-    
+    if (found || !obj || typeof obj !== "object") return;
+
     // UI bindings that take up physical DOM space are objects with an 'input' property.
-    if ('bind' in obj && typeof obj.bind === 'object' && obj.bind !== null && 'input' in obj.bind) {
+    if (
+      "bind" in obj &&
+      typeof obj.bind === "object" &&
+      obj.bind !== null &&
+      "input" in obj.bind
+    ) {
       found = true;
       return;
     }
@@ -96,33 +99,37 @@ const hasBindings = computed(() => {
 
 const renderedChartSpec = ref(null);
 
-watch(usedChartSpec, (newSpec) => {
-  if (!newSpec) {
-    renderedChartSpec.value = null;
-    return;
-  }
-  
-  // Create a deep copy so we can safely mutate it
-  const adjustedSpec = JSON.parse(JSON.stringify(newSpec));
-  
-  // Force the chart to be fully responsive to its CSS container
-  adjustedSpec.height = "container";
-  adjustedSpec.width = "container";
+watch(
+  usedChartSpec,
+  (newSpec) => {
+    if (!newSpec) {
+      renderedChartSpec.value = null;
+      return;
+    }
 
-  // Delay passing the spec to eox-chart until the next DOM update cycle.
-  // This ensures the dynamic chartStyles are physically applied
-  // to the container BEFORE Vega calculates its canvas size.
-  nextTick(() => {
-    renderedChartSpec.value = adjustedSpec;
-    chartRenderKey.value = Math.random(); // Force eox-chart to completely remount
-    
-    // Force a browser-level resize event after the chart mounts.
-    // This tells Vega to re-read the container dimensions once the CSS has finished painting.
-    setTimeout(() => {
-      window.dispatchEvent(new Event('resize'));
-    }, 150);
-  });
-}, { immediate: true });
+    // Create a deep copy so we can safely mutate it
+    const adjustedSpec = JSON.parse(JSON.stringify(newSpec));
+
+    // Force the chart to be fully responsive to its CSS container
+    adjustedSpec.height = "container";
+    adjustedSpec.width = "container";
+
+    // Delay passing the spec to eox-chart until the next DOM update cycle.
+    // This ensures the dynamic chartStyles are physically applied
+    // to the container BEFORE Vega calculates its canvas size.
+    nextTick(() => {
+      renderedChartSpec.value = adjustedSpec;
+      chartRenderKey.value = Math.random(); // Force eox-chart to completely remount
+
+      // Force a browser-level resize event after the chart mounts.
+      // This tells Vega to re-read the container dimensions once the CSS has finished painting.
+      setTimeout(() => {
+        window.dispatchEvent(new Event("resize"));
+      }, 150);
+    });
+  },
+  { immediate: true },
+);
 
 const chartRenderKey = ref(0);
 const containerEl = useTemplateRef("container");
@@ -141,7 +148,7 @@ onMounted(() => {
     if (el) {
       const eoxChart = el.querySelector("eox-chart");
       if (eoxChart && eoxChart.shadowRoot) {
-        if (!eoxChart.shadowRoot.querySelector('#eodash-chart-styles')) {
+        if (!eoxChart.shadowRoot.querySelector("#eodash-chart-styles")) {
           const style = document.createElement("style");
           style.id = "eodash-chart-styles";
           style.innerHTML = `
@@ -219,7 +226,7 @@ onBeforeUnmount(() => {
 const chartStyles = computed(() => {
   return {
     height: "100%",
-    width: "100%"
+    width: "100%",
   };
 });
 

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="container">
+  <div ref="container" class="eodash-chart-wrapper">
     <div class="chart-frame">
       <button
         v-if="usedChartData && usedChartSpec"
@@ -70,133 +70,83 @@ const usedChartSpec = computed(() => {
 });
 
 const chartRenderKey = ref(0);
-const frameHeight = ref(225);
 const containerEl = useTemplateRef("container");
 
-/**
-@type { MutationObserver | null}
-*/
-let observer = null;
-/** @type {ResizeObserver | null} */
-let resizeObserver = null;
 /** @type {MutationObserver | null} */
-let childMutationObserver = null;
+let observer = null;
+/** @type {number | null} */
+let styleInterval = null;
 
 onMounted(() => {
   const el = containerEl.value;
   if (!el) return;
 
-  const directParent = el.parentElement;
-  const grandParent = directParent?.parentElement;
-
-  const calculateHeight = () => {
-    if (!grandParent) return;
-    let availableHeight = grandParent.getBoundingClientRect().height;
-
-    if (
-      directParent &&
-      directParent.classList.contains("eodash-process-container")
-    ) {
-      const styles = window.getComputedStyle(directParent);
-      availableHeight -=
-        (parseFloat(styles.paddingTop) || 0) +
-        (parseFloat(styles.paddingBottom) || 0);
-
-      Array.from(directParent.children).forEach((child) => {
-        if (child !== el) {
-          const childHeight = child.getBoundingClientRect().height;
-          const childStyles = window.getComputedStyle(child);
-          const margins =
-            (parseFloat(childStyles.marginTop) || 0) +
-            (parseFloat(childStyles.marginBottom) || 0);
-          availableHeight -= childHeight + margins;
-        }
-      });
-
-      // Subtract height of vega-bindings if they exist inside the web component
+  // Continuously enforce the layout structure and the form offset
+  styleInterval = window.setInterval(() => {
+    if (el) {
       const eoxChart = el.querySelector("eox-chart");
       if (eoxChart && eoxChart.shadowRoot) {
-        const bindingsForm =
-          eoxChart.shadowRoot.querySelector(".vega-bindings");
-        if (bindingsForm) {
-          const formHeight = bindingsForm.getBoundingClientRect().height;
-          availableHeight -= formHeight + 12; // Add 12px extra padding for the form
+        if (!eoxChart.shadowRoot.querySelector('#eodash-chart-styles')) {
+          const style = document.createElement("style");
+          style.id = "eodash-chart-styles";
+          style.innerHTML = `
+            .vega-embed {
+              position: relative !important;
+              display: flex !important;
+              flex-direction: column !important;
+              height: 100% !important;
+            }
+            .vega-bindings {
+              position: absolute !important;
+              top: 0 !important;
+              left: 10px !important;
+              display: flex !important;
+              flex-wrap: wrap;
+              gap: 10px;
+              background: rgba(255, 255, 255, 0.85);
+              padding: 6px 12px;
+              border-radius: 6px;
+              box-shadow: 0 2px 5px rgba(0,0,0,0.15);
+              z-index: 100 !important;
+              max-width: calc(100% - 90px) !important;
+            }
+            .vega-bindings:empty {
+              display: none !important;
+            }
+            .vega-bind {
+              display: flex;
+              align-items: center;
+              gap: 6px;
+            }
+          `;
+          eoxChart.shadowRoot.appendChild(style);
+        }
+
+        // Dynamically pull the form up by its own height and pad the container
+        const bindingsEl = eoxChart.shadowRoot.querySelector('.vega-bindings');
+        const embedEl = eoxChart.shadowRoot.querySelector('.vega-embed');
+        
+        if (bindingsEl && bindingsEl.children.length > 0) {
+          const height = bindingsEl.getBoundingClientRect().height;
+          // Apply a smaller negative margin to pull it up slightly, 
+          // and a matching padding to the container to push the chart down.
+          const newMargin = `-${height + 5}px`;
+          const newPadding = `${height + 5}px`;
+          if (bindingsEl.style.marginTop !== newMargin) {
+             bindingsEl.style.marginTop = newMargin;
+             if (embedEl) embedEl.style.paddingTop = newPadding;
+          }
+        } else if (bindingsEl) {
+          if (bindingsEl.style.marginTop !== '') {
+             bindingsEl.style.marginTop = '';
+             if (embedEl) embedEl.style.paddingTop = '';
+          }
         }
       }
-
-      // small buffer to prevent border scrollbars
-      availableHeight -= 12;
-    } else {
-      // If maximized or in another panel
-      if (directParent) {
-        const styles = window.getComputedStyle(directParent);
-        availableHeight -=
-          (parseFloat(styles.paddingTop) || 0) +
-          (parseFloat(styles.paddingBottom) || 0);
-      }
-      availableHeight -= 12;
     }
+  }, 200);
 
-    if (availableHeight > 0) {
-      frameHeight.value = Math.max(150, Math.floor(availableHeight));
-    }
-  };
-
-  const setupShadowObserver = () => {
-    const eoxChart = el.querySelector("eox-chart");
-    if (eoxChart && eoxChart.shadowRoot && !eoxChart.hasAttribute("data-observed")) {
-      const shadowObserver = new MutationObserver(() => calculateHeight());
-      shadowObserver.observe(eoxChart.shadowRoot, {
-        childList: true,
-        subtree: true,
-      });
-      eoxChart.setAttribute("data-observed", "true");
-    }
-  };
-
-  // Initial calculation after layout
-  nextTick(() => {
-    calculateHeight();
-    setupShadowObserver();
-  });
-
-  // Watch for data changes which might trigger form re-rendering
-  watch(
-    [usedChartData, usedChartSpec],
-    () => {
-      nextTick(() => {
-        calculateHeight();
-        setupShadowObserver();
-      });
-    },
-    { deep: true },
-  );
-
-  if (grandParent) {
-    resizeObserver = new ResizeObserver(() => {
-      calculateHeight();
-    });
-    resizeObserver.observe(grandParent);
-
-    if (directParent) {
-      resizeObserver.observe(directParent);
-      Array.from(directParent.children).forEach((child) => {
-        if (child !== el) resizeObserver?.observe(child);
-      });
-
-      childMutationObserver = new MutationObserver(() => {
-        calculateHeight();
-        Array.from(directParent.children).forEach((child) => {
-          if (child !== el) resizeObserver?.observe(child);
-        });
-        setupShadowObserver();
-      });
-      childMutationObserver.observe(directParent, { childList: true });
-    }
-  }
-
-  // for mobile view, the overlay panel containing chart is initially hidden
-  // we create an observer when display of overlay is not none anymore
+  // For mobile view, handle overlay display changes
   const overlay = getOverlayParent(el);
   if (!overlay) return;
 
@@ -204,7 +154,6 @@ onMounted(() => {
     const style = getComputedStyle(overlay);
     const visible = style.display !== "none";
     if (visible) {
-      // forcibly rerender chart, otherwise size of canvas is 0
       chartRenderKey.value = Math.random();
     }
   });
@@ -217,15 +166,14 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   observer?.disconnect();
-  resizeObserver?.disconnect();
-  childMutationObserver?.disconnect();
+  if (styleInterval) window.clearInterval(styleInterval);
 });
 
 const chartStyles = computed(() => {
-  const styles = {
-    height: `${frameHeight.value}px`,
+  return {
+    height: "100%",
+    width: "100%"
   };
-  return styles;
 });
 
 const toggleIcon = computed(() =>
@@ -237,13 +185,31 @@ function toggleLayout() {
 }
 </script>
 <style scoped>
+.eodash-chart-wrapper {
+  height: 100%; /* Force full height in fullscreen layout */
+  flex-grow: 1;
+  min-height: 0; /* Critical for flex shrinking */
+  display: flex;
+  flex-direction: column;
+}
+
 .chart-frame {
   position: relative;
+  flex-grow: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  margin-top: 10px;
+}
+
+eox-chart {
+  flex-grow: 1;
+  min-height: 0;
 }
 
 .chart-toggle {
   position: absolute;
-  top: 18px;
+  top: -4px;
   right: 46px;
   z-index: 2;
   cursor: pointer;

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -1,6 +1,12 @@
 <template>
-  <div ref="container" class="eodash-chart-wrapper">
-    <div class="chart-frame">
+  <div 
+    ref="container" 
+    class="eodash-chart-wrapper"
+  >
+    <div 
+      class="chart-frame"
+      :style="{ paddingBottom: hasBindings ? '25px' : '0px' }"
+    >
       <button
         v-if="usedChartData && usedChartSpec"
         class="chart-toggle"
@@ -12,8 +18,8 @@
         </svg>
       </button>
       <eox-chart
-        v-if="usedChartData && usedChartSpec"
-        .spec="toRaw(usedChartSpec)"
+        v-if="usedChartData && renderedChartSpec"
+        .spec="toRaw(renderedChartSpec)"
         :key="chartRenderKey"
         .dataValues="toRaw(usedChartData)"
         @click:item="onChartClick"
@@ -68,6 +74,54 @@ const usedChartSpec = computed(() => {
   return enableCompare ? compareChartSpec.value : chartSpec.value;
 });
 
+const hasBindings = computed(() => {
+  const spec = usedChartSpec.value;
+  if (!spec) return false;
+  
+  // Recursively search for any object with a 'bind' key
+  let found = false;
+  const searchBindings = (obj) => {
+    if (found || !obj || typeof obj !== 'object') return;
+    if ('bind' in obj) {
+      found = true;
+      return;
+    }
+    Object.values(obj).forEach(searchBindings);
+  };
+  searchBindings(spec);
+  return found;
+});
+
+const renderedChartSpec = ref(null);
+
+watch(usedChartSpec, (newSpec) => {
+  if (!newSpec) {
+    renderedChartSpec.value = null;
+    return;
+  }
+  
+  // Create a deep copy so we can safely mutate it
+  const adjustedSpec = JSON.parse(JSON.stringify(newSpec));
+  
+  // Force the chart to be fully responsive to its CSS container
+  adjustedSpec.height = "container";
+  adjustedSpec.width = "container";
+
+  // Delay passing the spec to eox-chart until the next DOM update cycle.
+  // This ensures the dynamic chartStyles are physically applied
+  // to the container BEFORE Vega calculates its canvas size.
+  nextTick(() => {
+    renderedChartSpec.value = adjustedSpec;
+    chartRenderKey.value = Math.random(); // Force eox-chart to completely remount
+    
+    // Force a browser-level resize event after the chart mounts.
+    // This tells Vega to re-read the container dimensions once the CSS has finished painting.
+    setTimeout(() => {
+      window.dispatchEvent(new Event('resize'));
+    }, 150);
+  });
+}, { immediate: true });
+
 const chartRenderKey = ref(0);
 const containerEl = useTemplateRef("container");
 
@@ -93,7 +147,8 @@ onMounted(() => {
               box-sizing: border-box !important;
             }
             #vis {
-              min-height: 200px !important;
+              min-height: 100px !important;
+              flex: 1 1 auto !important;
             }
             :host, .vega-embed {
               display: flex !important;
@@ -112,7 +167,7 @@ onMounted(() => {
               border-radius: 6px;
               box-shadow: 0 2px 5px rgba(0,0,0,0.15);
               margin: 0 !important;
-              margin-top: -5px !important;
+              margin-top: -10px !important;
               z-index: 10;
             }
             .vega-bindings:empty {
@@ -156,6 +211,7 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   observer?.disconnect();
+  if (styleInterval) window.clearInterval(styleInterval);
 });
 
 const chartStyles = computed(() => {
@@ -190,7 +246,6 @@ function toggleLayout() {
   min-height: 80px; /* Prevent chart from becoming unusably small */
   display: flex;
   flex-direction: column;
-  padding-bottom: 30px; /* Reserve space at the bottom */
 }
 
 .chart-frame {

--- a/widgets/EodashChart.vue
+++ b/widgets/EodashChart.vue
@@ -93,7 +93,6 @@ onMounted(() => {
               box-sizing: border-box !important;
             }
             #vis {
-              
               min-height: 200px !important;
             }
             :host, .vega-embed {
@@ -113,13 +112,14 @@ onMounted(() => {
               border-radius: 6px;
               box-shadow: 0 2px 5px rgba(0,0,0,0.15);
               margin: 0 !important;
-              margin-top: -25px !important;
+              margin-top: -5px !important;
+              z-index: 10;
             }
             .vega-bindings:empty {
               display: none !important;
             }
             .vega-embed > canvas, .vega-embed > svg {
-              max-height: 100% !important;
+              height: 100% !important;
               max-width: 100% !important;
               object-fit: contain;
             }
@@ -190,6 +190,7 @@ function toggleLayout() {
   min-height: 80px; /* Prevent chart from becoming unusably small */
   display: flex;
   flex-direction: column;
+  padding-bottom: 30px; /* Reserve space at the bottom */
 }
 
 .chart-frame {

--- a/widgets/EodashProcess/index.vue
+++ b/widgets/EodashProcess/index.vue
@@ -45,7 +45,7 @@ import "@eox/drawtools";
 import "@eox/jsonform";
 import { useSTAcStore } from "@/store/stac";
 import { storeToRefs } from "pinia";
-import { computed, ref, useTemplateRef } from "vue";
+import { computed, ref, useTemplateRef, watch } from "vue";
 import ProcessList from "./ProcessList.vue";
 import EodashChart from "../EodashChart.vue";
 import { handleProcesses } from "./methods/handling";
@@ -87,6 +87,41 @@ const jsonformEl =
   /** @type {Readonly<import("vue").ShallowRef<import("@eox/jsonform").EOxJSONForm | null>>} */ (
     useTemplateRef("jsonformEl")
   );
+
+// Inject custom styles into the eox-jsonform shadow DOM to make eox-drawtools inline
+watch(jsonformEl, (el) => {
+  if (el && el.shadowRoot) {
+    const styleId = "eodash-drawtools-inline-style";
+    if (!el.shadowRoot.getElementById(styleId)) {
+      const style = document.createElement("style");
+      style.id = styleId;
+      style.textContent = `
+        .form-control:has(eox-drawtools) {
+          display: flex;
+          align-items: center;
+          gap: 15px;
+          border: none !important;
+          padding: 8px 12px !important;
+          background: transparent !important;
+        }
+        .form-control:has(eox-drawtools) > label {
+          margin: 0 !important;
+          flex-shrink: 0;
+          min-width: 120px;
+          line-height: 1;
+          display: flex;
+          align-items: center;
+        }
+        .form-control:has(eox-drawtools) > eox-drawtools {
+          flex-grow: 1;
+          display: flex;
+          align-items: center;
+        }
+      `;
+      el.shadowRoot.appendChild(style);
+    }
+  }
+});
 
 const isAsync = computed(
   () =>

--- a/widgets/EodashProcess/index.vue
+++ b/widgets/EodashProcess/index.vue
@@ -1,19 +1,24 @@
 <template>
   <div ref="container" class="eodash-process-container">
-    <ProcessList :map-element="mapElement" :enable-compare="enableCompare" />
-    <eox-jsonform
-      v-if="jsonformSchema"
-      :key="jsonformKey"
-      ref="jsonformEl"
-      .schema="jsonformSchema"
-    ></eox-jsonform>
-    <EodashChart
-      v-if="!areChartsSeparateLayout"
-      :vega-embed-options="vegaEmbedOptions"
-      :enable-compare="enableCompare"
+    <div class="eodash-process-content">
+      <ProcessList :map-element="mapElement" :enable-compare="enableCompare" />
+      <eox-jsonform
+        v-if="jsonformSchema"
+        :key="jsonformKey"
+        ref="jsonformEl"
+        .schema="jsonformSchema"
+      ></eox-jsonform>
+      <EodashChart
+        v-if="!areChartsSeparateLayout"
+        :vega-embed-options="vegaEmbedOptions"
+        :enable-compare="enableCompare"
+      >
+      </EodashChart>
+    </div>
+    <div 
+      class="eodash-process-actions" 
+      v-if="showExecBtn || (processResults.length && isProcessed && !isAsync)"
     >
-    </EodashChart>
-    <div class="text-right">
       <v-btn
         v-if="showExecBtn"
         :loading="loading"
@@ -267,7 +272,8 @@ eox-jsonform {
 
 /* Force the specific panel wrapping this component to utilize 100% height */
 .bg-surface:has(.eodash-process-container) {
-  height: 100%;
+  height: calc(100% - 30px);
+  overflow: hidden;
 }
 
 /* Make sure this container takes up full height and acts as a flex column */
@@ -275,6 +281,21 @@ eox-jsonform {
   height: 100%;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
+}
+
+.eodash-process-content {
+  flex-grow: 1;
   overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.eodash-process-actions {
+  text-align: right;
+  padding: 4px 12px;
+  flex-shrink: 0;
+  border-top: 1px solid rgba(0, 0, 0, 0.1);
+  background: inherit;
 }
 </style>

--- a/widgets/EodashProcess/index.vue
+++ b/widgets/EodashProcess/index.vue
@@ -1,5 +1,5 @@
 <template>
-  <div ref="container" class="py-1 eodash-process-container">
+  <div ref="container" class="eodash-process-container">
     <ProcessList :map-element="mapElement" :enable-compare="enableCompare" />
     <eox-jsonform
       v-if="jsonformSchema"
@@ -189,7 +189,7 @@ useAutoExec(autoExec, jsonformEl, jsonformSchema, startProcess);
 </script>
 <style>
 eox-jsonform {
-  padding: 0.7em;
+  padding: 0;
   min-height: 0px;
   flex-shrink: 0;
 }
@@ -204,6 +204,6 @@ eox-jsonform {
   height: 100%;
   display: flex;
   flex-direction: column;
-  overflow: hidden;
+  overflow-y: auto;
 }
 </style>

--- a/widgets/EodashProcess/index.vue
+++ b/widgets/EodashProcess/index.vue
@@ -191,6 +191,7 @@ useAutoExec(autoExec, jsonformEl, jsonformSchema, startProcess);
 eox-jsonform {
   padding: 0.7em;
   min-height: 0px;
+  flex-shrink: 0;
 }
 
 /* Force the specific panel wrapping this component to utilize 100% height */
@@ -198,8 +199,11 @@ eox-jsonform {
   height: 100%;
 }
 
-/* Make sure this container also takes up that height */
+/* Make sure this container takes up full height and acts as a flex column */
 .eodash-process-container {
   height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
 }
 </style>

--- a/widgets/EodashProcess/index.vue
+++ b/widgets/EodashProcess/index.vue
@@ -97,28 +97,64 @@ watch(jsonformEl, (el) => {
       style.id = styleId;
       style.textContent = `
         .form-control:has(eox-drawtools) {
-          display: flex;
-          align-items: center;
-          gap: 15px;
-          border: none !important;
+          position: relative;
           padding: 8px 12px !important;
+          border: none !important;
           background: transparent !important;
         }
         .form-control:has(eox-drawtools) > label {
+          position: absolute;
+          left: 12px;
+          top: 8px;
           margin: 0 !important;
-          flex-shrink: 0;
-          min-width: 120px;
-          line-height: 1;
+          width: calc(100% - 180px); /* Give label maximum available width */
+          line-height: 1.2;
           display: flex;
-          align-items: center;
+          align-items: flex-start;
+          padding-top: 8px;
+          pointer-events: none; /* Let clicks pass through to buttons if they overlap slightly */
         }
         .form-control:has(eox-drawtools) > eox-drawtools {
-          flex-grow: 1;
-          display: flex;
-          align-items: center;
+          display: block;
+          width: 100%;
         }
       `;
       el.shadowRoot.appendChild(style);
+    }
+
+    const injectDrawtoolsStyle = () => {
+      const drawtools = el.shadowRoot.querySelector('eox-drawtools');
+      if (drawtools && drawtools.shadowRoot) {
+        if (!drawtools.shadowRoot.getElementById('eodash-drawtools-indent-style')) {
+          const dtStyle = document.createElement('style');
+          dtStyle.id = 'eodash-drawtools-indent-style';
+          dtStyle.textContent = `
+            eox-drawtools-controller {
+              display: flex;
+              justify-content: flex-end; /* Push buttons to the right */
+              min-height: 40px;
+              width: 100%;
+            }
+            eox-drawtools-list {
+              display: block;
+              margin-top: 10px;
+              width: 100%;
+            }
+          `;
+          drawtools.shadowRoot.appendChild(dtStyle);
+          return true;
+        }
+      }
+      return false;
+    };
+
+    if (!injectDrawtoolsStyle()) {
+      const observer = new MutationObserver(() => {
+        if (injectDrawtoolsStyle()) {
+          observer.disconnect();
+        }
+      });
+      observer.observe(el.shadowRoot, { childList: true, subtree: true });
     }
   }
 });

--- a/widgets/EodashProcess/index.vue
+++ b/widgets/EodashProcess/index.vue
@@ -15,8 +15,8 @@
       >
       </EodashChart>
     </div>
-    <div 
-      class="eodash-process-actions" 
+    <div
+      class="eodash-process-actions"
       v-if="showExecBtn || (processResults.length && isProcessed && !isAsync)"
     >
       <v-btn
@@ -128,11 +128,13 @@ watch(jsonformEl, (el) => {
     }
 
     const injectDrawtoolsStyle = () => {
-      const drawtools = el.shadowRoot.querySelector('eox-drawtools');
+      const drawtools = el?.shadowRoot?.querySelector('eox-drawtools');
       if (drawtools && drawtools.shadowRoot) {
-        if (!drawtools.shadowRoot.getElementById('eodash-drawtools-indent-style')) {
-          const dtStyle = document.createElement('style');
-          dtStyle.id = 'eodash-drawtools-indent-style';
+        if (
+          !drawtools.shadowRoot.getElementById("eodash-drawtools-indent-style")
+        ) {
+          const dtStyle = document.createElement("style");
+          dtStyle.id = "eodash-drawtools-indent-style";
           dtStyle.textContent = `
             eox-drawtools-controller {
               display: flex;


### PR DESCRIPTION
## Description

<!-- What does this PR change, and why? -->

## Checklist

- [ ] ran `npm run format` and `npm run check` pass
- [ ] Docs under `docs/` updated for any public API, config, or behavior change
- [ ] New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](../docs/eodash-store.md) reference is generated from it
- [ ] New widget props use the appropriate `/** @type {import("vue").PropType<T>} */` and they appear typed in the API reference
