### PR TITLE
feat: Persist rasterform state

### DIFF
--- a/core/client/eodashSTAC/EodashCollection.js
+++ b/core/client/eodashSTAC/EodashCollection.js
@@ -49,6 +49,12 @@ export class EodashCollection {
   /** @type {string | undefined} */
   color;
 
+  /**
+   * Which map this collection is rendered on.
+   * @type {import("@/types").MapKey}
+   */
+  map = "main";
+
   //  read only
   get collectionStac() {
     return this.#collectionStac;
@@ -225,6 +231,7 @@ export class EodashCollection {
         layerDatetime,
         extraProperties,
         this.#collectionStac,
+        this.map,
       );
 
       jsonArray.push(
@@ -237,6 +244,7 @@ export class EodashCollection {
           layerDatetime,
           extraProperties,
           this.#collectionStac,
+          this.map,
         )),
         ...((this.rasterEndpoint &&
           (await createLayerFromRender(
@@ -247,6 +255,7 @@ export class EodashCollection {
               ...extraProperties,
               ...(layerDatetime && { layerDatetime }),
             },
+            this.map,
           ))) ||
           []),
       );
@@ -254,7 +263,13 @@ export class EodashCollection {
       // get the correct style which is not attached to a link
       const id = this.#collectionStac?.id ?? "";
       const styles = await fetchStyle(item);
-      let { layerConfig, style } = extractLayerConfig(id, styles);
+      let { layerConfig, style } = extractLayerConfig(
+        id,
+        styles,
+        undefined,
+        undefined,
+        this.map,
+      );
       // fallback to STAC
       const json = {
         type: "STAC",

--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -19,6 +19,7 @@ import {
   normalizeRescale,
   normalizeNodata,
   resolveRenders,
+  applyRasterFormValue,
 } from "./helpers";
 import { handleAuthenticationOfLink } from "./auth";
 import log from "loglevel";
@@ -539,6 +540,7 @@ export const createLayersFromLinks = async (
         ...extractEoxLegendLink(wmsLink),
       };
     }
+    applyRasterFormValue(json, collectionId);
     jsonArray.push(json);
   }
 
@@ -647,6 +649,7 @@ export const createLayersFromLinks = async (
         ...extractEoxLegendLink(wmtsLink),
       };
     }
+    applyRasterFormValue(json, collectionId);
     jsonArray.push(json);
   }
 
@@ -731,6 +734,7 @@ export const createLayersFromLinks = async (
         ...extractEoxLegendLink(xyzLink),
       };
     }
+    applyRasterFormValue(json, collectionId);
     jsonArray.push(json);
   }
 
@@ -821,6 +825,7 @@ export const createLayersFromLinks = async (
         ...extractEoxLegendLink(tilejsonLink),
       };
     }
+    applyRasterFormValue(json, collectionId);
     jsonArray.push(json);
   }
 
@@ -1083,6 +1088,7 @@ export const createLayerFromRender = async (
         tileSize: [renders[key].tilesize, renders[key].tilesize],
       };
     }
+    applyRasterFormValue(json, collection.id);
     layers.push(json);
   }
 

