### PR TITLE
fix: order for burning in fixed

### DIFF
--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -680,6 +680,21 @@ export const removeUnneededProperties = (layers, formValues = {}) => {
       }
     }
 
+    const {
+      id,
+      title,
+      mapboxStyle,
+      projection,
+      applyOptions,
+      layerConfig,
+      visible,
+    } = clonedLayer.properties || {};
+
+    // If style was not at root but in properties (layerConfig), move it to root early
+    if (!clonedLayer.style && layerConfig?.style) {
+      clonedLayer.style = layerConfig.style;
+    }
+
     // Burn in OpenLayers ["var", "name"] variables using flatFormValues overriding style.variables
     const styleVariables = {
       ...(clonedLayer.style?.variables || {}),
@@ -693,16 +708,6 @@ export const removeUnneededProperties = (layers, formValues = {}) => {
       });
     }
 
-    const {
-      id,
-      title,
-      mapboxStyle,
-      projection,
-      applyOptions,
-      layerConfig,
-      visible,
-    } = clonedLayer.properties || {};
-
     clonedLayer.properties = {
       id,
       title,
@@ -714,11 +719,6 @@ export const removeUnneededProperties = (layers, formValues = {}) => {
 
     if (clonedLayer["interactions"]) {
       delete clonedLayer["interactions"];
-    }
-
-    // If style was not at root but in properties (layerConfig), move it to root
-    if (!clonedLayer.style && layerConfig?.style) {
-      clonedLayer.style = layerConfig.style;
     }
 
     // Cleanup unnecessary properties


### PR DESCRIPTION
## Description

The burn in of the variables was no longer working, there was a hickup with the order it was executed in.

## Checklist

- [x] ran `npm run format` and `npm run check` pass
- [ ] ~~Docs under `docs/` updated for any public API, config, or behavior change~~
- [ ] ~~New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](../docs/eodash-store.md) reference is generated from it~~
- [ ] ~~New widget props use the appropriate `/** @type {import("vue").PropType<T>} */` and they appear typed in the API reference~~
