### PR TITLE
feat: Support EodashStyle & Rasterform `${}` templating

### DIFF
--- a/core/client/eodashSTAC/EodashCollection.js
+++ b/core/client/eodashSTAC/EodashCollection.js
@@ -6,6 +6,7 @@ import {
   fetchApiItems,
   fetchPreAggregations,
   fetchStyle,
+  renderConfigTemplate,
   fetchAllStyles,
   findLayer,
   generateFeatures,
@@ -262,7 +263,7 @@ export class EodashCollection {
     } else {
       // get the correct style which is not attached to a link
       const id = this.#collectionStac?.id ?? "";
-      const styles = await fetchStyle(item);
+      const styles = renderConfigTemplate(await fetchStyle(item), item);
       let { layerConfig, style } = extractLayerConfig(
         id,
         styles,

--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -181,12 +181,12 @@ export async function createLayersFromAssets(
       );
       // get the correct style which is not attached to a link
       let { layerConfig, style } = extractLayerConfig(
-      collectionId,
-      styles,
-      undefined,
-      undefined,
-      map,
-    );
+        collectionId,
+        styles,
+        undefined,
+        undefined,
+        map,
+      );
       let assetLayerId = createAssetID(
         collectionId,
         stacObject.id,
@@ -297,12 +297,12 @@ export async function createLayersFromAssets(
       );
       // get the correct style which is not attached to a link
       let { layerConfig, style } = extractLayerConfig(
-      collectionId,
-      styles,
-      undefined,
-      undefined,
-      map,
-    );
+        collectionId,
+        styles,
+        undefined,
+        undefined,
+        map,
+      );
       let assetLayerId = createAssetID(
         collectionId,
         stacObject.id,
@@ -374,12 +374,12 @@ export async function createLayersFromAssets(
       );
       // get the correct style which is not attached to a link
       let { layerConfig, style } = extractLayerConfig(
-      collectionId,
-      styles,
-      undefined,
-      undefined,
-      map,
-    );
+        collectionId,
+        styles,
+        undefined,
+        undefined,
+        map,
+      );
       let assetLayerId = createAssetID(collectionId, stacObject.id, fgbIdx[i]);
       if (
         assets[assetName]?.roles?.includes("overlay") ||
@@ -500,6 +500,7 @@ export const createLayersFromLinks = async (
           item?.["eodash:rasterform"] ||
           collection?.["eodash:rasterform"]
       ),
+      item,
     );
     let { layerConfig } = extractLayerConfig(
       collectionId,
@@ -585,6 +586,7 @@ export const createLayersFromLinks = async (
           item?.["eodash:rasterform"] ||
           collection?.["eodash:rasterform"]
       ),
+      item,
     );
     const returnedLayerConfig = extractLayerConfig(
       collectionId,
@@ -690,6 +692,7 @@ export const createLayersFromLinks = async (
           item?.["eodash:rasterform"] ||
           collection?.["eodash:rasterform"]
       ),
+      item,
     );
     let { layerConfig } = extractLayerConfig(
       collectionId,
@@ -803,6 +806,7 @@ export const createLayersFromLinks = async (
           item?.["eodash:rasterform"] ||
           collection?.["eodash:rasterform"]
       ),
+      item,
     );
     const { layerConfig } = extractLayerConfig(
       collectionId,
@@ -1039,6 +1043,7 @@ export const createLayerFromRender = async (
     /** @type {string|object|undefined} */ (
       item?.["eodash:rasterform"] || collection?.["eodash:rasterform"]
     ),
+    item,
   );
   let { layerConfig } = extractLayerConfig(
     collection.id,

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -48,23 +48,54 @@ export function generateFeatures(links, extraProperties = {}, rel = "item") {
 }
 
 /**
+ * Renders `${...}` placeholders in a JSON config against a view, e.g.
+ * `${properties.sat:orbit_state}` against a STAC item. Returns the input
+ * unchanged when it holds no placeholders or rendering fails.
+ *
+ * @template T
+ * @param {T} json
+ * @param {Record<string, any>} view - lookup context for the placeholders
+ * @returns {T}
+ */
+export function renderConfigTemplate(json, view) {
+  if (!json || typeof json !== "object") {
+    return json;
+  }
+  const str = JSON.stringify(json);
+  if (!str.includes("${")) {
+    return json;
+  }
+  try {
+    return JSON.parse(
+      mustache.render(str, view, {}, { tags: ["${", "}"], escape: (v) => v }),
+    );
+  } catch (e) {
+    log.warn("[eodash] failed to render config template:", e);
+    return json;
+  }
+}
+
+/**
  * Fetches or extracts the raster form configuration for a STAC object.
- * Supports direct JSON objects, data URIs, and URL strings.
+ * Supports direct JSON objects, data URIs, and URL strings. `${...}`
+ * placeholders are rendered against `item` when provided.
  *
  * @param {string|object|undefined} rasterform - The rasterform property from the STAC object.
+ * @param {import("stac-ts").StacItem} [item] - Item the form is rendered against.
  * @returns {Promise<import("@/types").EodashRasterJSONForm|undefined>}
  */
-export async function fetchRasterForm(rasterform) {
-  if (!rasterform) {
-    return undefined;
+export async function fetchRasterForm(rasterform, item) {
+  /** @type {import("@/types").EodashRasterJSONForm | undefined} */
+  let form = undefined;
+  if (typeof rasterform === "object" && rasterform) {
+    form = /** @type {import("@/types").EodashRasterJSONForm} */ (rasterform);
+  } else if (typeof rasterform === "string" && rasterform) {
+    form = await axios.get(rasterform).then((resp) => resp.data);
   }
-  if (typeof rasterform === "object") {
-    return /** @type {import("@/types").EodashRasterJSONForm} */ (rasterform);
+  if (!form || !item) {
+    return form;
   }
-  if (typeof rasterform === "string") {
-    return await axios.get(rasterform).then((resp) => resp.data);
-  }
-  return undefined;
+  return renderConfigTemplate(form, item);
 }
 
 /**
@@ -267,7 +298,12 @@ export function persistLayerConfigState(olLayer, value, map = "main") {
  * @param {import("@/types").MapKey} [map]
  * @returns {Record<string, any>} seeded schema (original untouched)
  */
-export function restorePersistedSchema(schema, collectionId, type, map = "main") {
+export function restorePersistedSchema(
+  schema,
+  collectionId,
+  type,
+  map = "main",
+) {
   // form opted out of persistence
   if (schema?.options?.persist_state === false) return schema;
   const cached = getCachedConfig(collectionId, type, map);
@@ -471,7 +507,8 @@ export const fetchStyle = async (
 
 /**
  * Resolves a style by preferring the item's own `style` link and falling back
- * to the collection's. Takes the same key arguments as `fetchStyle`.
+ * to the collection's. Takes the same key arguments as `fetchStyle`. `${...}`
+ * placeholders are rendered against `item` (see {@link renderConfigTemplate}).
  *
  * @param {import("stac-ts").StacItem | import("stac-ts").StacCollection} item
  * @param {import("stac-ts").StacCollection | null | undefined} collection
@@ -479,9 +516,15 @@ export const fetchStyle = async (
  * @param {string} [assetKey]
  * @returns {Promise<import("@/types").EodashStyleJson | undefined>}
  */
-export const resolveStyle = async (item, collection, linkKey, assetKey) =>
-  (await fetchStyle(item, linkKey, assetKey)) ??
-  (await fetchStyle(collection, linkKey, assetKey));
+export const resolveStyle = async (item, collection, linkKey, assetKey) => {
+  const style =
+    (await fetchStyle(item, linkKey, assetKey)) ??
+    (await fetchStyle(collection, linkKey, assetKey));
+  if (!style || !item) {
+    return style;
+  }
+  return renderConfigTemplate(style, item);
+};
 
 /**
  * Fetches all style JSONs from a STAC Item and returns an array with style objects

--- a/docs/STAC.md
+++ b/docs/STAC.md
@@ -257,6 +257,8 @@ type EodashStyleJson = import("ol/style/flat").FlatStyleLike & {
 };
 ```
 
+Form values persist across layer rebuilds, and definitions support `${...}` item templating — see [Layer Configuration Forms](/widgets/internal-widgets/EodashLayerControl#layer-configuration-forms).
+
 ### eodash Raster Form
 
 The `eodash:rasterform` property allows providing visualization controls for tiled layers (WMS, WMTS, XYZ) that do not use OpenLayers Flat Styles. 

--- a/docs/widgets/internal-widgets/EodashLayerControl.md
+++ b/docs/widgets/internal-widgets/EodashLayerControl.md
@@ -34,6 +34,41 @@ widget: {
 }
 ```
 
+## Layer Configuration Forms
+
+Layers can expose configuration forms in the panel, defined through [eodash Flat Styles](/STAC#eodash-flat-styles) or [`eodash:rasterform`](/STAC#eodash-raster-form) in the STAC metadata.
+
+### State persistence
+
+Form values are remembered per collection and per map (main/compare), and re-applied when the map rebuilds its layers (datetime change, item selection). Opt a form out when its values are only valid for a specific item:
+
+```json
+{
+  "jsonform": {
+    "options": { "persist_state": false }
+  }
+}
+```
+
+### Item templating
+
+Form definitions may contain `${...}` placeholders, resolved as dotted paths against the STAC item being rendered — so one definition can serve item-dependent variants:
+
+```json
+{
+  "expression": {
+    "type": "string",
+    "enum": [
+      "/${properties.sat:orbit_state}:vv",
+      "/${properties.sat:orbit_state}:vh"
+    ],
+    "default": "/${properties.sat:orbit_state}:vv"
+  }
+}
+```
+
+For an item with `"sat:orbit_state": "ascending"`, the form renders with `/ascending:vv`. <span v-pre>`{{ }}`</span> templates are untouched and still evaluated by the form at runtime. see [json-editor](https://github.com/json-editor/json-editor#templates)
+
 <!-- @widget-props -->
 
 ## See also


### PR DESCRIPTION
## Description

This adds support for `${...}` placeholders in style and rasterform definitions, resolved against the STAC item being rendered. A single definition can now adapt to item metadata instead of being duplicated per variant; the driving case is  EOPF Sentinel-1, see EOPF-Explorer/data-pipeline#348, where the ascending/descending bands forms were identical except for the orbit prefix inside the band paths.

The `${}` syntax avoids clashing with the `{{ }}` templates that json-editor evaluates at runtime. Combined with `persist_state: false`, this lets the two Sentinel-1 orbit forms collapse into a single orbit-agnostic one. Configs without placeholders are unaffected.

## Checklist

- [x] ran `npm run format` and `npm run check` pass
- [x] Docs under `docs/` updated for any public API, config, or behavior change
- [ ] ~New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](../docs/eodash-store.md) reference is generated from it~
- [ ] ~New widget props use the appropriate `/** @type {import("vue").PropType<T>} */` and they appear typed in the API reference~
