### PR TITLE
Feat: Support TileJSON Raster Layer

### DIFF
--- a/core/client/eodashSTAC/EodashCollection.js
+++ b/core/client/eodashSTAC/EodashCollection.js
@@ -192,9 +192,14 @@ export class EodashCollection {
 
     const isSupported =
       item.links.some((link) =>
-        ["wms", "xyz", "wmts", "vector-tile", "mapbox-style-document"].includes(
-          link.rel,
-        ),
+        [
+          "wms",
+          "xyz",
+          "wmts",
+          "vector-tile",
+          "mapbox-style-document",
+          "tilejson",
+        ].includes(link.rel),
       ) || Object.keys(dataAssets).length;
 
     if (isSupported) {
@@ -356,7 +361,9 @@ export class EodashCollection {
       (/** @type {any} */ a) => a.key?.startsWith("datetime_") || a.interval,
     );
     if (datetimeAgg?.buckets) {
-      return datetimeAgg.buckets.map((/** @type {any} */ b) => new Date(b.key));
+      return datetimeAgg.buckets
+        .map((/** @type {any} */ b) => new Date(b.key))
+        .filter((/** @type {Date} */ d) => !isNaN(d.getTime()));
     }
 
     const items = await this.getItems(true, false, centerDatetime);
@@ -371,7 +378,9 @@ export class EodashCollection {
           new Date(/** @type {string} */ (i.properties?.[datetimeProperty]))
       : //@ts-expect-error todo
         (i) => new Date(/** @type {string} */ (i[datetimeProperty]));
-    return items?.map(mapToDates) || [];
+    return (items ?? [])
+      .map(mapToDates)
+      .filter((/** @type {Date} */ d) => !isNaN(d.getTime()));
   }
 
   async getExtent() {

--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -1,5 +1,6 @@
 import { registerProjection } from "@/store/actions";
 import { mapEl } from "@/store/states";
+import { useEodash } from "@/composables";
 
 import {
   extractRoles,
@@ -15,9 +16,13 @@ import {
   getBandsProperty,
   applyTitilerUpscaling,
   encodeURLObject,
+  normalizeRescale,
+  normalizeNodata,
+  resolveRenders,
 } from "./helpers";
 import { handleAuthenticationOfLink } from "./auth";
 import log from "loglevel";
+import axios from "@/plugins/axios";
 import { useSTAcStore } from "@/store/stac";
 
 /**
@@ -437,6 +442,10 @@ export const createLayersFromLinks = async (
     item.links.filter((l) => l.rel === "vector-tile") ?? [];
   const mapboxStyleDocumentArray =
     item.links.filter((l) => l.rel === "mapbox-style-document") ?? [];
+  // An xyz link takes precedence over a tilejson link;
+  const tilejsonArray = xyzArray.length
+    ? []
+    : (item.links.filter((l) => l.rel === "tilejson") ?? []);
   // Taking projection code from main map view, as main view defines
   // projection for comparison map
   const viewProjectionCode = mapEl?.value?.projection || "EPSG:3857";
@@ -725,6 +734,83 @@ export const createLayersFromLinks = async (
     jsonArray.push(json);
   }
 
+  for (const tilejsonLink of tilejsonArray) {
+    // The tilejson href is a complete URL with the render params baked in by the
+    // STAC producer; fetch it and use its `tiles[0]` template as an XYZ source.
+    const tileJSON = await axios
+      .get(tilejsonLink.href)
+      .then((res) => res.data)
+      .catch((err) => {
+        console.error("[eodash] Failed to fetch item TileJSON", err);
+        return null;
+      });
+    if (!tileJSON?.tiles?.[0]) {
+      console.warn(
+        "[eodash] No tile URL in item TileJSON response",
+        tilejsonLink.href,
+      );
+      continue;
+    }
+
+    const tilejsonProjection =
+      /** @type {number | string | {name: string, def: string} | undefined} */
+      (tilejsonLink?.["proj:epsg"] || tilejsonLink?.["eodash:proj4_def"]);
+    await registerProjection(tilejsonProjection);
+    const projectionCode = getProjectionCode(tilejsonProjection || "EPSG:3857");
+    const rasterForm = await fetchRasterForm(
+      /** @type {string|object|undefined} */ (
+        tilejsonLink?.["eodash:rasterform"] ||
+          item?.["eodash:rasterform"] ||
+          collection?.["eodash:rasterform"]
+      ),
+    );
+    const { layerConfig } = extractLayerConfig(
+      collectionId,
+      {},
+      rasterForm,
+      "tileUrl",
+    );
+    const linkId = createLayerID(
+      collectionId,
+      item.id,
+      tilejsonLink,
+      viewProjectionCode,
+    );
+
+    log.debug("TileJSON layer added", linkId);
+    /** @type {Record<string, any>} */
+    const json = {
+      type: "Tile",
+      properties: {
+        id: linkId,
+        title: tilejsonLink.title || title || item.id,
+        roles: tilejsonLink.roles,
+        layerDatetime,
+        layerConfig,
+      },
+      source: {
+        type: "XYZ",
+        url: tileJSON.tiles[0],
+        projection: projectionCode,
+        ...(tilejsonLink.attribution
+          ? { attributions: tilejsonLink.attribution }
+          : {}),
+      },
+    };
+    if (Number.isFinite(tileJSON.minzoom)) json.minZoom = tileJSON.minzoom;
+    if (Number.isFinite(tileJSON.maxzoom)) json.maxZoom = tileJSON.maxzoom;
+
+    extractRoles(json.properties, tilejsonLink);
+    if (extraProperties !== null) {
+      json.properties = {
+        ...json.properties,
+        ...extraProperties,
+        ...extractEoxLegendLink(tilejsonLink),
+      };
+    }
+    jsonArray.push(json);
+  }
+
   for (const vectorTileLink of vectorTileArray ?? []) {
     const vectorTileLinkProjection =
       /** @type {number | string | {name: string, def: string} | undefined} */
@@ -876,18 +962,21 @@ export const createLayerFromRender = async (
   item,
   extraProperties,
 ) => {
-  if (!collection || !collection.renders || !item) {
+  // config renders > collection STAC renders > item renders
+  const renders = /** @type {Record<string,import("@/types").Render>} */ (
+    resolveRenders(collection, useEodash()?.options?.renders) ?? item?.renders
+  );
+  if (!collection || !item || !renders) {
     return [];
   }
 
-  // Skip when an explicit xyz link already targets the collection on the same endpoint
-  const hasMatchingXyzLink = item.links?.some(
+  // Yield to a raster xyz/tilejson link — createLayersFromLinks renders it.
+  const hasMatchingTileLink = item.links?.some(
     (link) =>
-      link.rel === "xyz" &&
-      link.href?.includes(rasterURL) &&
-      link.href?.includes(`/collections/${collection.id}/`),
+      (link.rel === "xyz" || link.rel === "tilejson") &&
+      link.href?.includes(rasterURL),
   );
-  if (hasMatchingXyzLink) {
+  if (hasMatchingTileLink) {
     return [];
   }
 
@@ -898,44 +987,60 @@ export const createLayerFromRender = async (
   );
   let { layerConfig } = extractLayerConfig(collection.id, {}, rasterForm);
 
-  const renders = /** @type {Record<string,import("@/types").Render>} */ (
-    collection.renders ?? item?.renders
-  );
+  /**
+   * Resolves the first defined value of a property across a render's assets,
+   * checking item assets before falling back to collection assets.
+   * @param {import("@/types").Render} render
+   * @param {string} propertyName
+   * @returns {any}
+   */
+  const getRenderAssetProperty = (render, propertyName) => {
+    for (const assetKey of render.assets ?? []) {
+      const asset = item?.assets?.[assetKey] ?? collection?.assets?.[assetKey];
+      const value = asset?.[propertyName];
+      if (value !== undefined) {
+        return value;
+      }
+    }
+    return undefined;
+  };
+
   const layers = [];
-  // special case for rescale
   for (const key in renders) {
     const title = renders[key].title;
 
-    const assetsCollection =
-      renders[key].assets[0] in item["assets"] ? item : collection;
+    const expression =
+      renders[key].expression ??
+      getRenderAssetProperty(renders[key], "expression");
 
     const paramsObject = {
-      assets: renders[key].assets,
-      expression:
-        renders[key].expression ??
-        assetsCollection["assets"]?.[renders[key].assets[0]]?.expression,
-      nodata:
-        renders[key].nodata ??
-        assetsCollection["assets"]?.[renders[key].assets[0]]?.nodata,
+      // TiTiler treats assets and expression as mutually exclusive band selection
+      assets: expression ? undefined : renders[key].assets,
+      expression,
+      nodata: normalizeNodata(
+        renders[key].nodata ?? getRenderAssetProperty(renders[key], "nodata"),
+      ),
       resampling:
         renders[key].resampling ??
-        assetsCollection["assets"]?.[renders[key].assets[0]]?.resampling,
+        getRenderAssetProperty(renders[key], "resampling"),
       color_formula:
         renders[key].color_formula ??
-        assetsCollection["assets"]?.[renders[key].assets[0]]?.color_formula,
+        getRenderAssetProperty(renders[key], "color_formula"),
       colormap:
         renders[key].colormap ??
-        assetsCollection["assets"]?.[renders[key].assets[0]]?.colormap,
+        getRenderAssetProperty(renders[key], "colormap"),
       colormap_name:
         renders[key].colormap_name ??
-        assetsCollection["assets"]?.[renders[key].assets[0]]?.colormap_name,
-      rescale:
-        renders[key].rescale ??
-        assetsCollection["assets"]?.[renders[key].assets[0]]?.rescale,
+        getRenderAssetProperty(renders[key], "colormap_name"),
+      rescale: normalizeRescale(
+        renders[key].rescale ?? getRenderAssetProperty(renders[key], "rescale"),
+      ),
+      bidx: renders[key].bidx,
+      tilesize: renders[key].tilesize,
     };
     const paramsStr = encodeURLObject(paramsObject);
     const url = `${rasterURL}/collections/${collection.id}/items/${item.id}/tiles/WebMercatorQuad/{z}/{x}/{y}?${paramsStr}`;
-    layers.push({
+    const json = {
       /** @type {"Tile"} */
       type: "Tile",
       properties: {
@@ -958,7 +1063,14 @@ export const createLayerFromRender = async (
         url,
         projection: "EPSG:3857",
       },
-    });
+    };
+    if (renders[key].tilesize) {
+      // @ts-expect-error tileGrid is added here and supported in eox-map layer definition
+      json.source.tileGrid = {
+        tileSize: [renders[key].tilesize, renders[key].tilesize],
+      };
+    }
+    layers.push(json);
   }
 
   return layers;

--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -751,6 +751,14 @@ export const createLayersFromLinks = async (
       );
       continue;
     }
+    // Only raster XYZ tiles are supported; skip vector & TMS scheme TileJSON
+    if (tileJSON.vector_layers || tileJSON.scheme === "tms") {
+      console.warn(
+        "[eodash] Unsupported TileJSON (only raster XYZ is supported)",
+        tilejsonLink.href,
+      );
+      continue;
+    }
 
     const tilejsonProjection =
       /** @type {number | string | {name: string, def: string} | undefined} */
@@ -790,10 +798,15 @@ export const createLayersFromLinks = async (
       },
       source: {
         type: "XYZ",
-        url: tileJSON.tiles[0],
+        ...(tileJSON.tiles.length > 1
+          ? { urls: tileJSON.tiles }
+          : { url: tileJSON.tiles[0] }),
         projection: projectionCode,
-        ...(tilejsonLink.attribution
-          ? { attributions: tilejsonLink.attribution }
+        // Link attribution wins; the TileJSON document's own is the fallback.
+        ...(tilejsonLink.attribution || tileJSON.attribution
+          ? {
+              attributions: tilejsonLink.attribution || tileJSON.attribution,
+            }
           : {}),
       },
     };

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -950,6 +950,7 @@ export function getDatetimeProperty(linksOrItems) {
     return prop;
   }
 }
+
 /**
  *
  * @param {*} stacObject
@@ -1368,26 +1369,56 @@ export function applyTitilerUpscaling(url, upscalingEndpoints) {
 }
 
 /**
- * Picks the render presets for a collection, preferring the collection's own
- * STAC `renders` extension and falling back to client-provided config
- *
+ * Picks the render presets for a collection, preferring client-provided config
+ * (`options.renders[collectionId]`) and falling back to the collection's own STAC
+ * `renders` extension when no config entry exists.
  * @param {import("stac-ts").StacCollection | null | undefined} collection
  * @param {Record<string, Record<string, import("@/types").Render>> | undefined} [configRenders]
  * @returns {Record<string, import("@/types").Render> | undefined}
  */
 export function resolveRenders(collection, configRenders) {
-  if (collection?.renders) {
-    return /** @type {Record<string, import("@/types").Render>} */ (
-      collection.renders
-    );
-  }
-  return collection?.id ? configRenders?.[collection.id] : undefined;
+  const config = collection?.id ? configRenders?.[collection.id] : undefined;
+  if (config) return config;
+  return /** @type {Record<string, import("@/types").Render>|undefined} */ (
+    collection?.renders ?? undefined
+  );
 }
 
 /**
- * Serializes an object into a TiTiler query string. Arrays join with commas;
- * nested arrays repeat the key (e.g. `rescale: [[0,1]]` -> `rescale=0,1`);
- * objects are JSON-encoded. Shared by the render-extension and mosaic paths.
+ * TiTiler expects rescale as [min,max] pairs; chunks a flat numeric list
+ * into pairs (e.g. [0,0.4,0,0.1] -> [[0,0.4],[0,0.1]]). Nested input passes through.
+ * @param {number[]|number[][]|undefined} rescale - flat or nested rescale values
+ * @returns {number[][]|undefined} rescale as [min,max] pairs
+ */
+export function normalizeRescale(rescale) {
+  if (!rescale?.length || Array.isArray(rescale[0])) {
+    return /** @type {number[][]|undefined} */ (rescale);
+  }
+  const pairs = [];
+  for (let i = 0; i < rescale.length; i += 2) {
+    pairs.push(/** @type {number[]} */ (rescale).slice(i, i + 2));
+  }
+  return pairs;
+}
+
+/**
+ * Drops NaN nodata values; NaN is already the implicit fill for float data,
+ * so forwarding `nodata=nan` to TiTiler is redundant.
+ * @param {string|number|undefined} nodata - nodata value from render/asset metadata
+ * @returns {string|number|undefined} nodata, or undefined when it is NaN
+ */
+export function normalizeNodata(nodata) {
+  if (typeof nodata === "number" && Number.isNaN(nodata)) return undefined;
+  if (typeof nodata === "string" && nodata.trim().toLowerCase() === "nan")
+    return undefined;
+  return nodata;
+}
+
+/**
+ * Serializes an object into a TiTiler query string. Arrays repeat the key per
+ * element (TiTiler list params, e.g. `assets=a&assets=b`); nested elements
+ * comma-join (`rescale: [[0,1],[0,2]]` -> `rescale=0,1&rescale=0,2`); objects
+ * are JSON-encoded. Shared by the render-extension and mosaic paths.
  * @param {Record<string,any>} obj
  * @returns {string}
  */
@@ -1403,23 +1434,12 @@ export function encodeURLObject(obj) {
 
     switch (valueType) {
       case "array": {
-        // Check if any element in the array is itself an array (multi-dimensional)
-        const hasNestedArrays = value.some((/** @type {any} */ item) =>
-          Array.isArray(item),
-        );
-
-        if (hasNestedArrays) {
-          // For multi-dimensional arrays, repeat the key with different values
-          for (const val of value) {
-            if (Array.isArray(val)) {
-              str += `${key}=${val.join(",")}&`;
-            } else {
-              str += `${key}=${val}&`;
-            }
+        for (const val of value) {
+          if (Array.isArray(val)) {
+            str += `${key}=${val.join(",")}&`;
+          } else {
+            str += `${key}=${encodeURIComponent(val)}&`;
           }
-        } else {
-          // For simple arrays, join with commas
-          str += `${key}=${value.join(",")}&`;
         }
         break;
       }

--- a/core/client/eodashSTAC/mosaic.js
+++ b/core/client/eodashSTAC/mosaic.js
@@ -25,6 +25,8 @@ import { useEodash, useOnLayersUpdate } from "@/composables";
 import {
   encodeURLObject,
   extractLayerTimeValues,
+  normalizeNodata,
+  normalizeRescale,
   resolveRenders,
 } from "./helpers";
 import { useSTAcStore } from "@/store/stac";
@@ -248,17 +250,21 @@ async function createMosaicLayers(mosaicEndpoint, params) {
   }
 
   const renderParamsStr = encodeURLObject({
-    assets: preset.assets,
+    // TiTiler treats assets and expression as mutually exclusive band selection
+    assets: preset.expression ? undefined : preset.assets,
     expression: preset.expression,
-    nodata: preset.nodata,
+    nodata: normalizeNodata(preset.nodata),
     resampling: preset.resampling,
     color_formula: preset.color_formula,
     colormap: preset.colormap,
     colormap_name: preset.colormap_name,
-    rescale: preset.rescale,
+    rescale: normalizeRescale(preset.rescale),
   });
 
-  const tileParams = new URLSearchParams({ tilesize: "512", ...params });
+  const tileParams = new URLSearchParams({
+    tilesize: `${preset.tilesize ?? "512"}`,
+    ...params,
+  });
   const tileJsonUrl = `${mosaicEndpoint}?${renderParamsStr}${tileParams.toString()}`;
 
   const tileJSON = await axios

--- a/core/client/types.ts
+++ b/core/client/types.ts
@@ -648,6 +648,10 @@ export interface Render {
   expression?: string;
   /** Zoom levels range applicable for the visualization */
   minmax_zoom?: number[];
+  /** Band indexes to apply the rendering to. */
+  bidx?: number[];
+  /** Tile size to request from the tile server. */
+  tilesize?: number;
 }
 /** @ignore */
 export interface TitilerSTACParameters {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@eox/jsonform": "^1.12.1",
         "@eox/layercontrol": "^1.8.0",
         "@eox/layout": "^1.0.0",
-        "@eox/map": "^2.7.0",
+        "@eox/map": "https://pkg.pr.new/EOX-A/EOxElements/@eox/map@1654196",
         "@eox/stacinfo": "^1.2.0",
         "@eox/timecontrol": "^2.6.0",
         "@eox/ui": "^1.1.0",
@@ -1265,7 +1265,7 @@
     },
     "node_modules/@eox/elements-utils": {
       "version": "1.2.0",
-      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/elements-utils@476eb30400cd1eb84a18869610ece33e5ba3e50f",
+      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/elements-utils@62ff47cdd5925f8ae1db6fb3dd2fdfc711c6d494",
       "integrity": "sha512-xMqkbMsmchnvpQSUeus57n7J6gW23QiS/AzP9TQkoEjMTsMZO0lLUNV+/vfTjuOUVLgzK+iSySF0CwRh06O86A==",
       "dependencies": {
         "@eox/ui": "^1.1.0"
@@ -1709,8 +1709,8 @@
     },
     "node_modules/@eox/map": {
       "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@eox/map/-/map-2.7.0.tgz",
-      "integrity": "sha512-DsSz2cWzaUcLphsMai9LSCGd3etqVqIX783DIOd32zRR0VY62DbpkgqzYI0Bx1656+4wTs7pM7eaPbCvIgf2rg==",
+      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/map@1654196",
+      "integrity": "sha512-7jKOx/AgFwqTmFN7lYMxQKh48CUdQ34q4FI+CjVWwij6Czbn1vrE4LyPM4+coXvuwdPTTpxR4uFQzAamou8uYA==",
       "dependencies": {
         "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@eox/jsonform": "^1.12.1",
         "@eox/layercontrol": "^1.8.0",
         "@eox/layout": "^1.0.0",
-        "@eox/map": "https://pkg.pr.new/EOX-A/EOxElements/@eox/map@1654196",
+        "@eox/map": "^2.7.0",
         "@eox/stacinfo": "^1.2.0",
         "@eox/timecontrol": "^2.6.0",
         "@eox/ui": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@eox/jsonform": "^1.12.1",
     "@eox/layercontrol": "^1.8.0",
     "@eox/layout": "^1.0.0",
-    "@eox/map": "^2.7.0",
+    "@eox/map": "https://pkg.pr.new/EOX-A/EOxElements/@eox/map@1654196",
     "@eox/stacinfo": "^1.2.0",
     "@eox/timecontrol": "^2.6.0",
     "@eox/ui": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "@eox/jsonform": "^1.12.1",
     "@eox/layercontrol": "^1.8.0",
     "@eox/layout": "^1.0.0",
-    "@eox/map": "https://pkg.pr.new/EOX-A/EOxElements/@eox/map@1654196",
+    "@eox/map": "^2.7.0",
     "@eox/stacinfo": "^1.2.0",
     "@eox/timecontrol": "^2.6.0",
     "@eox/ui": "^1.1.0",

--- a/templates/compare.js
+++ b/templates/compare.js
@@ -41,7 +41,6 @@ export default {
                 },
                 source: {
                   type: "XYZ",
-                  //@ts-expect-error todo
                   url: "https://s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/g/{z}/{y}/{x}.jpeg",
                 },
               },

--- a/templates/expert.js
+++ b/templates/expert.js
@@ -40,7 +40,6 @@ export default {
                 },
                 source: {
                   type: "XYZ",
-                  //@ts-expect-error todo
                   url: "https://s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/g/{z}/{y}/{x}.jpeg",
                 },
               },

--- a/templates/lite.js
+++ b/templates/lite.js
@@ -33,7 +33,6 @@ export default {
             },
             source: {
               type: "XYZ",
-              //@ts-expect-error todo
               url: "https://s2maps-tiles.eu/wmts/1.0.0/terrain-light_3857/default/g/{z}/{y}/{x}.jpeg",
             },
           },

--- a/widgets/EodashItemCatalog/methods/map.js
+++ b/widgets/EodashItemCatalog/methods/map.js
@@ -46,7 +46,6 @@ export function renderItemsFeatures(
     },
     source: {
       type: "Vector",
-      //@ts-expect-error todo
       url:
         "data:application/geo+json," +
         encodeURIComponent(

--- a/widgets/EodashMap/methods/btns.js
+++ b/widgets/EodashMap/methods/btns.js
@@ -76,37 +76,38 @@ function showAllPanels() {
 }
 /**
  *
- * @param {import("@eox/map").EoxLayer[]} layers
- * @return {import("@eox/map").EoxLayer[]}
+ * @param {import("@eox/map").EoxLayer[]} layers - eox map layers
+ * @returns {import("@eox/map").EoxLayer[]} anonymized Cors
  */
 function addCorsAnonym(layers) {
-  //@ts-expect-error todo
-  return layers.map((layer) => {
-    if (layer.type === "Group") {
-      layer.layers = addCorsAnonym([...(layer.layers ?? [])]);
-      return layer;
-    }
-    // check if not mapbox style as a fix for ts error
-    if (layer.type === "MapboxStyle") {
-      return layer;
-    }
+  return /** @type {import("@eox/map").EoxLayer[]} */ (
+    layers.map((layer) => {
+      if (layer.type === "Group") {
+        layer.layers = addCorsAnonym([...(layer.layers ?? [])]);
+        return layer;
+      }
+      // check if not mapbox style as a fix for ts error
+      if (layer.type === "MapboxStyle") {
+        return layer;
+      }
 
-    return {
-      ...layer,
-      ...(layer.source && {
-        source: {
-          ...layer.source,
-          crossOrigin: "anonymous",
-        },
-        ...(layer.sources && {
-          sources: layer.sources.map((source) => ({
-            ...source,
+      return {
+        ...layer,
+        ...("source" in layer && {
+          source: {
+            ...layer.source,
             crossOrigin: "anonymous",
-          })),
+          },
+          ...(layer.sources && {
+            sources: layer.sources.map((source) => ({
+              ...source,
+              crossOrigin: "anonymous",
+            })),
+          }),
         }),
-      }),
-    };
-  });
+      };
+    })
+  );
 }
 
 export const onMapZoomOut = () => {

--- a/widgets/EodashProcess/methods/outputs.js
+++ b/widgets/EodashProcess/methods/outputs.js
@@ -421,7 +421,6 @@ export async function processVector(links, jsonformValue, layerId) {
       type: "Vector",
       source: {
         type: "Vector",
-        //@ts-expect-error TODO
         url: mustache.render(link.href, {
           ...(jsonformValue ?? {}),
         }),

--- a/widgets/EodashProcess/methods/utils.js
+++ b/widgets/EodashProcess/methods/utils.js
@@ -89,10 +89,10 @@ export async function createTiffLayerDefinition(
   }
   // We want to make sure the urls are alphabetically sorted
   urls = urls.sort();
-  /** @type {import("@eox/map/src/layers").EOxLayerType<"WebGLTile","GeoTIFF"> | undefined} */
+
   const layerdef =
     urls.length > 0
-      ? {
+      ? /** @type {import("@eox/map/src/layers").EOxLayerType<"WebGLTile","GeoTIFF">} */ ({
           type: "WebGLTile",
           source: {
             type: "GeoTIFF",
@@ -106,7 +106,7 @@ export async function createTiffLayerDefinition(
             layerControlToolsExpand: true,
           },
           ...(style && { style: style }),
-        }
+        })
       : undefined;
 
   // We want to see if the currently selected indicator uses a
@@ -309,31 +309,33 @@ export async function creatAsyncProcessLayerDefinitions(
 
     switch (resultItem.type) {
       case "image/tiff": {
-        layers.push({
-          type: "WebGLTile",
-          properties: {
-            id: endpointLink.id + "_process" + resultItem.id + postfixId,
-            title:
-              "Results " +
-              (selectedStac?.id ?? "") +
-              " " +
-              (resultItem.id ?? ""),
-            layerControlToolsExpand: true,
-            ...(layerConfig && { layerConfig }),
-            ...extraProperties,
-          },
-          source: {
-            type: "GeoTIFF",
-            normalize: !style,
-            sources: resultItem.urls.map((url) => ({ url })),
-            //@ts-expect-error TODO
-            ...(selectedStac["eodash:mapProjection"]?.["name"] && {
+        layers.push(
+          /** @type {import("@eox/map/src/layers").EOxLayerType<"WebGLTile","GeoTIFF">} */ ({
+            type: "WebGLTile",
+            properties: {
+              id: endpointLink.id + "_process" + resultItem.id + postfixId,
+              title:
+                "Results " +
+                (selectedStac?.id ?? "") +
+                " " +
+                (resultItem.id ?? ""),
+              layerControlToolsExpand: true,
+              ...(layerConfig && { layerConfig }),
+              ...extraProperties,
+            },
+            source: {
+              type: "GeoTIFF",
+              normalize: !style,
+              sources: resultItem.urls.map((url) => ({ url })),
               //@ts-expect-error TODO
-              projection: selectedStac["eodash:mapProjection"]["name"],
-            }),
-          },
-          ...(style && { style }),
-        });
+              ...(selectedStac["eodash:mapProjection"]?.["name"] && {
+                //@ts-expect-error TODO
+                projection: selectedStac["eodash:mapProjection"]["name"],
+              }),
+            },
+            ...(style && { style }),
+          }),
+        );
         break;
       }
       case "application/geo+json": {


### PR DESCRIPTION
This pull request introduces support for rendering `tilejson` links in STAC items and collections, by fetching the TileJSON metadata and use the contained tile URL as an XYZ source. In case an XYZ and TileJSON links are present in one item, the client prioritizes XYZ links other ways it renders the TileJSON.

Additionally, normalization of the render extension parameters for compatibility with TiTiler, and improved logic for selecting and merging render presets, as well as minor fixes and code cleanups.
 
Update: This PR only supports raster and raster array XYZ tileJSON, and does not support TMS schemes nor Vector layers
 
## Checklist

- [x] ran `npm run format` and `npm run check` pass
- [ ] ~Docs under `docs/` updated for any public API, config, or behavior change~
- [ ] ~New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](../docs/eodash-store.md) reference is generated from it~
- [ ] ~New widget props use the appropriate `/** @type {import("vue").PropType<T>} */` and they appear typed in the API reference~
