### PR TITLE
Feat: Introduce TiTiler upscaling factor

### DIFF
--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -1597,9 +1597,11 @@ function applyValuesToUrl(url, values) {
  * - titiler v1: appends `@2x` to the `{y}` tile coordinate
  * - titiler v2: adds `tilesize=512` query parameter (v2 removed the `@2x` suffix)
  * Plain strings in the config default to v1 behavior for backward compatibility.
+ * - scaleFactor, if larger than 1, multiplies the default size of 512px tile requested from server by the value
+ * for v1, the value is rounded to nearest integer, for titiler v2 it can be a decimal
  *
  * @param {string} url - The XYZ tile URL template
- * @param {Array<string | { url: string; titilerVersion?: 1 | 2 }>} upscalingEndpoints
+ * @param {Array<string | { url: string; titilerVersion?: 1 | 2, scaleFactor?: number }>} upscalingEndpoints
  * @returns {{ url: string; tileSize: [number, number] } | null} null if no endpoint matches
  */
 export function applyTitilerUpscaling(url, upscalingEndpoints) {
@@ -1614,14 +1616,18 @@ export function applyTitilerUpscaling(url, upscalingEndpoints) {
 
   const version = typeof match === "string" ? 1 : (match.titilerVersion ?? 1);
 
+  const scaleFactor =
+    typeof match === "string" ? 1 : (match.scaleFactor ?? 1);
+
   if (version === 2) {
     const [base, query] = url.split("?");
     const params = new URLSearchParams(query);
-    params.set("tilesize", "512");
+    const tilesize = Math.round(512 * scaleFactor).toString();
+    params.set("tilesize", tilesize);
     return { url: `${base}?${params.toString()}`, tileSize: [512, 512] };
   }
-
-  return { url: url.replace("{y}", "{y}@2x"), tileSize: [512, 512] };
+  const exponent = Math.round(2 * scaleFactor).toString();
+  return { url: url.replace("{y}", `{y}@${exponent}x`), tileSize: [512, 512] };
 }
 
 /**

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -1597,7 +1597,7 @@ function applyValuesToUrl(url, values) {
  * - titiler v1: appends `@2x` to the `{y}` tile coordinate
  * - titiler v2: adds `tilesize=512` query parameter (v2 removed the `@2x` suffix)
  * Plain strings in the config default to v1 behavior for backward compatibility.
- * - scaleFactor, if larger than 1, multiplies the default size of 512px tile requested from server by the value at the expense of larger data transfers
+ * - scaleFactor, if larger than 2, multiplies the default size of 512px tile requested from server by the value at the expense of larger data transfers
  * for v1, the value is rounded to nearest integer, for titiler v2 it can be a decimal
  *
  * @param {string} url - The XYZ tile URL template
@@ -1615,17 +1615,17 @@ export function applyTitilerUpscaling(url, upscalingEndpoints) {
   }
 
   const version = typeof match === "string" ? 1 : (match.titilerVersion ?? 1);
-
-  const scaleFactor = typeof match === "string" ? 1 : (match.scaleFactor ?? 1);
+  let scaleFactor = typeof match === "string" ? 2 : (match.scaleFactor ?? 2);
 
   if (version === 2) {
     const [base, query] = url.split("?");
     const params = new URLSearchParams(query);
-    const tilesize = Math.round(512 * scaleFactor).toString();
+    const tilesize = Math.round(256 * scaleFactor).toString();
     params.set("tilesize", tilesize);
     return { url: `${base}?${params.toString()}`, tileSize: [512, 512] };
   }
-  const exponent = Math.round(2 * scaleFactor).toString();
+  scaleFactor = Math.min(scaleFactor, 4);
+  const exponent = Math.round(scaleFactor).toString();
   return { url: url.replace("{y}", `{y}@${exponent}x`), tileSize: [512, 512] };
 }
 

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -1597,7 +1597,7 @@ function applyValuesToUrl(url, values) {
  * - titiler v1: appends `@2x` to the `{y}` tile coordinate
  * - titiler v2: adds `tilesize=512` query parameter (v2 removed the `@2x` suffix)
  * Plain strings in the config default to v1 behavior for backward compatibility.
- * - scaleFactor, if larger than 1, multiplies the default size of 512px tile requested from server by the value
+ * - scaleFactor, if larger than 1, multiplies the default size of 512px tile requested from server by the value at the expense of larger data transfers
  * for v1, the value is rounded to nearest integer, for titiler v2 it can be a decimal
  *
  * @param {string} url - The XYZ tile URL template

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -1616,8 +1616,7 @@ export function applyTitilerUpscaling(url, upscalingEndpoints) {
 
   const version = typeof match === "string" ? 1 : (match.titilerVersion ?? 1);
 
-  const scaleFactor =
-    typeof match === "string" ? 1 : (match.scaleFactor ?? 1);
+  const scaleFactor = typeof match === "string" ? 1 : (match.scaleFactor ?? 1);
 
   if (version === 2) {
     const [base, query] = url.split("?");

--- a/core/client/store/stac.js
+++ b/core/client/store/stac.js
@@ -31,7 +31,7 @@ export const useSTAcStore = defineStore("stac", () => {
 
   /**
    * List of supported endpoints for upscaling
-   * @type {import("vue").Ref<Array<string | { url: string; titilerVersion?: 1 | 2 }>>}
+   * @type {import("vue").Ref<Array<string | { url: string; titilerVersion?: 1 | 2, scaleFactor?: number; }>>}
    */
   const supportedUpscalingEndpoints = ref([]);
 

--- a/core/client/store/stac.js
+++ b/core/client/store/stac.js
@@ -30,7 +30,10 @@ export const useSTAcStore = defineStore("stac", () => {
   const isApi = ref(false);
 
   /**
-   * List of supported endpoints for upscaling
+   * List of supported endpoints for upscaling.
+   * `scaleFactor` for v1 corresponds to `@nx` suffix (max 4).
+   * `scaleFactor` for v2 multiplies base tile size of 256px.
+   * Default `scaleFactor` is 2.
    * @type {import("vue").Ref<Array<string | { url: string; titilerVersion?: 1 | 2, scaleFactor?: number; }>>}
    */
   const supportedUpscalingEndpoints = ref([]);

--- a/core/client/types.ts
+++ b/core/client/types.ts
@@ -337,7 +337,7 @@ export type StacEndpoint =
       rasterEndpoint?: string;
       vectorEndpoint?: string;
       supportedUpscalingEndpoints?: Array<
-        string | { url: string; titilerVersion?: 1 | 2 }
+        string | { url: string; titilerVersion?: 1 | 2; scaleFactor?: number }
       >;
       colormapRegistry?: string | Record<string, string[]>;
     };

--- a/core/client/types.ts
+++ b/core/client/types.ts
@@ -337,7 +337,18 @@ export type StacEndpoint =
       rasterEndpoint?: string;
       vectorEndpoint?: string;
       supportedUpscalingEndpoints?: Array<
-        string | { url: string; titilerVersion?: 1 | 2; scaleFactor?: number }
+        | string
+        | {
+            url: string;
+            titilerVersion?: 1 | 2;
+            /**
+             * The scaling factor for tile requests.
+             * For TiTiler v1, it corresponds to the `@nx` suffix (e.g., 2 for `@2x`). Max 4.
+             * For TiTiler v2, it multiplies the base tile size of 256px (e.g., 2 for `tilesize=512`).
+             * Defaults to 2 (baseline 512px tiles).
+             */
+            scaleFactor?: number;
+          }
       >;
       colormapRegistry?: string | Record<string, string[]>;
     };

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -37,8 +37,8 @@ Alternatively, an object can be passed to configure a STAC API endpoint and dedi
     api: true,
     rasterEndpoint: "https://api.explorer.eopf.copernicus.eu/raster",
     supportedUpscalingEndpoints: [
-      { url: "https://api.explorer.eopf.copernicus.eu/raster", titilerVersion: 1 },
-      { url: "https://api.explorer.eopf.copernicus.eu/rstaging", titilerVersion: 2 },
+      { url: "https://api.explorer.eopf.copernicus.eu/raster", titilerVersion: 1, scaleFactor: 2 },
+      { url: "https://api.explorer.eopf.copernicus.eu/rstaging", titilerVersion: 2, scaleFactor: 4 },
     ],
   },
 }