--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -51,6 +51,7 @@ function buildCapabilitiesUrl(href) {
  * @param {Record<string, unknown>} [layerDatetime]
  * @param {object | null} [extraProperties]
  * @param {import("stac-ts").StacCollection | null} [collection] - Used to fall back to a collection-level style link.
+ * @param {import("@/types").MapKey} [map] - which map the layers are built for
  **/
 export async function createLayersFromAssets(
   collectionId,
@@ -60,6 +61,7 @@ export async function createLayersFromAssets(
   layerDatetime,
   extraProperties,
   collection,
+  map = "main",
 ) {
   log.debug("Creating layers from assets");
   const jsonArray = [];
@@ -178,7 +180,13 @@ export async function createLayersFromAssets(
         assetName,
       );
       // get the correct style which is not attached to a link
-      let { layerConfig, style } = extractLayerConfig(collectionId, styles);
+      let { layerConfig, style } = extractLayerConfig(
+      collectionId,
+      styles,
+      undefined,
+      undefined,
+      map,
+    );
       let assetLayerId = createAssetID(
         collectionId,
         stacObject.id,
@@ -234,6 +242,9 @@ export async function createLayersFromAssets(
       const { layerConfig, style } = extractLayerConfig(
         collectionId,
         fetchedStyle,
+        undefined,
+        undefined,
+        map,
       );
       const bandsPath = getBandsProperty(layerConfig?.schema);
       const defaultBands = bandsPath?.reduce(
@@ -285,7 +296,13 @@ export async function createLayersFromAssets(
         assetName,
       );
       // get the correct style which is not attached to a link
-      let { layerConfig, style } = extractLayerConfig(collectionId, styles);
+      let { layerConfig, style } = extractLayerConfig(
+      collectionId,
+      styles,
+      undefined,
+      undefined,
+      map,
+    );
       let assetLayerId = createAssetID(
         collectionId,
         stacObject.id,
@@ -356,7 +373,13 @@ export async function createLayersFromAssets(
         assetName,
       );
       // get the correct style which is not attached to a link
-      let { layerConfig, style } = extractLayerConfig(collectionId, styles);
+      let { layerConfig, style } = extractLayerConfig(
+      collectionId,
+      styles,
+      undefined,
+      undefined,
+      map,
+    );
       let assetLayerId = createAssetID(collectionId, stacObject.id, fgbIdx[i]);
       if (
         assets[assetName]?.roles?.includes("overlay") ||
@@ -424,6 +447,7 @@ export async function createLayersFromAssets(
  * @param {Record<string,any>} [layerDatetime]
  * @param {object | null} [extraProperties]
  * @param {import('stac-ts').StacCollection} [collection]
+ * @param {import("@/types").MapKey} [map] - which map the layers are built for
  */
 export const createLayersFromLinks = async (
   collectionId,
@@ -432,6 +456,7 @@ export const createLayersFromLinks = async (
   layerDatetime,
   extraProperties,
   collection,
+  map = "main",
 ) => {
   log.debug("Creating layers from links");
   /** @type {Record<string,any>[]} */
@@ -481,6 +506,7 @@ export const createLayersFromLinks = async (
       {},
       rasterForm,
       "tileUrl",
+      map,
     );
 
     log.debug("WMS Layer added", linkId);
@@ -540,7 +566,7 @@ export const createLayersFromLinks = async (
         ...extractEoxLegendLink(wmsLink),
       };
     }
-    applyRasterFormValue(json, collectionId);
+    applyRasterFormValue(json, collectionId, map);
     jsonArray.push(json);
   }
 
@@ -565,6 +591,7 @@ export const createLayersFromLinks = async (
       {},
       rasterForm,
       "tileUrl",
+      map,
     );
     const projectionCode = getProjectionCode(wmtsLinkProjection || "EPSG:3857");
     // TODO: WARNING! This is a temporary project specific implementation
@@ -649,7 +676,7 @@ export const createLayersFromLinks = async (
         ...extractEoxLegendLink(wmtsLink),
       };
     }
-    applyRasterFormValue(json, collectionId);
+    applyRasterFormValue(json, collectionId, map);
     jsonArray.push(json);
   }
 
@@ -669,6 +696,7 @@ export const createLayersFromLinks = async (
       {},
       rasterForm,
       "tileUrl",
+      map,
     );
     await registerProjection(xyzLinkProjection);
     const projectionCode = getProjectionCode(xyzLinkProjection || "EPSG:3857");
@@ -734,7 +762,7 @@ export const createLayersFromLinks = async (
         ...extractEoxLegendLink(xyzLink),
       };
     }
-    applyRasterFormValue(json, collectionId);
+    applyRasterFormValue(json, collectionId, map);
     jsonArray.push(json);
   }
 
@@ -781,6 +809,7 @@ export const createLayersFromLinks = async (
       {},
       rasterForm,
       "tileUrl",
+      map,
     );
     const linkId = createLayerID(
       collectionId,
@@ -825,7 +854,7 @@ export const createLayersFromLinks = async (
         ...extractEoxLegendLink(tilejsonLink),
       };
     }
-    applyRasterFormValue(json, collectionId);
+    applyRasterFormValue(json, collectionId, map);
     jsonArray.push(json);
   }
 
@@ -850,7 +879,13 @@ export const createLayersFromLinks = async (
     // fetch styles and separate them by their mapping between links and assets
     const styles = await resolveStyle(item, collection, key);
     // get the correct style which is not attached to a link
-    let { layerConfig, style } = extractLayerConfig(collectionId, styles);
+    let { layerConfig, style } = extractLayerConfig(
+      collectionId,
+      styles,
+      undefined,
+      undefined,
+      map,
+    );
 
     let href = vectorTileLink.href;
     if ("auth:schemes" in item && "auth:refs" in vectorTileLink) {
@@ -972,6 +1007,7 @@ export const createLayersFromLinks = async (
  * @param {import("stac-ts").StacItem | undefined | null} item
  * @param {string} rasterURL
  * @param {Record<string, any>} [extraProperties]
+ * @param {import("@/types").MapKey} [map] - which map the layers are built for
  * @returns {Promise<import("@eox/map/src/layers").EOxLayerType<"Tile","XYZ">[]>}
  */
 export const createLayerFromRender = async (
@@ -979,6 +1015,7 @@ export const createLayerFromRender = async (
   collection,
   item,
   extraProperties,
+  map = "main",
 ) => {
   // config renders > collection STAC renders > item renders
   const renders = /** @type {Record<string,import("@/types").Render>} */ (
@@ -1003,7 +1040,13 @@ export const createLayerFromRender = async (
       item?.["eodash:rasterform"] || collection?.["eodash:rasterform"]
     ),
   );
-  let { layerConfig } = extractLayerConfig(collection.id, {}, rasterForm);
+  let { layerConfig } = extractLayerConfig(
+    collection.id,
+    {},
+    rasterForm,
+    undefined,
+    map,
+  );
 
   /**
    * Resolves the first defined value of a property across a render's assets,
@@ -1088,7 +1131,7 @@ export const createLayerFromRender = async (
         tileSize: [renders[key].tilesize, renders[key].tilesize],
       };
     }
-    applyRasterFormValue(json, collection.id);
+    applyRasterFormValue(json, collection.id, map);
     layers.push(json);
   }
 

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -4,7 +4,7 @@ import log from "loglevel";
 import mustache from "mustache";
 import { updateVectorLayerStyle } from "@eox/layercontrol";
 import { getStyleVariablesState } from "./triggers.js";
-import { itemsCache, splitItemsCache } from "@/utils/states.js";
+import { itemsCache, splitItemsCache, rasterFormValue } from "@/utils/states.js";
 
 /**
  *  @param {import("stac-ts").StacLink[]} [links]
@@ -1334,6 +1334,80 @@ export function updateLayerUrl(olLayer, jsonformValue) {
   }
 
   return false;
+}
+
+/**
+ * Injects jsonform values into a tile URL.
+ * Nested objects are spread into their sub-keys, arrays become repeated params.
+ * Keeps parity so a baked URL matches what a live jsonform edit would produce.
+ *
+ * @param {string} url
+ * @param {Record<string, any>} values
+ * @returns {string}
+ */
+function applyValuesToUrl(url, values) {
+  const [base, query] = url.split("?");
+  const searchParams = new URLSearchParams(query || "");
+  for (const [key, value] of Object.entries(values)) {
+    if (value === undefined || value === null || value === "") {
+      continue;
+    }
+    if (Array.isArray(value)) {
+      searchParams.delete(key);
+      value.forEach((v) => searchParams.append(key, String(v)));
+    } else if (typeof value === "object") {
+      for (const [k, v] of Object.entries(value)) {
+        if (v !== undefined && v !== null && v !== "") {
+          searchParams.set(k, String(v));
+        }
+      }
+    } else {
+      searchParams.set(key, String(value));
+    }
+  }
+  const qs = searchParams.toString();
+  return qs ? `${base}?${qs}` : base;
+}
+
+/**
+ * Bakes the last user-selected rasterform value (see {@link rasterFormValue}) into a
+ * freshly built tileUrl layer so the selection survives a time/item rebuild. Values
+ * are written into the source (WMS params or the tile URL) because eox reads initial
+ * values back from there (`getStartVals`) and overwrites by param key on live edits.
+ * Mutates the layer in place.
+ * @param {Record<string, any>} layer - built layer json
+ * @param {string} collectionId
+ */
+export function applyRasterFormValue(layer, collectionId) {
+  if (layer?.properties?.layerConfig?.type !== "tileUrl") {
+    return;
+  }
+  const value = rasterFormValue.value[collectionId];
+  const source = layer.source;
+  console.log(
+    "[DBG-RF] bake id:",
+    layer.properties?.id,
+    "key:",
+    collectionId,
+    "cachedValue:",
+    value,
+    "urlBefore:",
+    source?.url,
+  );
+  if (!source || !value || !Object.keys(value).length) {
+    return;
+  }
+  if (source.params) {
+    // WMS: applied via updateParams, read back via getParams
+    Object.assign(source.params, value);
+    return;
+  }
+  if (typeof source.url === "string") {
+    source.url = applyValuesToUrl(source.url, value);
+  } else if (Array.isArray(source.urls)) {
+    //@ts-expect-error todo
+    source.urls = source.urls.map((u) => applyValuesToUrl(u, value));
+  }
 }
 
 /**

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -3,8 +3,11 @@ import axios from "@/plugins/axios";
 import log from "loglevel";
 import mustache from "mustache";
 import { updateVectorLayerStyle } from "@eox/layercontrol";
-import { getStyleVariablesState } from "./triggers.js";
-import { itemsCache, splitItemsCache, rasterFormValue } from "@/utils/states.js";
+import {
+  itemsCache,
+  splitItemsCache,
+  layerConfigFormState,
+} from "@/utils/states.js";
 
 /**
  *  @param {import("stac-ts").StacLink[]} [links]
@@ -68,10 +71,10 @@ export async function fetchRasterForm(rasterform) {
  * Spearates and extracts layerConfig (jsonform schema & legend) from a style json
  *
  * @param {string} collectionId
- *  @param { import("@/types").EodashStyleJson} [style]
+ * @param { import("@/types").EodashStyleJson} [style]
  * @param {Record<string,any>} [rasterJsonform]
- * @param {string} [layerConfigType]
- * */
+ * @param {"style" | "tileUrl"} [layerConfigType]
+ **/
 export function extractLayerConfig(
   collectionId,
   style,
@@ -85,14 +88,19 @@ export function extractLayerConfig(
     style = { ...style };
   }
 
-  if (style?.variables && Object.keys(style.variables ?? {}).length) {
-    style.variables = getStyleVariablesState(collectionId, style.variables);
+  if (style?.variables) {
+    // render the saved rescale/gamma from the first frame
+    style.variables = applyStyleVariables(collectionId, style.variables);
   }
 
   if (rasterJsonform) {
     return {
       layerConfig: {
-        schema: rasterJsonform.jsonform,
+        schema: restorePersistedSchema(
+          rasterJsonform.jsonform,
+          collectionId,
+          "tileUrl",
+        ),
         legend: rasterJsonform.legend,
         type: "tileUrl",
       },
@@ -100,12 +108,16 @@ export function extractLayerConfig(
     };
   }
 
-  /** @type {Record<string,unknown> | undefined} */
+  /** @type {import("@/types").EodashLayerConfig | undefined} */
   let layerConfig = undefined;
 
   if (style?.jsonform) {
     // this explicitly sets legend only if jsonform is configured
-    layerConfig = { schema: style.jsonform, type: layerConfigType || "style" };
+    const type = layerConfigType || "style";
+    layerConfig = {
+      schema: restorePersistedSchema(style.jsonform, collectionId, type),
+      type,
+    };
     delete style.jsonform;
     if (style?.legend) {
       layerConfig.legend = style.legend;
@@ -118,6 +130,180 @@ export function extractLayerConfig(
   );
 
   return { layerConfig, style };
+}
+
+/**
+ * Deep-clones `schema` and overwrites each leaf property's `default` with the
+ * matching entry in `values` (keyed by property name), walking nested
+ * `properties`, `oneOf`/`allOf`/`anyOf` branches and local `$ref`s. Leaves the
+ * original schema untouched so shared/cached schemas are not mutated.
+ *
+ * @param {Record<string, any>} schema
+ * @param {Record<string, any>} values - Flat map of property name -> persisted value.
+ * @returns {Record<string, any>}
+ */
+export function seedSchemaDefaults(schema, values) {
+  if (!schema || typeof schema !== "object" || !values) return schema;
+  const cloned = JSON.parse(JSON.stringify(schema));
+
+  /**
+   * @param {Record<string, any> | undefined} node
+   * @param {Set<string>} seenRefs
+   */
+  const walk = (node, seenRefs) => {
+    if (!node || typeof node !== "object") return;
+    if (typeof node.$ref === "string" && !seenRefs.has(node.$ref)) {
+      walk(
+        resolveLocalRef(node.$ref, cloned),
+        new Set([...seenRefs, node.$ref]),
+      );
+    }
+    if (node.properties) {
+      for (const [key, propSchema] of Object.entries(node.properties)) {
+        if (
+          key in values &&
+          /** @type {any} */ (propSchema)?.type !== "object"
+        ) {
+          /** @type {any} */ (propSchema).default = JSON.parse(
+            JSON.stringify(values[key]),
+          );
+        } else {
+          walk(/** @type {any} */ (propSchema), seenRefs);
+        }
+      }
+    }
+    for (const combinator of ["oneOf", "allOf", "anyOf"]) {
+      if (Array.isArray(node[combinator]))
+        node[combinator].forEach((/** @type {any} */ branch) =>
+          walk(branch, seenRefs),
+        );
+    }
+  };
+  walk(cloned, new Set());
+  return cloned;
+}
+
+/**
+ * Resolves a local `$ref` pointer (e.g. `#/definitions/foo`) against `rootSchema`.
+ *
+ * @param {string} ref
+ * @param {Record<string, any>} rootSchema
+ * @returns {Record<string, any> | undefined}
+ */
+function resolveLocalRef(ref, rootSchema) {
+  if (!ref.startsWith("#/")) return undefined;
+  return ref
+    .slice(2)
+    .split("/")
+    .reduce(
+      (node, part) => node?.[part.replace(/~1/g, "/").replace(/~0/g, "~")],
+      rootSchema,
+    );
+}
+
+/**
+ * Flattens a nested jsonform value into a single map keyed by leaf property name
+ * (e.g. `{ rescaleRed: { minRed, maxRed } }` -> `{ minRed, maxRed }`). Arrays are
+ * kept whole (bands stay a single value).
+ * @param {Record<string, any>} obj
+ * @returns {Record<string, any>}
+ */
+export function flattenFormValues(obj) {
+  /** @type {Record<string, any>} */
+  const result = {};
+  for (const key in obj) {
+    if (
+      obj[key] !== null &&
+      typeof obj[key] === "object" &&
+      !Array.isArray(obj[key])
+    ) {
+      Object.assign(result, flattenFormValues(obj[key]));
+    } else {
+      result[key] = obj[key];
+    }
+  }
+  return result;
+}
+
+/**
+ * @param {string} collectionId
+ * @param {"style" | "tileUrl"} type
+ * @returns {Record<string, any> | undefined}
+ */
+function getCachedConfig(collectionId, type) {
+  return layerConfigFormState.value[collectionId]?.[type];
+}
+
+/**
+ * Remembers a layer config editor's current value (see {@link layerConfigFormState})
+ * so it can be restored after a time/item rebuild. Call from the `layerConfig:change`
+ * handler.
+ * @param {import("ol/layer/Layer").default} olLayer - layer from the change event
+ * @param {Record<string, any>} value - current jsonform value
+ */
+export function persistLayerConfigState(olLayer, value) {
+  const type = olLayer.get("_jsonDefinition")?.properties?.layerConfig?.type;
+  const [collectionId] = (olLayer.get("id") ?? "").split(";:;");
+  if (!collectionId || (type !== "style" && type !== "tileUrl")) return;
+  (layerConfigFormState.value[collectionId] ??= {})[type] = value;
+}
+
+/**
+ * Restores a remembered selection onto a rebuilt schema by seeding its leaf
+ * defaults — the channel the range/minmax and bands editors honor on a fresh
+ * mount (they ignore startval).
+ * @param {Record<string, any>} schema
+ * @param {string} collectionId
+ * @param {"style" | "tileUrl"} type
+ * @returns {Record<string, any>} seeded schema (original untouched)
+ */
+export function restorePersistedSchema(schema, collectionId, type) {
+  const cached = getCachedConfig(collectionId, type);
+  if (!cached || !Object.keys(cached).length) return schema;
+  return seedSchemaDefaults(schema, flattenFormValues(cached));
+}
+
+/**
+ * Mirrors the remembered style variables onto a rebuilt style so the layer
+ * renders the saved rescale/gamma from the first frame.
+ * @param {string} collectionId
+ * @param {Record<string, any>} [variables]
+ * @returns {Record<string, any> | undefined}
+ */
+export function applyStyleVariables(collectionId, variables) {
+  const cached = getCachedConfig(collectionId, "style");
+  if (!cached || !variables) return variables;
+  const values = flattenFormValues(cached);
+  const merged = { ...variables };
+  for (const key of Object.keys(merged)) {
+    if (key in values) merged[key] = values[key];
+  }
+  return merged;
+}
+
+/**
+ * Writes the remembered tileUrl selection into a rebuilt layer's source (WMS
+ * params or the tile URL) so eox reads it back as the form's start values
+ * (`getStartVals`). Mutates in place.
+ * @param {Record<string, any>} layer - built layer json
+ * @param {string} collectionId
+ */
+export function applyRasterFormValue(layer, collectionId) {
+  if (layer?.properties?.layerConfig?.type !== "tileUrl") return;
+  const value = getCachedConfig(collectionId, "tileUrl");
+  const source = layer.source;
+  if (!source || !value || !Object.keys(value).length) return;
+  if (source.params) {
+    Object.assign(source.params, value);
+    return;
+  }
+  if (typeof source.url === "string") {
+    source.url = applyValuesToUrl(source.url, value);
+  } else if (Array.isArray(source.urls)) {
+    source.urls = /** @type {string[]} */ (source.urls).map((u) =>
+      applyValuesToUrl(u, value),
+    );
+  }
 }
 
 /**
@@ -641,26 +827,6 @@ export const removeUnneededProperties = (layers, formValues = {}) => {
     }
 
     // Flatten formValues to handle nested properties (e.g., vminmax: { vmin, vmax })
-    /**
-     * @param {Record<string,any>} obj
-     * @returns {Record<string,any>}
-     */
-    const flattenFormValues = (obj) => {
-      /** @type {Record<string,any>} */
-      let result = {};
-      for (const key in obj) {
-        if (
-          obj[key] !== null &&
-          typeof obj[key] === "object" &&
-          !Array.isArray(obj[key])
-        ) {
-          Object.assign(result, flattenFormValues(obj[key]));
-        } else {
-          result[key] = obj[key];
-        }
-      }
-      return result;
-    };
     const flatFormValues = flattenFormValues(formValues);
 
     // Burn in style variables using Mustache if formValues are provided
@@ -1367,47 +1533,6 @@ function applyValuesToUrl(url, values) {
   }
   const qs = searchParams.toString();
   return qs ? `${base}?${qs}` : base;
-}
-
-/**
- * Bakes the last user-selected rasterform value (see {@link rasterFormValue}) into a
- * freshly built tileUrl layer so the selection survives a time/item rebuild. Values
- * are written into the source (WMS params or the tile URL) because eox reads initial
- * values back from there (`getStartVals`) and overwrites by param key on live edits.
- * Mutates the layer in place.
- * @param {Record<string, any>} layer - built layer json
- * @param {string} collectionId
- */
-export function applyRasterFormValue(layer, collectionId) {
-  if (layer?.properties?.layerConfig?.type !== "tileUrl") {
-    return;
-  }
-  const value = rasterFormValue.value[collectionId];
-  const source = layer.source;
-  console.log(
-    "[DBG-RF] bake id:",
-    layer.properties?.id,
-    "key:",
-    collectionId,
-    "cachedValue:",
-    value,
-    "urlBefore:",
-    source?.url,
-  );
-  if (!source || !value || !Object.keys(value).length) {
-    return;
-  }
-  if (source.params) {
-    // WMS: applied via updateParams, read back via getParams
-    Object.assign(source.params, value);
-    return;
-  }
-  if (typeof source.url === "string") {
-    source.url = applyValuesToUrl(source.url, value);
-  } else if (Array.isArray(source.urls)) {
-    //@ts-expect-error todo
-    source.urls = source.urls.map((u) => applyValuesToUrl(u, value));
-  }
 }
 
 /**

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -74,12 +74,14 @@ export async function fetchRasterForm(rasterform) {
  * @param { import("@/types").EodashStyleJson} [style]
  * @param {Record<string,any>} [rasterJsonform]
  * @param {"style" | "tileUrl"} [layerConfigType]
+ * @param {import("@/types").MapKey} [map]
  **/
 export function extractLayerConfig(
   collectionId,
   style,
   rasterJsonform,
   layerConfigType,
+  map = "main",
 ) {
   if (!style && !rasterJsonform) {
     return { layerConfig: undefined, style: undefined };
@@ -90,7 +92,7 @@ export function extractLayerConfig(
 
   if (style?.variables) {
     // render the saved rescale/gamma from the first frame
-    style.variables = applyStyleVariables(collectionId, style.variables);
+    style.variables = applyStyleVariables(collectionId, style.variables, map);
   }
 
   if (rasterJsonform) {
@@ -100,6 +102,7 @@ export function extractLayerConfig(
           rasterJsonform.jsonform,
           collectionId,
           "tileUrl",
+          map,
         ),
         legend: rasterJsonform.legend,
         type: "tileUrl",
@@ -115,7 +118,7 @@ export function extractLayerConfig(
     // this explicitly sets legend only if jsonform is configured
     const type = layerConfigType || "style";
     layerConfig = {
-      schema: restorePersistedSchema(style.jsonform, collectionId, type),
+      schema: restorePersistedSchema(style.jsonform, collectionId, type, map),
       type,
     };
     delete style.jsonform;
@@ -228,10 +231,11 @@ export function flattenFormValues(obj) {
 /**
  * @param {string} collectionId
  * @param {"style" | "tileUrl"} type
+ * @param {import("@/types").MapKey} map
  * @returns {Record<string, any> | undefined}
  */
-function getCachedConfig(collectionId, type) {
-  return layerConfigFormState.value[collectionId]?.[type];
+function getCachedConfig(collectionId, type, map) {
+  return layerConfigFormState.value[map]?.[collectionId]?.[type];
 }
 
 /**
@@ -240,12 +244,17 @@ function getCachedConfig(collectionId, type) {
  * handler.
  * @param {import("ol/layer/Layer").default} olLayer - layer from the change event
  * @param {Record<string, any>} value - current jsonform value
+ * @param {import("@/types").MapKey} [map] - which map the edit belongs to
  */
-export function persistLayerConfigState(olLayer, value) {
-  const type = olLayer.get("_jsonDefinition")?.properties?.layerConfig?.type;
+export function persistLayerConfigState(olLayer, value, map = "main") {
+  const layerConfig = olLayer.get("_jsonDefinition")?.properties?.layerConfig;
+  const type = layerConfig?.type;
   const [collectionId] = (olLayer.get("id") ?? "").split(";:;");
   if (!collectionId || (type !== "style" && type !== "tileUrl")) return;
-  (layerConfigFormState.value[collectionId] ??= {})[type] = value;
+  // form opted out of persistence (top level schema option)
+  if (layerConfig?.schema?.options?.persist_state === false) return;
+  const byCollection = (layerConfigFormState.value[map] ??= {});
+  (byCollection[collectionId] ??= {})[type] = value;
 }
 
 /**
@@ -255,10 +264,13 @@ export function persistLayerConfigState(olLayer, value) {
  * @param {Record<string, any>} schema
  * @param {string} collectionId
  * @param {"style" | "tileUrl"} type
+ * @param {import("@/types").MapKey} [map]
  * @returns {Record<string, any>} seeded schema (original untouched)
  */
-export function restorePersistedSchema(schema, collectionId, type) {
-  const cached = getCachedConfig(collectionId, type);
+export function restorePersistedSchema(schema, collectionId, type, map = "main") {
+  // form opted out of persistence
+  if (schema?.options?.persist_state === false) return schema;
+  const cached = getCachedConfig(collectionId, type, map);
   if (!cached || !Object.keys(cached).length) return schema;
   return seedSchemaDefaults(schema, flattenFormValues(cached));
 }
@@ -268,10 +280,11 @@ export function restorePersistedSchema(schema, collectionId, type) {
  * renders the saved rescale/gamma from the first frame.
  * @param {string} collectionId
  * @param {Record<string, any>} [variables]
+ * @param {import("@/types").MapKey} [map]
  * @returns {Record<string, any> | undefined}
  */
-export function applyStyleVariables(collectionId, variables) {
-  const cached = getCachedConfig(collectionId, "style");
+export function applyStyleVariables(collectionId, variables, map = "main") {
+  const cached = getCachedConfig(collectionId, "style", map);
   if (!cached || !variables) return variables;
   const values = flattenFormValues(cached);
   const merged = { ...variables };
@@ -287,14 +300,15 @@ export function applyStyleVariables(collectionId, variables) {
  * (`getStartVals`). Mutates in place.
  * @param {Record<string, any>} layer - built layer json
  * @param {string} collectionId
+ * @param {import("@/types").MapKey} [map]
  */
-export function applyRasterFormValue(layer, collectionId) {
+export function applyRasterFormValue(layer, collectionId, map = "main") {
   if (layer?.properties?.layerConfig?.type !== "tileUrl") return;
-  const value = getCachedConfig(collectionId, "tileUrl");
+  const value = getCachedConfig(collectionId, "tileUrl", map);
   const source = layer.source;
   if (!source || !value || !Object.keys(value).length) return;
   if (source.params) {
-    Object.assign(source.params, value);
+    Object.assign(source.params, flattenFormValues(value));
     return;
   }
   if (typeof source.url === "string") {

--- a/core/client/eodashSTAC/triggers.js
+++ b/core/client/eodashSTAC/triggers.js
@@ -4,7 +4,7 @@
 import { changeMapProjection, registerProjection } from "@/store/actions";
 import log from "loglevel";
 import { getProjectionCode } from "./helpers";
-import { availableMapProjection, mapEl } from "@/store/states";
+import { availableMapProjection } from "@/store/states";
 
 /**
  * checks if there's a projection on the Collection and
@@ -41,76 +41,3 @@ export const setMapProjFromCol = async (STAcCollection) => {
     await changeMapProjection((availableMapProjection.value = ""));
   }
 };
-/**
- *
- * @param {string} collectionId
- * @param {import("@/types").EodashStyleJson["variables"]} variables
- */
-export function getStyleVariablesState(collectionId, variables) {
-  const mapElement = /** @type {import("@eox/map").EOxMap} */ (mapEl.value);
-  if (!mapElement || !mapElement.layers.length || !variables) {
-    return variables;
-  }
-
-  const analysisGroup =
-    /** @type {import("@eox/map/src/layers").EOxLayerTypeGroup | undefined} */ (
-      mapElement.layers.find(
-        (layer) => layer.properties?.id === "AnalysisGroup",
-      )
-    );
-  if (!analysisGroup) {
-    return variables;
-  }
-  
-  const matchingLayers = (analysisGroup.layers ?? []).filter((layer) => {
-    const [collection] = layer.properties?.id.split(";:;") ?? [];
-    return collection === collectionId;
-  });
-  console.log(
-    "[DBG-SV] called",
-    collectionId,
-    "newKeys:",
-    Object.keys(variables),
-    "matching:",
-    matchingLayers.map((l) => l.properties?.id),
-  );
-
-  const styleVariablesKeys = Object.keys(variables);
-  for (const matchingLayer of matchingLayers) {
-    const olLayer = mapElement.getLayerById(matchingLayer.properties?.id ?? "");
-    const oldVariablesState =
-      /** @type {import("ol/layer").Vector} */ (
-        olLayer
-        //@ts-expect-error variables doesn't exist in non-flat style
-      ).getStyle?.()?.variables ??
-      //@ts-expect-error (styleVariables_ is a private property)
-      /** @type {import("ol/layer").WebGLTile} */ (olLayer).styleVariables_;
-
-    console.log(
-      "[DBG-SV] layer",
-      matchingLayer.properties?.id,
-      "oldVars:",
-      oldVariablesState && JSON.parse(JSON.stringify(oldVariablesState)),
-    );
-    if (!oldVariablesState) {
-      continue;
-    }
-    // Carry over the values for keys that still apply, keep the rest.
-    const sharedKeys = styleVariablesKeys.filter(
-      (key) => key in oldVariablesState,
-    );
-    if (!sharedKeys.length) {
-      continue;
-    }
-    const merged = {
-      ...variables,
-      ...Object.fromEntries(
-        sharedKeys.map((key) => [key, oldVariablesState[key]]),
-      ),
-    };
-    console.log("[DBG-SV] returning merged", merged);
-    return merged;
-  }
-  console.log("[DBG-SV] no match, returning defaults");
-  return variables;
-}

--- a/core/client/eodashSTAC/triggers.js
+++ b/core/client/eodashSTAC/triggers.js
@@ -61,41 +61,56 @@ export function getStyleVariablesState(collectionId, variables) {
   if (!analysisGroup) {
     return variables;
   }
-  const matchingLayer = analysisGroup.layers?.find((layer) => {
-    const [collection, ..._other] = layer.properties?.id.split(";:;") ?? [
-      "",
-      "",
-      "",
-    ];
+  
+  const matchingLayers = (analysisGroup.layers ?? []).filter((layer) => {
+    const [collection] = layer.properties?.id.split(";:;") ?? [];
     return collection === collectionId;
   });
+  console.log(
+    "[DBG-SV] called",
+    collectionId,
+    "newKeys:",
+    Object.keys(variables),
+    "matching:",
+    matchingLayers.map((l) => l.properties?.id),
+  );
 
-  if (!matchingLayer) {
-    return variables;
-  }
-  // TODO instead tap into store for changed variables state per layer
-  // because XYZ and WMTS use tileurlfunction update, where we can not retrieve
-  // current values from OL layers anyhow
-
-  const olLayer = mapElement.getLayerById(matchingLayer.properties?.id ?? "");
-  let oldVariablesState =
-    /** @type {import("ol/layer").Vector} */ (
-      olLayer
-      //@ts-expect-error variables doesn't exist in non-flat style
-    ).getStyle?.()?.variables ??
-    //@ts-expect-error (styleVariables_ is a private property)
-    /** @type {import("ol/layer").WebGLTile} */ (olLayer).styleVariables_;
-
-  if (!oldVariablesState) {
-    return variables;
-  }
   const styleVariablesKeys = Object.keys(variables);
-  const matchingKeys =
-    Object.keys(oldVariablesState).every((key) =>
-      styleVariablesKeys.includes(key),
-    ) &&
-    styleVariablesKeys.every((key) =>
-      Object.keys(oldVariablesState).includes(key),
+  for (const matchingLayer of matchingLayers) {
+    const olLayer = mapElement.getLayerById(matchingLayer.properties?.id ?? "");
+    const oldVariablesState =
+      /** @type {import("ol/layer").Vector} */ (
+        olLayer
+        //@ts-expect-error variables doesn't exist in non-flat style
+      ).getStyle?.()?.variables ??
+      //@ts-expect-error (styleVariables_ is a private property)
+      /** @type {import("ol/layer").WebGLTile} */ (olLayer).styleVariables_;
+
+    console.log(
+      "[DBG-SV] layer",
+      matchingLayer.properties?.id,
+      "oldVars:",
+      oldVariablesState && JSON.parse(JSON.stringify(oldVariablesState)),
     );
-  return matchingKeys ? oldVariablesState : variables;
+    if (!oldVariablesState) {
+      continue;
+    }
+    // Carry over the values for keys that still apply, keep the rest.
+    const sharedKeys = styleVariablesKeys.filter(
+      (key) => key in oldVariablesState,
+    );
+    if (!sharedKeys.length) {
+      continue;
+    }
+    const merged = {
+      ...variables,
+      ...Object.fromEntries(
+        sharedKeys.map((key) => [key, oldVariablesState[key]]),
+      ),
+    };
+    console.log("[DBG-SV] returning merged", merged);
+    return merged;
+  }
+  console.log("[DBG-SV] no match, returning defaults");
+  return variables;
 }

--- a/core/client/store/stac.js
+++ b/core/client/store/stac.js
@@ -238,6 +238,7 @@ export const useSTAcStore = defineStore("stac", () => {
           [...collectionsPalette].reverse(),
           isApi.value,
           rasterEndpoint.value,
+          "compare",
         );
         selectedCompareItem.value = /** @type {any} */ (stacItem) ?? undefined;
         selectedCompareStac.value = resp.data;

--- a/core/client/types.ts
+++ b/core/client/types.ts
@@ -522,6 +522,12 @@ export type EodashRasterJSONForm = {
   legend?: import("@eox/layercontrol/src/components/layer-config.js").EOxLayerControlLayerConfig["layerConfig"]["legend"];
 };
 /**
+ * Which map a layer/config belongs to: "main" map, "compare"
+ * map.
+ * @ignore
+ */
+export type MapKey = "main" | "compare";
+/**
  * layerConfig attached to a built layer, consumed by eox-layercontrol to render
  * the config editor. Produced by `extractLayerConfig`.
  * @ignore

--- a/core/client/types.ts
+++ b/core/client/types.ts
@@ -521,6 +521,17 @@ export type EodashRasterJSONForm = {
   jsonform: Record<string, any>;
   legend?: import("@eox/layercontrol/src/components/layer-config.js").EOxLayerControlLayerConfig["layerConfig"]["legend"];
 };
+/**
+ * layerConfig attached to a built layer, consumed by eox-layercontrol to render
+ * the config editor. Produced by `extractLayerConfig`.
+ * @ignore
+ */
+export type EodashLayerConfig = {
+  schema: Record<string, any>;
+  type: "style" | "tileUrl";
+  legend?: import("@eox/layercontrol/src/components/layer-config.js").EOxLayerControlLayerConfig["layerConfig"]["legend"];
+};
+
 /** @ignore */
 export type LayersEventBusKeys =
   | "layers:updated"

--- a/core/client/utils/index.js
+++ b/core/client/utils/index.js
@@ -162,6 +162,7 @@ export const setCollectionsPalette = (colors) => {
  * @param {string[]} colorPalette - The color palette to assign to each collection
  * @param {boolean} isAPI - Flag indicating if the collection is fetched from an API
  * @param {string | null} rasterEndpoint - Optional raster endpoint URL
+ * @param {import("@/types").MapKey} [map] - which map these collections belong to
  * @async
  * @description This function extracts collection URLs from the indicator, fetches collection data,
  * processes parquet items if available, and updates the eodashCollections array with new collection data.
@@ -174,6 +175,7 @@ export const updateEodashCollections = async (
   colorPalette,
   isAPI,
   rasterEndpoint = null,
+  map = "main",
 ) => {
   // init eodash collections
   const collectionUrls = extractCollectionUrls(selectedStac, absoluteUrl);
@@ -182,6 +184,7 @@ export const updateEodashCollections = async (
     collectionUrls.map((cu, idx) => {
       return new Promise((resolve, _reject) => {
         const ec = new EodashCollection(cu, isAPI, rasterEndpoint);
+        ec.map = map;
         ec.fetchCollection().then((col) => {
           // assign color from the palette
           ec.color = colorPalette[idx % colorPalette.length];

--- a/core/client/utils/states.js
+++ b/core/client/utils/states.js
@@ -50,6 +50,12 @@ export const layerControlFormValue = ref({});
 export const layerControlFormValueCompare = ref({});
 
 /**
+ * Current value of the rasterform (tileUrl) JSON form, keyed by collection id.
+ * @type {import("vue").Ref<Record<string, Record<string, any>>>}
+ */
+export const rasterFormValue = ref({});
+
+/**
  * STAC indicators color palette, defaults to Bank-Wong palette
  *  @type {string[]} */
 export const collectionsPalette = reactive([

--- a/core/client/utils/states.js
+++ b/core/client/utils/states.js
@@ -54,11 +54,12 @@ export const layerControlFormValueCompare = ref({});
  * choices persist when the map rebuilds — for example when the date or the
  * selected item changes.
  *
- * Entries are keyed by collection and editor kind (style vs. tile URL), which is
- * what keeps a choice through item/time changes and stops the style and raster
- * editors from overwriting one another. A collection that exposes two layers of
- * the same kind shares one slot.
- * @type {import("vue").Ref<Record<string, Record<string, any>>>}
+ * Entries are keyed by map (main vs. compare), then collection, then editor kind
+ * (style vs. tile URL): the map key keeps the two maps independent, the collection
+ * key keeps a choice through item/time changes, and the kind key stops the style
+ * and raster editors from overwriting one another. A collection that exposes two
+ * layers of the same kind shares one slot.
+ * @type {import("vue").Ref<Record<string, Record<string, Record<string, any>>>>}
  */
 export const layerConfigFormState = ref({});
 

--- a/core/client/utils/states.js
+++ b/core/client/utils/states.js
@@ -50,10 +50,17 @@ export const layerControlFormValue = ref({});
 export const layerControlFormValueCompare = ref({});
 
 /**
- * Current value of the rasterform (tileUrl) JSON form, keyed by collection id.
+ * Remembers each layer's configuration form values so a user's styling and band
+ * choices persist when the map rebuilds — for example when the date or the
+ * selected item changes.
+ *
+ * Entries are keyed by collection and editor kind (style vs. tile URL), which is
+ * what keeps a choice through item/time changes and stops the style and raster
+ * editors from overwriting one another. A collection that exposes two layers of
+ * the same kind shares one slot.
  * @type {import("vue").Ref<Record<string, Record<string, any>>>}
  */
-export const rasterFormValue = ref({});
+export const layerConfigFormState = ref({});
 
 /**
  * STAC indicators color palette, defaults to Bank-Wong palette

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@eox/geosearch": "^1.2.0",
         "@eox/itemfilter": "^1.17.3",
         "@eox/jsonform": "^1.12.1",
-        "@eox/layercontrol": "^1.8.0",
+        "@eox/layercontrol": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@11201c6",
         "@eox/layout": "^1.0.0",
         "@eox/map": "^2.7.0",
         "@eox/stacinfo": "^1.2.0",
@@ -1681,8 +1681,8 @@
     },
     "node_modules/@eox/layercontrol": {
       "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@eox/layercontrol/-/layercontrol-1.8.0.tgz",
-      "integrity": "sha512-5rsTkmHryOGL7q8N3IiFouRjNOzCzdDXy21ntzAFBKWEi0rp0u07ms4WvXK8e3ULqFA5jS2LtvrHYp9aMiEUwA==",
+      "resolved": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@11201c6",
+      "integrity": "sha512-IA+vodipMUDPOnbcexR+SgUHqWLtVfDlrgXVfVQZGe/cjB8P3JZ8i6riDa8SvYZXCgRRaXu+tDxZpPfP3hLTLg==",
       "dependencies": {
         "@eox/elements-utils": "^1.2.0",
         "@eox/ui": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "@eox/geosearch": "^1.2.0",
     "@eox/itemfilter": "^1.17.3",
     "@eox/jsonform": "^1.12.1",
-    "@eox/layercontrol": "^1.8.0",
+    "@eox/layercontrol": "https://pkg.pr.new/EOX-A/EOxElements/@eox/layercontrol@11201c6",
     "@eox/layout": "^1.0.0",
     "@eox/map": "^2.7.0",
     "@eox/stacinfo": "^1.2.0",

--- a/widgets/EodashLayerControl.vue
+++ b/widgets/EodashLayerControl.vue
@@ -182,7 +182,11 @@ const onLayerConfigChange = (evt) => {
   updateGeoZarrBands(evt.detail.layer, evt.detail.jsonformValue);
   updateLayerUrl(evt.detail.layer, evt.detail.jsonformValue);
   // remember the selection so it survives a time/item rebuild
-  persistLayerConfigState(evt.detail.layer, evt.detail.jsonformValue);
+  persistLayerConfigState(
+    evt.detail.layer,
+    evt.detail.jsonformValue,
+    props.map === "second" ? "compare" : "main",
+  );
 
   if (props.map === "second") {
     layerControlFormValueCompare.value = evt.detail.jsonformValue;

--- a/widgets/EodashLayerControl.vue
+++ b/widgets/EodashLayerControl.vue
@@ -37,6 +37,7 @@ import {
   eodashCompareCollections,
   layerControlFormValue,
   layerControlFormValueCompare,
+  rasterFormValue,
 } from "@/utils/states";
 import {
   getColFromLayer,
@@ -180,6 +181,21 @@ const debouncedHandleDateTime = (evt) => {
 const onLayerConfigChange = (evt) => {
   updateGeoZarrBands(evt.detail.layer, evt.detail.jsonformValue);
   updateLayerUrl(evt.detail.layer, evt.detail.jsonformValue);
+
+  // cache rasterForm state
+  const jsonLayer = evt.detail.layer.get("_jsonDefinition");
+  const [collectionId] = (evt.detail.layer.get("id") ?? "").split(";:;");
+  console.log(
+    "[DBG-LC] change id:",
+    evt.detail.layer.get("id"),
+    "type:",
+    jsonLayer?.properties?.layerConfig?.type,
+    "value:",
+    evt.detail.jsonformValue,
+  );
+  if (collectionId && jsonLayer?.properties?.layerConfig?.type === "tileUrl") {
+    rasterFormValue.value[collectionId] = evt.detail.jsonformValue;
+  }
 
   if (props.map === "second") {
     layerControlFormValueCompare.value = evt.detail.jsonformValue;

--- a/widgets/EodashLayerControl.vue
+++ b/widgets/EodashLayerControl.vue
@@ -37,12 +37,12 @@ import {
   eodashCompareCollections,
   layerControlFormValue,
   layerControlFormValueCompare,
-  rasterFormValue,
 } from "@/utils/states";
 import {
   getColFromLayer,
   updateGeoZarrBands,
   updateLayerUrl,
+  persistLayerConfigState,
 } from "@/eodashSTAC/helpers";
 import { storeToRefs } from "pinia";
 import { useSTAcStore } from "@/store/stac";
@@ -181,21 +181,8 @@ const debouncedHandleDateTime = (evt) => {
 const onLayerConfigChange = (evt) => {
   updateGeoZarrBands(evt.detail.layer, evt.detail.jsonformValue);
   updateLayerUrl(evt.detail.layer, evt.detail.jsonformValue);
-
-  // cache rasterForm state
-  const jsonLayer = evt.detail.layer.get("_jsonDefinition");
-  const [collectionId] = (evt.detail.layer.get("id") ?? "").split(";:;");
-  console.log(
-    "[DBG-LC] change id:",
-    evt.detail.layer.get("id"),
-    "type:",
-    jsonLayer?.properties?.layerConfig?.type,
-    "value:",
-    evt.detail.jsonformValue,
-  );
-  if (collectionId && jsonLayer?.properties?.layerConfig?.type === "tileUrl") {
-    rasterFormValue.value[collectionId] = evt.detail.jsonformValue;
-  }
+  // remember the selection so it survives a time/item rebuild
+  persistLayerConfigState(evt.detail.layer, evt.detail.jsonformValue);
 
   if (props.map === "second") {
     layerControlFormValueCompare.value = evt.detail.jsonformValue;


### PR DESCRIPTION
## Description

This fixes the persistence of the `layerConfig` style and introduces the same behaviour to the rasterform; whenever the map rebuilds its layers on a datetime change or item selection, the schema defaults and the start values are reseeded.
This introduces a new utility (non-user-facing) state `layerConfigFormState` that is keyed by map (main/compare), per collection, and per editor kind (style vs tile URL) to make sure different layers don't overlap.

Forms can opt out of persistence via a new top-level schema option `persist_state: false`. For cases where forms have values that are only valid for a specific item and would break when carried over to another one, e.g S1 items

## Checklist

- [x] ran `npm run format` and `npm run check` pass
- [ ] ~Docs under `docs/` updated for any public API, config, or behavior change~
- [ ] ~New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](../docs/eodash-store.md) reference is generated from it~
- [ ] ~New widget props use the appropriate `/** @type {import("vue").PropType<T>} */` and they appear typed in the API reference~
