### PR TITLE
fix: remove legacy direct wmts handler for marine copernicus

### DIFF
--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -595,7 +595,9 @@ export const createLayersFromLinks = async (
       "tileUrl",
       map,
     );
-    const linkProjectionCode = getProjectionCode(wmtsLinkProjection || "EPSG:3857");
+    const linkProjectionCode = getProjectionCode(
+      wmtsLinkProjection || "EPSG:3857",
+    );
     let json;
     const linkId = createLayerID(
       collectionId,
@@ -626,9 +628,7 @@ export const createLayersFromLinks = async (
         projection: linkProjectionCode,
         style: extractedStyle,
         ...(matrixSet ? { matrixSet } : {}),
-        ...(wmtsLink.attribution
-          ? { attributions: wmtsLink.attribution }
-          : {}),
+        ...(wmtsLink.attribution ? { attributions: wmtsLink.attribution } : {}),
         dimensions: dimensionsWithoutStyle,
       },
     };

--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -595,10 +595,7 @@ export const createLayersFromLinks = async (
       "tileUrl",
       map,
     );
-    const projectionCode = getProjectionCode(wmtsLinkProjection || "EPSG:3857");
-    // TODO: WARNING! This is a temporary project specific implementation
-    // that needs to be removed once catalog and wmts creation from capabilities
-    // combined with custom view projections is solved
+    const linkProjectionCode = getProjectionCode(wmtsLinkProjection || "EPSG:3857");
     let json;
     const linkId = createLayerID(
       collectionId,
@@ -612,64 +609,29 @@ export const createLayersFromLinks = async (
     let { style, matrixSet, ...dimensionsWithoutStyle } = { ...dimensions };
     let extractedStyle = /** @type { string } */ (style || "default");
 
-    // TODO, this does not yet work between layer time changes because we do not get
-    // updated variables from OL layer due to usage of tileurlfunction
+    log.debug("WMTS Layer from capabilities added", linkId);
 
-    if (wmtsLink.href.includes("marine.copernicus")) {
-      log.debug(
-        "Warning: WMTS Layer from capabilities added, function needs to be updated",
-        linkId,
-      );
-      json = {
-        type: "Tile",
-        properties: {
-          id: linkId,
-          title: title || item.id,
-          layerDatetime,
-          layerConfig: returnedLayerConfig.layerConfig,
-        },
-        source: {
-          type: "WMTS",
-          // TODO: Hard coding url as the current one set is for capabilities
-          url: "https://wmts.marine.copernicus.eu/teroWmts",
-          layer: wmtsLink["wmts:layer"],
-          style: extractedStyle,
-          // TODO: Hard coding matrixSet until we find solution to wmts creation from capabilities
-          matrixSet: "EPSG:3857",
-          projection: projectionCode,
-          tileGrid: {
-            tileSize: [128, 128],
-          },
-          ...(wmtsLink.attribution
-            ? { attributions: wmtsLink.attribution }
-            : {}),
-          dimensions: dimensionsWithoutStyle,
-        },
-      };
-    } else {
-      log.debug("WMTS Layer from capabilities added", linkId);
-
-      json = {
-        type: "Tile",
-        properties: {
-          id: linkId,
-          title: wmtsLink.title || title || item.id,
-          layerDatetime,
-          layerConfig: returnedLayerConfig.layerConfig,
-        },
-        source: {
-          type: "WMTSCapabilities",
-          url: buildCapabilitiesUrl(wmtsLink.href),
-          layer: wmtsLink["wmts:layer"],
-          style: extractedStyle,
-          ...(matrixSet ? { matrixSet } : {}),
-          ...(wmtsLink.attribution
-            ? { attributions: wmtsLink.attribution }
-            : {}),
-          dimensions: dimensionsWithoutStyle,
-        },
-      };
-    }
+    json = {
+      type: "Tile",
+      properties: {
+        id: linkId,
+        title: wmtsLink.title || title || item.id,
+        layerDatetime,
+        layerConfig: returnedLayerConfig.layerConfig,
+      },
+      source: {
+        type: "WMTSCapabilities",
+        url: buildCapabilitiesUrl(wmtsLink.href),
+        layer: wmtsLink["wmts:layer"],
+        projection: linkProjectionCode,
+        style: extractedStyle,
+        ...(matrixSet ? { matrixSet } : {}),
+        ...(wmtsLink.attribution
+          ? { attributions: wmtsLink.attribution }
+          : {}),
+        dimensions: dimensionsWithoutStyle,
+      },
+    };
     extractRoles(json.properties, wmtsLink);
     if (extraProperties !== null) {
       json.properties = {

--- a/tests/unit/eodashSTAC/helpers.test.js
+++ b/tests/unit/eodashSTAC/helpers.test.js
@@ -12,44 +12,54 @@ describe("applyTitilerUpscaling", () => {
   test("applies v1 upscaling (default)", () => {
     const upscalingEndpoints = ["https://api.example.com"];
     const result = applyTitilerUpscaling(url, upscalingEndpoints);
-    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}@2x?assets=data");
+    expect(result.url).toBe(
+      "https://api.example.com/tiles/{z}/{x}/{y}@2x?assets=data",
+    );
     expect(result.tileSize).toEqual([512, 512]);
   });
 
   test("applies v1 upscaling with scaleFactor", () => {
     const upscalingEndpoints = [
-      { url: "https://api.example.com", titilerVersion: 1, scaleFactor: 3 }
+      { url: "https://api.example.com", titilerVersion: 1, scaleFactor: 3 },
     ];
     const result = applyTitilerUpscaling(url, upscalingEndpoints);
     // scaleFactor 3 -> exponent = Math.round(2 * 3) = 6
-    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}@6x?assets=data");
+    expect(result.url).toBe(
+      "https://api.example.com/tiles/{z}/{x}/{y}@6x?assets=data",
+    );
   });
 
   test("applies v2 upscaling", () => {
     const upscalingEndpoints = [
-      { url: "https://api.example.com", titilerVersion: 2 }
+      { url: "https://api.example.com", titilerVersion: 2 },
     ];
     const result = applyTitilerUpscaling(url, upscalingEndpoints);
-    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}?assets=data&tilesize=512");
+    expect(result.url).toBe(
+      "https://api.example.com/tiles/{z}/{x}/{y}?assets=data&tilesize=512",
+    );
     expect(result.tileSize).toEqual([512, 512]);
   });
 
   test("applies v2 upscaling with decimal scaleFactor", () => {
     const upscalingEndpoints = [
-      { url: "https://api.example.com", titilerVersion: 2, scaleFactor: 1.5 }
+      { url: "https://api.example.com", titilerVersion: 2, scaleFactor: 1.5 },
     ];
     const result = applyTitilerUpscaling(url, upscalingEndpoints);
     // 512 * 1.5 = 768
-    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}?assets=data&tilesize=768");
+    expect(result.url).toBe(
+      "https://api.example.com/tiles/{z}/{x}/{y}?assets=data&tilesize=768",
+    );
   });
 
   test("applies v1 upscaling with decimal scaleFactor (rounded)", () => {
     const upscalingEndpoints = [
-      { url: "https://api.example.com", titilerVersion: 1, scaleFactor: 1.4 }
+      { url: "https://api.example.com", titilerVersion: 1, scaleFactor: 1.4 },
     ];
     const result = applyTitilerUpscaling(url, upscalingEndpoints);
     // scaleFactor 1.4 -> exponent = Math.round(2 * 1.4) = Math.round(2.8) = 3
-    expect(result.url).toBe("https://api.example.com/tiles/{z}/{x}/{y}@3x?assets=data");
+    expect(result.url).toBe(
+      "https://api.example.com/tiles/{z}/{x}/{y}@3x?assets=data",
+    );
   });
 
   test("handles plain string as v1 with scaleFactor 1", () => {


### PR DESCRIPTION
## Description

- remove legacy direct wmts handler for marine copernicus, current else block is sufficient

## Checklist

- [x] I have performed a self review on my code
- [ ] I added a test related to this feature/fix
- [x] I ran `npm run format` and `npm run check` pass
- [ ] Docs under `docs/` are updated for any public API, config, or behavior change
- [ ] New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](https://eodash.github.io/eodash/eodash-store) reference is generated from it
- [ ] New widget props are typed properly and they appear typed in the API reference
