### PR TITLE
fix: Refactor and enhance bands editor

### DIFF
--- a/core/client/utils/bands-editor/arithmetic.js
+++ b/core/client/utils/bands-editor/arithmetic.js
@@ -1,5 +1,10 @@
-import { addDraggableBands } from "./dom.js";
-import { createSlotStyles, createSlot, fillSlotWithBand } from "./dom";
+import {
+  createSlotStyles,
+  createSlot,
+  fillSlotWithBand,
+  clearSlot,
+  addDraggableBands,
+} from "./dom";
 const MUSTACHE_REGEX = /\{\{([^}]+)\}\}/g;
 /**
  * Build the arithmetic expression interface
@@ -19,7 +24,7 @@ export function buildArithmeticInterface(editor, colors, bands, bandTitles) {
   editor.control?.appendChild(document.createElement("hr"));
 
   // Add formula display with embedded slots after the bands
-  addFormulaSlots(editor, formulaTemplate, bands, bandTitles);
+  addFormulaSlots(editor, formulaTemplate);
 }
 
 /**
@@ -39,14 +44,72 @@ function generateFormulaString(editor) {
   });
 }
 
+/** @param {string} str */
+function escapeRegExp(str) {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Reverse of {@link generateFormulaString}: derive variable assignments from
+ * a formula string by matching it against the template. Unfilled `{{X}}`
+ * placeholders are tolerated; repeated variables must hold the same band.
+ * @param {import("./index.js").BandsEditor} editor - The editor instance
+ * @param {string} value - Formula string
+ * @returns {Record<string, string> | null} Variable assignments, or null if
+ * the value doesn't match the template
+ */
+function parseFormulaValue(editor, value) {
+  const bands = editor.bands ?? [];
+  if (!value || !bands.length) return null;
+
+  /** @type {string} */
+  const template = editor.schema.formulaTemplate || "{{A}}";
+  // Longest-first so a band is never half-matched by a shorter prefix of it
+  const bandAlternation = [...bands]
+    .sort((a, b) => b.length - a.length)
+    .map(escapeRegExp)
+    .join("|");
+
+  /** @type {string[]} */
+  const variableOrder = [];
+  /** @type {Record<string, number>} */
+  const groupNumbers = {};
+
+  const pattern = template
+    .split(/(\{\{[^}]+\}\})/)
+    .map((part) => {
+      const placeholder = part.match(/^\{\{([^}]+)\}\}$/);
+      if (!placeholder) return escapeRegExp(part);
+
+      const variable = placeholder[1].trim();
+      // Repeated variable: must match whatever the first occurrence captured
+      if (groupNumbers[variable]) return `\\${groupNumbers[variable]}`;
+
+      variableOrder.push(variable);
+      groupNumbers[variable] = variableOrder.length;
+      return `(${bandAlternation}|${escapeRegExp(part)})`;
+    })
+    .join("");
+
+  const match = value.match(new RegExp(`^${pattern}$`));
+  if (!match) return null;
+
+  /** @type {Record<string, string>} */
+  const values = {};
+  variableOrder.forEach((variable, i) => {
+    const captured = match[i + 1];
+    // Skip captures that are still unfilled placeholders
+    if (captured && !captured.startsWith("{{")) values[variable] = captured;
+  });
+  return values;
+}
+
 /**
  * Add formula display with embedded circular slots
  * @param {import("./index.js").BandsEditor} editor - The editor instance
  * @param {string} template - Formula template string
- * @param {Array<string>} bands - Array of band identifiers
- * @param {Array<string>} bandTitles - Array of band titles
  */
-function addFormulaSlots(editor, template, bands, bandTitles) {
+function addFormulaSlots(editor, template) {
   const formulaContainer = document.createElement("div");
   formulaContainer.classList.add("slots-container");
 
@@ -80,17 +143,9 @@ function addFormulaSlots(editor, template, bands, bandTitles) {
       const enumValue = e.dataTransfer?.getData("band");
       if (!enumValue) return;
 
-      const enumIndex = bands.indexOf(enumValue);
-      const title = bandTitles[enumIndex] || enumValue;
-
       editor.variableValues[variable] = enumValue;
-
-      // Update ALL slots for this variable using unified system
-      updateAllSlotsForVariable(editor, variable, enumValue, title);
-
-      // final formula string as the value
-      //@ts-expect-error todo
-      editor.value = generateFormulaString(editor);
+      // setValue re-renders the slots from the new value
+      editor.setValue(generateFormulaString(editor));
       editor.onChange(true);
     });
     formulaContainer.appendChild(slotElement);
@@ -103,42 +158,29 @@ function addFormulaSlots(editor, template, bands, bandTitles) {
   });
 
   editor.control?.appendChild(formulaContainer);