--- a/tests/unit/eodashSTAC/helpers.test.js
+++ b/tests/unit/eodashSTAC/helpers.test.js
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "vitest";
+import { applyTitilerUpscaling } from "@/eodashSTAC/helpers";
+
+describe("applyTitilerUpscaling", () => {
+  const url = "https://api.example.com/tiles/{z}/{x}/{y}?assets=data";
+
+  test("returns null if no endpoint matches", () => {
+    const upscalingEndpoints = ["https://other-api.com"];
+    expect(applyTitilerUpscaling(url, upscalingEndpoints)).toBeNull();
+  });
+
+  test("applies v1 upscaling (default)", () => {
+    const upscalingEndpoints = ["https://api.example.com"];
+    const result = applyTitilerUpscaling(url, upscalingEndpoints);
+    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}@2x?assets=data");
+    expect(result.tileSize).toEqual([512, 512]);
+  });
+
+  test("applies v1 upscaling with scaleFactor", () => {
+    const upscalingEndpoints = [
+      { url: "https://api.example.com", titilerVersion: 1, scaleFactor: 3 }
+    ];
+    const result = applyTitilerUpscaling(url, upscalingEndpoints);
+    // scaleFactor 3 -> exponent = Math.round(2 * 3) = 6
+    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}@6x?assets=data");
+  });
+
+  test("applies v2 upscaling", () => {
+    const upscalingEndpoints = [
+      { url: "https://api.example.com", titilerVersion: 2 }
+    ];
+    const result = applyTitilerUpscaling(url, upscalingEndpoints);
+    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}?assets=data&tilesize=512");
+    expect(result.tileSize).toEqual([512, 512]);
+  });
+
+  test("applies v2 upscaling with decimal scaleFactor", () => {
+    const upscalingEndpoints = [
+      { url: "https://api.example.com", titilerVersion: 2, scaleFactor: 1.5 }
+    ];
+    const result = applyTitilerUpscaling(url, upscalingEndpoints);
+    // 512 * 1.5 = 768
+    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}?assets=data&tilesize=768");
+  });
+
+  test("applies v1 upscaling with decimal scaleFactor (rounded)", () => {
+    const upscalingEndpoints = [
+      { url: "https://api.example.com", titilerVersion: 1, scaleFactor: 1.4 }
+    ];
+    const result = applyTitilerUpscaling(url, upscalingEndpoints);
+    // scaleFactor 1.4 -> exponent = Math.round(2 * 1.4) = Math.round(2.8) = 3
+    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}@3x?assets=data");
+  });
+
+  test("handles plain string as v1 with scaleFactor 1", () => {
+    const upscalingEndpoints = ["https://api.example.com"];
+    const result = applyTitilerUpscaling(url, upscalingEndpoints);
+    expect(result.url).toContain("@2x");
+  });
+});

