### PR TITLE
feat: Support "item" URL search parameter

### DIFF
--- a/core/client/composables/index.js
+++ b/core/client/composables/index.js
@@ -23,7 +23,7 @@ import mustache from "mustache";
 import { toAbsolute } from "stac-js/src/http.js";
 import axios from "@/plugins/axios";
 import { storeToRefs } from "pinia";
-
+import { bboxToCenterZoom, sanitizeBbox } from "@/eodashSTAC/helpers";
 /**
 /** @type {import('@/types').Eodash | null}*/
 
@@ -163,6 +163,8 @@ export const useURLSearchParametersSync = () => {
         y,
         /** @type {number | undefined} */
         z;
+      /** @type {number[] | undefined} - restored item extent; wins over x/y/z */
+      let itemBbox;
       for (const [key, value] of searchParams) {
         switch (key) {
           case "template": {
@@ -215,6 +217,21 @@ export const useURLSearchParametersSync = () => {
                   const poiAbsoluteUrl = toAbsolute(poiUrl, indicatorUrl);
                   await store.loadSelectedSTAC(poiAbsoluteUrl, true);
                 }
+              } else if (store.isApi && searchParams.has("item")) {
+                // Restore a specific catalog item within the collection
+                const itemId = searchParams.get("item");
+                const itemUrl = `${store.stacEndpoint}/collections/${match.id}/items/${itemId}`;
+                /** @type {import("stac-ts").StacItem | null} */
+                const item = await axios
+                  .get(itemUrl)
+                  .then((resp) => resp.data)
+                  .catch(() => null);
+                await store.loadSelectedSTAC(
+                  /** @type {string} */ (match.id),
+                  false,
+                  item ?? undefined,
+                );
+                itemBbox = /** @type {any} */ (item)?.bbox;
               } else {
                 await store.loadSelectedSTAC(
                   /** @type {string} */ (store.isApi ? match.id : match.href),
@@ -251,7 +268,18 @@ export const useURLSearchParametersSync = () => {
         }
       }
 
-      if (x && y && z) {
+      if (itemBbox?.length) {
+        // A restored item extent takes precedence over the saved x/y/z.
+        const { center, zoom } = bboxToCenterZoom(
+          sanitizeBbox(itemBbox),
+          mapEl.value?.map?.getSize?.(),
+        );
+        mapPosition.value = [center[0], center[1], zoom];
+        if (mapEl.value) {
+          mapEl.value.center = center;
+          mapEl.value.zoom = zoom;
+        }
+      } else if (x && y && z) {
         log.debug("Coordinates found, applying map poisition", x, y, z);
         mapPosition.value = [x, y, z];
         if (mapEl.value) {
@@ -265,14 +293,16 @@ export const useURLSearchParametersSync = () => {
       }
     }
 
+    const { selectedItem } = storeToRefs(useSTAcStore());
     watch(
-      [indicator, mapPosition, datetime, activeTemplate, poi],
+      [indicator, mapPosition, datetime, activeTemplate, poi, selectedItem],
       ([
         updatedIndicator,
         updatedMapPosition,
         updatedDatetime,
         updatedTemplate,
         updatedPoi,
+        updatedItem,
       ]) => {
         if ("URLSearchParams" in window) {
           const searchParams = new URLSearchParams(window.location.search);
@@ -298,6 +328,13 @@ export const useURLSearchParametersSync = () => {
             }
           } else {
             searchParams.set("poi", updatedPoi);
+          }
+
+          const itemId = /** @type {any} */ (updatedItem)?.id;
+          if (itemId) {
+            searchParams.set("item", itemId);
+          } else if (searchParams.has("item")) {
+            searchParams.delete("item");
           }
 
           const newRelativePathQuery =

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -1455,3 +1455,37 @@ export function encodeURLObject(obj) {
   }
   return str;
 }
+
+/**
+ * Estimate a lon/lat center and an OL zoom that fit a WGS84 bbox
+ * @param {number[]} bbox - `[minX, minY, maxX, maxY]` in EPSG:4326
+ * @param {number[]} [size] - map viewport `[width, height]` in px
+ * @returns {{ center: number[]; zoom: number }}
+ */
+export const bboxToCenterZoom = (
+  [minX, minY, maxX, maxY],
+  size = [800, 600],
+) => {
+  const WORLD = 256;
+  /** @param {number} lat */
+  const latRad = (lat) => {
+    const sin = Math.sin((lat * Math.PI) / 180);
+    const rad = Math.log((1 + sin) / (1 - sin)) / 2;
+    return Math.max(Math.min(rad, Math.PI), -Math.PI) / 2;
+  };
+  const latFraction = Math.max((latRad(maxY) - latRad(minY)) / Math.PI, 1e-9);
+  const lngDiff = maxX - minX;
+  const lngFraction = Math.max(
+    (lngDiff < 0 ? lngDiff + 360 : lngDiff) / 360,
+    1e-9,
+  );
+  const zoom = Math.min(
+    Math.log2(size[1] / WORLD / latFraction),
+    Math.log2(size[0] / WORLD / lngFraction),
+    20,
+  );
+  return {
+    center: [(minX + maxX) / 2, (minY + maxY) / 2],
+    zoom: Math.max(0, Math.floor(zoom)),
+  };
+};

--- a/templates/explore.js
+++ b/templates/explore.js
@@ -60,7 +60,28 @@ export default {
       widget: {
         name: "EodashItemCatalog",
         properties: {
-          layoutTarget: undefined,
+          useMosaic: false,
+          layoutTarget: "mosaic",
+          datetimeFilter: true,
+          filters: [
+            {
+              property: "eo:cloud_cover",
+              type: "range",
+              title: "Cloud cover",
+              unitLabel: "%",
+            },
+            {
+              property: "platform",
+              type: "multiselect",
+              title: "Platform",
+            },
+            {
+              property: "sat:orbit_state",
+              type: "multiselect",
+              title: "Orbit direction",
+            },
+          ],
+          hoverProperties: ["datetime", "eo:cloud_cover", "sat:orbit_state"],
         },
       },
     },


### PR DESCRIPTION
## Description
This adds the the rendered "item" id to the URL params  which used when `api: true`
## Checklist

- [x] ran `npm run format` and `npm run check` pass
- [ ] ~Docs under `docs/` updated for any public API, config, or behavior change~
- [ ] ~New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](../docs/eodash-store.md) reference is generated from it~
- [ ] ~New widget props use the appropriate `/** @type {import("vue").PropType<T>} */` and they appear typed in the API reference~