+}
 
-  // Initialize slots with existing values after all slots are created
-  setTimeout(() => {
-    initializeSlots(editor);
+/**
+ * Sync the formula slots with the editor's current value, falling back to
+ * `options.defaultVariables` when the value can't be parsed
+ * @param {import("./index.js").BandsEditor} editor - The editor instance
+ */
+export function refreshArithmeticSlots(editor) {
+  const parsed =
+    parseFormulaValue(editor, /** @type {string} */ (editor.getValue())) ??
+    editor.options?.defaultVariables ??
+    {};
+  editor.variableValues = { ...parsed };
+
+  Object.keys(editor.variableSlots ?? {}).forEach((variable) => {
+    const slots = editor.variableSlots[variable];
+    const enumValue = editor.variableValues[variable];
+    if (!enumValue) {
+      slots.forEach(clearSlot);
+      return;
+    }
+    const title =
+      editor.bandTitles?.[editor.bands?.indexOf(enumValue)] || enumValue;
+    slots.forEach((slot) => fillSlotWithBand(slot, enumValue, title));
   });
-}
-
-/**
- * Initialize all slots with existing values
- * @param {import("./index.js").BandsEditor} editor - The editor instance
- */
-function initializeSlots(editor) {
-  if (editor.variableValues && editor.variableSlots) {
-    Object.keys(editor.variableValues).forEach((variable) => {
-      const enumValue = editor.variableValues[variable];
-      const bands = editor.bands || editor.schema.enum || [];
-      const bandTitles =
-        editor.bandTitles || editor.schema.options?.enum_titles || bands;
-      const enumIndex = bands.indexOf(enumValue);
-      const title = bandTitles[enumIndex] || enumValue;
-      updateAllSlotsForVariable(editor, variable, enumValue, title);
-    });
-  }
-}
-
-/**
- * Update all slots for a specific variable with band circle
- * @param {import("./index.js").BandsEditor} editor - The editor instance
- * @param {string} variable - Variable name
- * @param {string} enumValue - Band value
- * @param {string} title - Band title
- */
-function updateAllSlotsForVariable(editor, variable, enumValue, title) {
-  if (editor.variableSlots && editor.variableSlots[variable]) {
-    editor.variableSlots[variable].forEach((slot) => {
-      fillSlotWithBand(slot, enumValue, title);
-    });
-  }
 }

--- a/core/client/utils/bands-editor/colors.js
+++ b/core/client/utils/bands-editor/colors.js
@@ -17,13 +17,31 @@ export function generateBandColors(schema, format) {
     return colors;
   }
 
-  return bands.map(
-    () =>
-      "#" +
-      Math.floor(Math.random() * 16777215)
-        .toString(16)
-        .padStart(6, "0"),
-  );
+  // Stable hex per band so chips keep their color across rebuilds/tab switches.
+  return bands.map((band) => {
+    let hash = 0;
+    for (let i = 0; i < band.length; i++) {
+      hash = band.charCodeAt(i) + ((hash << 5) - hash);
+    }
+    return `#${((hash >>> 0) & 0xffffff).toString(16).padStart(6, "0")}`;
+  });
+}
+
+/**
+ * Readable text color (black/white) for a hex chip background, by luminance.
+ * @param {string} color
+ * @returns {string}
+ */
+export function contrastText(color) {
+  if (typeof color !== "string" || !color.startsWith("#")) return "#000";
+  const hex =
+    color.length === 4
+      ? color.slice(1).replace(/./g, "$&$&")
+      : color.slice(1);
+  const r = parseInt(hex.slice(0, 2), 16);
+  const g = parseInt(hex.slice(2, 4), 16);
+  const b = parseInt(hex.slice(4, 6), 16);
+  return 0.299 * r + 0.587 * g + 0.114 * b > 140 ? "#000" : "#fff";
 }
 
 /**

--- a/core/client/utils/bands-editor/colors.js
+++ b/core/client/utils/bands-editor/colors.js
@@ -5,9 +5,10 @@
  * @returns {string[]} Array of color strings
  */
 export function generateBandColors(schema, format) {
+  /** @type {string[]} */
   const bands =
     format === "bands"
-      ? schema.items?.enum
+      ? (schema.items?.enum ?? [])
       : (schema.options?.enum ?? schema.enum ?? []);
   const colors =
     format === "bands"
@@ -17,31 +18,17 @@ export function generateBandColors(schema, format) {
     return colors;
   }
 
-  // Stable hex per band so chips keep their color across rebuilds/tab switches.
+  // Stable hex per band so chips keep their color across rebuilds/tab
+  // switches; channels clamped to the light half so black text stays legible.
   return bands.map((band) => {
     let hash = 0;
     for (let i = 0; i < band.length; i++) {
       hash = band.charCodeAt(i) + ((hash << 5) - hash);
     }
-    return `#${((hash >>> 0) & 0xffffff).toString(16).padStart(6, "0")}`;
+    return [16, 8, 0]
+      .map((shift) => (((hash >>> shift) & 0xff) | 0x80).toString(16))
+      .reduce((hex, channel) => hex + channel, "#");
   });
-}
-
-/**
- * Readable text color (black/white) for a hex chip background, by luminance.
- * @param {string} color
- * @returns {string}
- */
-export function contrastText(color) {
-  if (typeof color !== "string" || !color.startsWith("#")) return "#000";
-  const hex =
-    color.length === 4
-      ? color.slice(1).replace(/./g, "$&$&")
-      : color.slice(1);
-  const r = parseInt(hex.slice(0, 2), 16);
-  const g = parseInt(hex.slice(2, 4), 16);
-  const b = parseInt(hex.slice(4, 6), 16);
-  return 0.299 * r + 0.587 * g + 0.114 * b > 140 ? "#000" : "#fff";
 }
 
 /**

--- a/core/client/utils/bands-editor/dom.js
+++ b/core/client/utils/bands-editor/dom.js
@@ -1,4 +1,4 @@
-import { getBandColor } from "./colors.js";
+import { getBandColor, contrastText } from "./colors.js";
 
 /**
  * Create band styles
@@ -96,14 +96,10 @@ export function createSlotStyles(bands, colors) {
 
     /* Band color styles */
     ${bands
-      .map(
-        (band) =>
-          `[data-band="${band}"] { background: ${getBandColor(
-            band,
-            bands,
-            colors,
-          )}; color: black; }`,
-      )
+      .map((band) => {
+        const bg = getBandColor(band, bands, colors);
+        return `[data-band="${band}"] { background: ${bg}; color: ${contrastText(bg)}; }`;
+      })
       .join("\n")}
 
     /* RGB slot styles */

--- a/core/client/utils/bands-editor/dom.js
+++ b/core/client/utils/bands-editor/dom.js
@@ -1,42 +1,4 @@
-import { getBandColor, contrastText } from "./colors.js";
-
-/**
- * Create band styles
- * @param {string[]} bands - Array of band identifiers
- * @param {string[]} colors - Array of color strings
- * @param {string} additionalStyles - Additional CSS styles
- * @returns {HTMLStyleElement} Style element
- */
-export function createBandStyles(bands, colors, additionalStyles = "") {
-  const style = document.createElement("style");
-  style.innerHTML = `
-    [data-band], [data-slot] {
-      display: inline-flex;
-      border: 1px solid darkgrey;
-      border-radius: 50%;
-      height: 40px;
-      aspect-ratio: 1/1;
-      padding: 4px;
-      margin: 2px;
-      align-items: center;
-      justify-content: center;
-      cursor: move;
-      font-size: 10px;
-    }
-    ${bands
-      .map(
-        (band) =>
-          `[data-band="${band}"] { background: ${getBandColor(
-            band,
-            bands,
-            colors,
-          )}; color: black; }`,
-      )
-      .join("\n")}
-    ${additionalStyles}
-  `;
-  return style;
-}
+import { getBandColor } from "./colors.js";
 
 /**
  * Create a draggable band element.
@@ -61,13 +23,14 @@ export function createBandDiv(enumValue, title) {
  * @param {Array<string>} bandTitles - Array of band titles
  */
 export function addDraggableBands(editor, bands, bandTitles) {
+  const palette = document.createElement("div");
+  palette.classList.add("bands-palette");
   bands.forEach((band, index) => {
     const title = bandTitles[index];
-    const bandDiv = createBandDiv(band, title);
-
     // createBandDiv already sets up drag functionality
-    editor.control?.appendChild(bandDiv);
+    palette.appendChild(createBandDiv(band, title));
   });
+  editor.control?.appendChild(palette);
 }
 
 /**
@@ -82,7 +45,7 @@ export function createSlotStyles(bands, colors) {
     /* Base styles for all band elements */
     [data-band] {
       display: inline-flex;
-      border: 1px solid darkgrey;
+      border: 1px solid var(--outline, darkgrey);
       border-radius: 50%;
       height: 40px;
       aspect-ratio: 1/1;
@@ -92,25 +55,53 @@ export function createSlotStyles(bands, colors) {
       justify-content: center;
       cursor: move;
       font-size: 10px;
+      font-weight: 500;
+      transition: box-shadow 150ms ease;
+    }
+    [data-band]:hover {
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+    }
+
+    /* One card holding the palette and the slots */
+    .bands-editor {
+      background: var(--surface-container, #f0f0f0);
+      border: 1px solid var(--outline-variant, #ccc);
+      border-radius: 4px;
+      padding: 12px;
+      margin: 8px 0;
+    }
+    .bands-editor hr {
+      border: none;
+      border-top: 1px solid var(--outline-variant, #ccc);
+      margin: 8px 0;
+    }
+
+    /* Centered palette of draggable bands */
+    .bands-palette {
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: center;
+      gap: 4px;
+      padding: 8px 0;
     }
 
     /* Band color styles */
     ${bands
-      .map((band) => {
-        const bg = getBandColor(band, bands, colors);
-        return `[data-band="${band}"] { background: ${bg}; color: ${contrastText(bg)}; }`;
-      })
+      .map(
+        (band) =>
+          `[data-band="${band}"] { background: ${getBandColor(band, bands, colors)}; color: black; }`,
+      )
       .join("\n")}
 
-    /* RGB slot styles */
+    /* Drop slot styles */
     [data-slot] {
       display: inline-flex;
       width: 50px;
       height: 50px;
       aspect-ratio: 1/1;
       padding: 1px;
-      border: 2px solid #666;
-      background: #f0f0f0;
+      border: 2px solid var(--outline, #666);
+      background: var(--surface-container-low, #f0f0f0);
       border-radius: 50%;
       align-items: center;
       justify-content: center;
@@ -118,29 +109,27 @@ export function createSlotStyles(bands, colors) {
       margin: 2px;
       position: relative;
       box-sizing: border-box;
+      transition: border-color 150ms ease, background 150ms ease;
     }
     [data-slot]:hover {
-      border-color: #333;
-      background: #f9f9f9;
+      border-color: var(--primary, #333);
+      background: var(--surface-container-high, #f9f9f9);
     }
     [data-slot]::before {
       content: attr(data-slot);
       position: absolute;
       font-size: 12px;
       font-weight: bold;
-      color: #666;
+      color: var(--on-surface-variant, #666);
       z-index: 0;
     }
 
-    /* container */
+    /* slots row inside the card */
     .slots-container {
       font-family: monospace;
       font-size: 18px;
-      padding: 16px;
-      background: #f0f0f0;
-      border: 1px solid #ccc;
-      border-radius: 4px;
-      margin: 8px 0;
+      color: var(--on-surface, inherit);
+      padding: 8px 0;
       display: flex;
       align-items: center;
       justify-content: center;
@@ -152,6 +141,14 @@ export function createSlotStyles(bands, colors) {
       font-size: 18px;
       margin: 0 2px;
     }
+
+    /* RGB channel affordance */
+    .rgb-slots [data-slot] {
+      border-style: dashed;
+    }
+    .rgb-slots [data-slot="R"] { border-color: #e57373; }
+    .rgb-slots [data-slot="G"] { border-color: #81c784; }
+    .rgb-slots [data-slot="B"] { border-color: #64b5f6; }
   `;
   return style;
 }
@@ -181,12 +178,14 @@ export function createSlot(identifier, onDrop) {
  * @param {string} title - Band title
  */
 export function fillSlotWithBand(slot, enumValue, title) {
-  // clear existing band and add new one
-  const existingBand = slot.querySelector("[data-band]");
-  if (existingBand) {
-    existingBand.remove();
-  }
+  clearSlot(slot);
+  slot.appendChild(createBandDiv(enumValue, title));
+}
 
-  const bandDiv = createBandDiv(enumValue, title);
-  slot.appendChild(bandDiv);
+/**
+ * Remove the band from a slot, if any
+ * @param {HTMLElement} slot - Slot element
+ */
+export function clearSlot(slot) {
+  slot.querySelector("[data-band]")?.remove();
 }

--- a/core/client/utils/bands-editor/index.js
+++ b/core/client/utils/bands-editor/index.js
@@ -3,12 +3,17 @@
  */
 import { AbstractEditor } from "@json-editor/json-editor/src/editor";
 import { generateBandColors } from "./colors";
-import { buildRGBInterface } from "./rgb.js";
-import { buildArithmeticInterface } from "./arithmetic.js";
+import { buildRGBInterface, refreshRGBSlots } from "./rgb.js";
+import {
+  buildArithmeticInterface,
+  refreshArithmeticSlots,
+} from "./arithmetic.js";
 
 export class BandsEditor extends AbstractEditor {
   /** @type {Record<string, HTMLElement[]>} */
   variableSlots = {};
+  /** @type {HTMLElement[]} */
+  rgbSlots = [];
   /** @type {Record<string, string>} */
   variableValues = {};
   /** @type {string[]} */
@@ -35,7 +40,7 @@ export class BandsEditor extends AbstractEditor {
 
     // control
     this.control = document.createElement("div");
-    this.control.classList.add("form-control");
+    this.control.classList.add("form-control", "bands-editor");
 
     if (format === "bands") {
       buildRGBInterface(this, this.colors, this.bands, this.bandTitles);
@@ -51,6 +56,20 @@ export class BandsEditor extends AbstractEditor {
     // appends
     this.container?.appendChild(this.label);
     this.container?.appendChild(this.control);
+  }
+
+  /**
+   * Keep the slot display in sync with every value change, including the
+   * initial default applied by postBuild. Never triggers onChange here.
+   * @param {unknown} value
+   */
+  setValue(value) {
+    super.setValue(value);
+    if ((this.schema.format || "bands") === "bands") {
+      refreshRGBSlots(this);
+    } else {
+      refreshArithmeticSlots(this);
+    }
   }
 }
 

--- a/core/client/utils/bands-editor/rgb.js
+++ b/core/client/utils/bands-editor/rgb.js
@@ -2,6 +2,7 @@ import {
   createSlotStyles,
   createSlot,
   fillSlotWithBand,
+  clearSlot,
   addDraggableBands,
 } from "./dom";
 
@@ -13,90 +14,61 @@ import {
  * @param {Array<string>} bandTitles - Array of band titles
  */
 export function buildRGBInterface(editor, colors, bands, bandTitles) {
-  // Use unified styles instead of creating separate styles
   const style = createSlotStyles(bands, colors);
   editor.control?.appendChild(style);
 
-  // Add draggable bands
   addDraggableBands(editor, bands, bandTitles);
 
   editor.control?.appendChild(document.createElement("hr"));
 
-  // Add RGB slots using unified slot system
-  addRGBSlots(editor, bands, bandTitles);
+  addRGBSlots(editor);
 }
 
 /**
- * Add RGB slots for traditional bands interface using unified slot system
+ * Add RGB drop slots and keep their references on the editor
  * @param {import("./index.js").BandsEditor} editor - The editor instance
- * @param {Array<string>} bands - Array of band identifiers
- * @param {Array<string>} bandTitles - Array of band titles
  */
-export function addRGBSlots(editor, bands, bandTitles) {
-  // Create a container for RGB slots
+export function addRGBSlots(editor) {
   const rgbContainer = document.createElement("div");
-  rgbContainer.classList.add("slots-container");
-  ["R", "G", "B"].forEach((slot, index) => {
+  rgbContainer.classList.add("slots-container", "rgb-slots");
+
+  editor.rgbSlots = ["R", "G", "B"].map((slot, index) => {
     const onDrop = (/** @type {DragEvent} */ e) => {
       e.preventDefault();
       const enumValue = e.dataTransfer?.getData("band");
       if (!enumValue) return;
 
-      const enumIndex = bands.indexOf(enumValue);
-      const title = bandTitles[enumIndex] || enumValue;
-
-      fillSlotWithBand(slotDiv, enumValue, title);
-      // Get current value as array or create new one
-      const currentValue = editor.getValue() || [];
+      // Copy before assigning: mutating the value returned by getValue()
+      // in place defeats change detection downstream.
+      const currentValue = [...(editor.getValue() || [])];
       currentValue[index] = enumValue;
+      // setValue re-renders the slots from the new value
       editor.setValue(currentValue);
       editor.onChange(true);
     };
 
     const slotDiv = createSlot(slot, onDrop);
-    addRGBSlotStyle(slotDiv);
     rgbContainer.appendChild(slotDiv);
-
-    // Initialize with existing value
-    setTimeout(() => {
-      const currentValue = editor.getValue();
-      if (currentValue?.[index]) {
-        const enumValue = currentValue[index];
-        const enumIndex = bands.indexOf(enumValue);
-        const title = bandTitles[enumIndex] || enumValue;
-        if (enumValue) {
-          fillSlotWithBand(slotDiv, enumValue, title);
-        }
-      }
-    });
+    return slotDiv;
   });
 
   editor.control?.appendChild(rgbContainer);
 }
 
 /**
- * Create specific styles for RGB slots
- * @param {HTMLElement} rgbSlot - Array of RGB slot elements
+ * Sync the RGB slots with the editor's current value
+ * @param {import("./index.js").BandsEditor} editor - The editor instance
  */
-function addRGBSlotStyle(rgbSlot) {
-  rgbSlot.style.border = "2px dashed";
-  switch (rgbSlot.dataset.slot) {
-    case "R": {
-      rgbSlot.style.borderColor = "#F88";
-      rgbSlot.style.background = "#FEE";
-      break;
+export function refreshRGBSlots(editor) {
+  const value = editor.getValue() || [];
+  editor.rgbSlots?.forEach((slot, index) => {
+    const enumValue = value[index];
+    if (!enumValue) {
+      clearSlot(slot);
+      return;
     }
-    case "G": {
-      rgbSlot.style.borderColor = "#8F8";
-      rgbSlot.style.background = "#EFE";
-      break;
-    }
-    case "B": {
-      rgbSlot.style.borderColor = "#88F";
-      rgbSlot.style.background = "#EEF";
-      break;
-    }
-    default:
-      break;
-  }
+    const title =
+      editor.bandTitles?.[editor.bands?.indexOf(enumValue)] || enumValue;
+    fillSlotWithBand(slot, enumValue, title);
+  });
 }


### PR DESCRIPTION
## Description

This fixes the bands editor slots drifting from the actual form value: defaults were never rendered in the arithmetic form, the initial display relied on timing workarounds, and repeated band swaps in the RGB form could stop updating the layer. The editor now re-renders its slots from the value on every `setValue`, including defaults and persisted state, and the arithmetic form derives its slot assignments back from the expression string, falling back to `defaultVariables`.

It also reworks the styling to use the EOxUI design tokens with a unified, centered layout, and makes fallback band colors stable across rebuilds instead of randomized.

## Checklist

- [x] ran `npm run format` and `npm run check` pass
- [ ] ~Docs under `docs/` updated for any public API, config, or behavior change~
- [ ] ~New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](../docs/eodash-store.md) reference is generated from it~
- [ ] ~New widget props use the appropriate `/** @type {import("vue").PropType<T>} */` and they appear typed in the API reference~