--- a/tests/unit/eodashSTAC/helpers.test.js
+++ b/tests/unit/eodashSTAC/helpers.test.js
@@ -12,44 +12,63 @@ describe("applyTitilerUpscaling", () => {
   test("applies v1 upscaling (default)", () => {
     const upscalingEndpoints = ["https://api.example.com"];
     const result = applyTitilerUpscaling(url, upscalingEndpoints);
-    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}@2x?assets=data");
+    expect(result.url).toBe(
+      "https://api.example.com/tiles/{z}/{x}/{y}@2x?assets=data",
+    );
     expect(result.tileSize).toEqual([512, 512]);
   });
 
   test("applies v1 upscaling with scaleFactor", () => {
     const upscalingEndpoints = [
-      { url: "https://api.example.com", titilerVersion: 1, scaleFactor: 3 }
+      { url: "https://api.example.com", titilerVersion: 1, scaleFactor: 3 },
     ];
     const result = applyTitilerUpscaling(url, upscalingEndpoints);
-    // scaleFactor 3 -> exponent = Math.round(2 * 3) = 6
-    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}@6x?assets=data");
+    expect(result.url).toBe(
+      "https://api.example.com/tiles/{z}/{x}/{y}@3x?assets=data",
+    );
+  });
+
+  test("applies v1 upscaling guard (max 4)", () => {
+    const upscalingEndpoints = [
+      { url: "https://api.example.com", titilerVersion: 1, scaleFactor: 10 },
+    ];
+    const result = applyTitilerUpscaling(url, upscalingEndpoints);
+    expect(result.url).toBe(
+      "https://api.example.com/tiles/{z}/{x}/{y}@4x?assets=data",
+    );
   });
 
   test("applies v2 upscaling", () => {
     const upscalingEndpoints = [
-      { url: "https://api.example.com", titilerVersion: 2 }
+      { url: "https://api.example.com", titilerVersion: 2 },
     ];
     const result = applyTitilerUpscaling(url, upscalingEndpoints);
-    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}?assets=data&tilesize=512");
+    expect(result.url).toBe(
+      "https://api.example.com/tiles/{z}/{x}/{y}?assets=data&tilesize=512",
+    );
     expect(result.tileSize).toEqual([512, 512]);
   });
 
