### PR TITLE
feat: implemented injection of url parameters based on style jsonform config

### DIFF
--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -1317,7 +1317,10 @@ export function updateLayerUrl(olLayer, jsonformValue) {
       return false;
     }
     jsonLayer.source.url = newUrl;
-    const source = olLayer.getSource();
+    if (olLayer.get("injectedUrl") === newUrl) {
+      return false;
+    }
+    olLayer.set("injectedUrl", newUrl);
     if (source && "setUrl" in source) {
       /** @type {any} */ (source).setUrl(newUrl);
       return true;

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -121,6 +121,39 @@ export function extractLayerConfig(
 }
 
 /**
+ * Recursively extracts URL keys from a JSON Schema.
+ * Maps schema property names to their defined `url_key`.
+ * @param {Record<string, any> | null | undefined} schema
+ * @returns {Record<string, string>}
+ */
+export function extractUrlKeys(schema) {
+  /** @type {Record<string, string>} */
+  const keys = {};
+  if (!schema || typeof schema !== "object") return keys;
+
+  if (schema.properties) {
+    for (const [key, propDef] of Object.entries(schema.properties)) {
+      if (propDef && typeof propDef === "object") {
+        if (typeof propDef.url_key === "string") {
+          keys[key] = propDef.url_key;
+        }
+        Object.assign(keys, extractUrlKeys(propDef));
+      }
+    }
+  }
+
+  for (const combinator of ["oneOf", "allOf", "anyOf"]) {
+    if (Array.isArray(schema[combinator])) {
+      for (const sub of schema[combinator]) {
+        Object.assign(keys, extractUrlKeys(sub));
+      }
+    }
+  }
+
+  return keys;
+}
+
+/**
  *
  * @param {number[]} bbox
  * @returns
@@ -1215,6 +1248,87 @@ export function updateGeoZarrBands(olLayer, jsonformValue) {
     new window.eoxMapAdvancedOlSources.GeoZarr(jsonLayer.source),
   );
   return true;
+}
+
+/**
+ * Safely appends query parameters to a URL string, preserving templates like {z}/{x}/{y}
+ * @param {string} url
+ * @param {Record<string, string>} params
+ * @returns {string}
+ */
+function appendQueryParams(url, params) {
+  const [base, query] = url.split("?");
+  const searchParams = new URLSearchParams(query || "");
+
+  for (const [key, val] of Object.entries(params)) {
+    if (val !== undefined && val !== null && val !== "") {
+      searchParams.set(key, val);
+    } else {
+      searchParams.delete(key);
+    }
+  }
+
+  const newQuery = searchParams.toString();
+  return newQuery ? `${base}?${newQuery}` : base;
+}
+
+/**
+ * Checks whether a VectorTile layer's URL needs to be updated based on jsonform output.
+ * If the style's jsonform schema has properties with `url_key` defined, their values
+ * are injected as query parameters into the source URL.
+ *
+ * @param {import("ol/layer/Layer").default} olLayer - Layer from layerConfig:change event
+ * @param {Record<string, any>} jsonformValue - Current jsonform output
+ * @returns {boolean} true if the URL was updated
+ */
+export function updateLayerUrl(olLayer, jsonformValue) {
+  const jsonLayer = olLayer.get("_jsonDefinition");
+  if (!jsonLayer || jsonLayer.type !== "VectorTile") {
+    return false;
+  }
+
+  const schema = jsonLayer.properties?.layerConfig?.schema;
+  const urlKeys = extractUrlKeys(schema);
+
+  if (Object.keys(urlKeys).length === 0) {
+    return false;
+  }
+
+  let originalUrl = olLayer.get("originalUrl") || jsonLayer.source?.url;
+
+  if (!originalUrl || typeof originalUrl !== "string") {
+    return false;
+  }
+
+  if (!olLayer.get("originalUrl")) {
+    olLayer.set("originalUrl", originalUrl);
+  }
+
+  /** @type {Record<string, string>} */
+  const queryParamsToInject = {};
+  for (const [propName, urlKey] of Object.entries(urlKeys)) {
+    queryParamsToInject[urlKey] = jsonformValue[propName];
+  }
+
+  const newUrl = appendQueryParams(originalUrl, queryParamsToInject);
+
+  if (jsonLayer.source?.url) {
+    if (jsonLayer.source.url === newUrl) {
+      return false;
+    }
+    jsonLayer.source.url = newUrl;
+    const source = olLayer.getSource();
+    if (source && "setUrl" in source) {
+      /** @type {any} */ (source).setUrl(newUrl);
+      return true;
+    }
+    if (source && "setUrls" in source) {
+      /** @type {any} */ (source).setUrls([newUrl]);
+      return true;
+    }
+  }
+
+  return false;
 }
 
 /**

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -1320,6 +1320,7 @@ export function updateLayerUrl(olLayer, jsonformValue) {
     if (olLayer.get("injectedUrl") === newUrl) {
       return false;
     }
+    const source = olLayer.getSource();
     olLayer.set("injectedUrl", newUrl);
     if (source && "setUrl" in source) {
       /** @type {any} */ (source).setUrl(newUrl);

--- a/widgets/EodashLayerControl.vue
+++ b/widgets/EodashLayerControl.vue
@@ -32,14 +32,17 @@ import "color-legend-element";
 import "@eox/timecontrol";
 import { computed, ref, watch } from "vue";
 import { mapEl, mapCompareEl } from "@/store/states";
-import { getColFromLayer } from "@/eodashSTAC/helpers";
 import {
   eodashCollections,
   eodashCompareCollections,
   layerControlFormValue,
   layerControlFormValueCompare,
 } from "@/utils/states";
-import { updateGeoZarrBands } from "@/eodashSTAC/helpers";
+import {
+  getColFromLayer,
+  updateGeoZarrBands,
+  updateLayerUrl,
+} from "@/eodashSTAC/helpers";
 import { storeToRefs } from "pinia";
 import { useSTAcStore } from "@/store/stac";
 import { bandsEditorInterface } from "@/utils/bands-editor";
@@ -187,6 +190,7 @@ const debouncedHandleDateTime = (evt) => {
  */
 const onLayerConfigChange = (evt) => {
   updateGeoZarrBands(evt.detail.layer, evt.detail.jsonformValue);
+  updateLayerUrl(evt.detail.layer, evt.detail.jsonformValue);
 
   if (props.map === "second") {
     layerControlFormValueCompare.value = evt.detail.jsonformValue;


### PR DESCRIPTION
## Description

So i have a use case where i have in TiPg lots of features, and ideally i want to filter them out based on some user configuration before they get to the client. Initially i was just using the style definition to make them transparent, but this makes all sorts of issues with selection and huge tiles.

I was looking at the logic of eodash:rasterform and thought that is exactly what i needed, but was not really applicable for vector tile styles.

So this is an attempt to introduce more or less the same logic. It is possible to add "url_key" to a property in the jsonform and that will then inject that into the vector tile request with the selected value.

I have tested it out, and i am very happy with the results, this gives us lots of server side filtering options for vector tiles with TiPg and should not be breaking in any other way, just one extra key in the jsonform definition.

<img width="1223" height="919" alt="image" src="https://github.com/user-attachments/assets/eec6f3dd-1f76-43ea-a77e-92ac7fcad8b3" />


## Checklist

- [x] ran `npm run format` and `npm run check` pass
- [ ] Docs under `docs/` updated for any public API, config, or behavior change
- [ ] New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](../docs/eodash-store.md) reference is generated from it
- [ ] New widget props use the appropriate `/** @type {import("vue").PropType<T>} */` and they appear typed in the API reference