-  test("applies v2 upscaling with decimal scaleFactor", () => {
+  test("applies v2 upscaling with scaleFactor (no limit)", () => {
     const upscalingEndpoints = [
-      { url: "https://api.example.com", titilerVersion: 2, scaleFactor: 1.5 }
+      { url: "https://api.example.com", titilerVersion: 2, scaleFactor: 8 },
     ];
     const result = applyTitilerUpscaling(url, upscalingEndpoints);
-    // 512 * 1.5 = 768
-    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}?assets=data&tilesize=768");
+    // 256 * 8 = 2048
+    expect(result.url).toBe(
+      "https://api.example.com/tiles/{z}/{x}/{y}?assets=data&tilesize=2048",
+    );
   });
 
   test("applies v1 upscaling with decimal scaleFactor (rounded)", () => {
     const upscalingEndpoints = [
-      { url: "https://api.example.com", titilerVersion: 1, scaleFactor: 1.4 }
+      { url: "https://api.example.com", titilerVersion: 1, scaleFactor: 3.4 },
     ];
     const result = applyTitilerUpscaling(url, upscalingEndpoints);
-    // scaleFactor 1.4 -> exponent = Math.round(2 * 1.4) = Math.round(2.8) = 3
-    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}@3x?assets=data");
+    // scaleFactor 3.4 -> exponent = Math.round(3.4) = 3
+    expect(result.url).toBe(
+      "https://api.example.com/tiles/{z}/{x}/{y}@3x?assets=data",
+    );
   });
 
   test("handles plain string as v1 with scaleFactor 1", () => {


### PR DESCRIPTION
## Description

`upscalingEndpoints` allowed to request 2x larger tiles from titiler (512px compared to default 256px) to decrease the number of tiles that the client requests from the server and delay request queue saturation, but it did not allow to actually upscale the rendered tiles (request larger tiles and use them as smaller tiles on the canvas).

This PR adds a `scaleFactor` config for that, effectively multiplying the 512 tilesize (or 2x) by that value to be used as 512px on the canvas.

So for scaleFactor: 2, it will request tileSize: 1024 from titiler, increasing the data transfers and server load, but allowing sharper images rendered on the map, therefore mitigating the fact that for EPSG:3857 z=5.xx we request tilematrixset 4 (1 off). 

This is a mitigation (but useful overall) PR I'd say.

## Checklist

- [x] I have performed a self review on my code
- [x] I added a test related to this feature/fix
- [x] I ran `npm run format` and `npm run check` pass
- [x] Docs under `docs/` are updated for any public API, config, or behavior change
- [ ] New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](https://eodash.github.io/eodash/eodash-store) reference is generated from it
- [ ] New widget props are typed properly and they appear typed in the API reference
