### PR TITLE
feat: geolocation support

### DIFF
--- a/docs/widgets/internal-widgets/EodashMap.md
+++ b/docs/widgets/internal-widgets/EodashMap.md
@@ -54,6 +54,8 @@ Every `btns` flag defaults to `true`; set one to `false` to hide that button.
 | `enableSearch` | Search for a location. |
 | `enableFeedback` | Open the feedback form. |
 | `enableBackToPOIs` | Return to the points of interest. |
+| `enableGeolocation` | Uses the browser Geolocation API to pan map to device location. |
+| `geolocationOptions` | Object containing [geolocation options](https://eox-a.github.io/EOxElements/?path=/story/elements-eox-map--geolocation&globals=code-language:vanilla). |
 | `enableCompareIndicators` | Pick the dataset shown on the compare map. May also be an object with `compareTemplate`, `fallbackTemplate`, and `itemFilterConfig`. |
 
 

--- a/tests/component/EodashMap/btns.test.js
+++ b/tests/component/EodashMap/btns.test.js
@@ -125,6 +125,13 @@ describe("EodashMapBtns", () => {
       expect(btnByTooltip("Change map projection")).toBeTruthy();
       expect(btnByTooltip("Back to POIs")).toBeTruthy();
       expect(btnByTooltip("Provide Feedback")).toBeTruthy();
+      expect(btnByTooltip("Show your location")).toBeTruthy();
+    });
+
+    test("shows the geolocation button when enableGeolocation is true", async () => {
+      await mountBtns({ props: { enableGeolocation: true } });
+
+      expect(btnByTooltip("Show your location")).toBeTruthy();
     });
 
     test("hides the zoom buttons when enableZoom is false", async () => {
@@ -215,6 +222,15 @@ describe("EodashMapBtns", () => {
       await mountBtns();
       btnByTooltip("Back to POIs")?.click();
       expect(loadPOiIndicator).toHaveBeenCalled();
+    });
+
+    test("geolocation delegates to onGeolocationClick", async () => {
+      const onGeolocationClick = vi.fn();
+      await mountBtns({
+        props: { enableGeolocation: true, onGeolocationClick },
+      });
+      btnByTooltip("Show your location")?.click();
+      expect(onGeolocationClick).toHaveBeenCalled();
     });
   });
 

--- a/tests/component/EodashMap/btns.test.js
+++ b/tests/component/EodashMap/btns.test.js
@@ -129,7 +129,7 @@ describe("EodashMapBtns", () => {
     });
 
     test("shows the geolocation button when enableGeolocation is true", async () => {
-      await mountBtns({ props: { enableGeolocation: true } });
+      await mountBtns({ props: { btns: { enableGeolocation: true } } });
 
       expect(btnByTooltip("Show your location")).toBeTruthy();
     });

--- a/tests/component/EodashMap/btns.test.js
+++ b/tests/component/EodashMap/btns.test.js
@@ -40,6 +40,7 @@ const btns = vi.hoisted(() => ({
   onCompareClick: vi.fn(),
   onSelectCompareIndicator: vi.fn(),
   switchGlobe: vi.fn(),
+  onGeolocationClick: vi.fn(),
   showCompareIndicators: { value: false },
 }));
 vi.mock("^/EodashMap/methods/btns", () => btns);
@@ -106,6 +107,7 @@ describe("EodashMapBtns", () => {
       btns.onMapZoomOut,
       btns.onCompareClick,
       btns.switchGlobe,
+      btns.onGeolocationClick,
       loadPOiIndicator,
       actions.changeMapProjection,
     ]) {
@@ -225,12 +227,11 @@ describe("EodashMapBtns", () => {
     });
 
     test("geolocation delegates to onGeolocationClick", async () => {
-      const onGeolocationClick = vi.fn();
       await mountBtns({
-        props: { enableGeolocation: true, onGeolocationClick },
+        props: { enableGeolocation: true },
       });
       btnByTooltip("Show your location")?.click();
-      expect(onGeolocationClick).toHaveBeenCalled();
+      expect(btns.onGeolocationClick).toHaveBeenCalled();
     });
   });
 

--- a/tests/component/EodashMap/map.test.js
+++ b/tests/component/EodashMap/map.test.js
@@ -55,7 +55,6 @@ vi.mock("^/EodashMap/EodashMapBtns.vue", () => ({
       "enableGlobe",
       "enableFeedback",
       "enableGeolocation",
-      "onGeolocationClick",
       "searchParams",
     ],
     setup(/** @type {any} */ props) {

--- a/tests/component/EodashMap/map.test.js
+++ b/tests/component/EodashMap/map.test.js
@@ -52,6 +52,8 @@ vi.mock("^/EodashMap/EodashMapBtns.vue", () => ({
       "enableZoom",
       "enableGlobe",
       "enableFeedback",
+      "enableGeolocation",
+      "onGeolocationClick",
       "searchParams",
     ],
     setup(/** @type {any} */ props) {
@@ -125,6 +127,15 @@ describe("EodashMap", () => {
       expect(format([-10.5, -20.5])).toBe("20.500 °S, 10.500 °W");
       expect(format(null)).toBe("");
     });
+
+    test("binds Geolocation control onto eox-map when enabled", async () => {
+      await mountAsyncComponent(EodashMap, {
+        props: { enableGeolocation: true },
+      });
+
+      await expect.poll(() => mainMap()?.controls?.Geolocation).toBeTruthy();
+      expect(mainMap()?.controls.Geolocation.tracking).toBe(true);
+    });
   });
 
   describe("tooltip transform", () => {
@@ -169,6 +180,16 @@ describe("EodashMap", () => {
       await expect.poll(() => btnsCapture.props).toBeTruthy();
       expect(btnsCapture.props.exportMap).toBe(true);
       expect(btnsCapture.props.enableGlobe).toBe(false);
+    });
+
+    test("forwards geolocation once an indicator is selected", async () => {
+      indicator.value = "collA";
+      await mountAsyncComponent(EodashMap, {
+        props: { btns: { enableGeolocation: true } },
+      });
+
+      await expect.poll(() => btnsCapture.props).toBeTruthy();
+      expect(btnsCapture.props.enableGeolocation).toBe(true);
     });
   });
 

--- a/tests/component/EodashMap/map.test.js
+++ b/tests/component/EodashMap/map.test.js
@@ -130,7 +130,7 @@ describe("EodashMap", () => {
 
     test("binds Geolocation control onto eox-map when enabled", async () => {
       await mountAsyncComponent(EodashMap, {
-        props: { enableGeolocation: true },
+        props: { btns: { enableGeolocation: true } },
       });
 
       await expect.poll(() => mainMap()?.controls?.Geolocation).toBeTruthy();

--- a/widgets/EodashMap/EodashMapBtns.vue
+++ b/widgets/EodashMap/EodashMapBtns.vue
@@ -201,6 +201,7 @@ import {
   onMapZoomOut,
   onMapZoomIn,
   showCompareIndicators,
+  onGeolocationClick,
 } from "./methods/btns";
 import "@eox/geosearch";
 
@@ -221,7 +222,6 @@ const {
   enableGlobe,
   enableFeedback,
   enableGeolocation,
-  onGeolocationClick,
 } = defineProps({
   exportMap: {
     type: Boolean,
@@ -269,12 +269,6 @@ const {
   enableGeolocation: {
     type: Boolean,
     default: true,
-  },
-  onGeolocationClick: {
-    type: /** @type {import("vue").PropType<(payload: PointerEvent) => void>} */ (
-      Function
-    ),
-    default: () => {},
   },
 });
 

--- a/widgets/EodashMap/EodashMapBtns.vue
+++ b/widgets/EodashMap/EodashMapBtns.vue
@@ -107,6 +107,16 @@
       ></eox-geosearch>
     </button>
     <button
+      v-if="enableGeolocation"
+      class="primary small circle small-elevate"
+      @click="onGeolocationClick"
+    >
+      <i class="small">
+        <svg viewBox="0 0 24 24"><path :d="mdiCrosshairsGps"></path></svg>
+      </i>
+      <div class="tooltip left">Show your location</div>
+    </button>
+    <button
       v-if="backToPOIs && (poi || comparePoi)"
       class="primary small circle small-elevate"
       @click="loadPOiIndicator()"
@@ -176,6 +186,7 @@ import {
   mdiStarFourPointsCircleOutline,
   mdiEarth,
   mdiMessageQuestion,
+  mdiCrosshairsGps,
 } from "@mdi/js";
 import ExportState from "^/ExportState.vue";
 import { computed, ref } from "vue";
@@ -209,6 +220,8 @@ const {
   searchParams,
   enableGlobe,
   enableFeedback,
+  enableGeolocation,
+  onGeolocationClick,
 } = defineProps({
   exportMap: {
     type: Boolean,
@@ -252,6 +265,16 @@ const {
   enableFeedback: {
     type: Boolean,
     default: true,
+  },
+  enableGeolocation: {
+    type: Boolean,
+    default: true,
+  },
+  onGeolocationClick: {
+    type: /** @type {import("vue").PropType<(payload: PointerEvent) => void>} */ (
+      Function
+    ),
+    default: () => {},
   },
 });
 

--- a/widgets/EodashMap/index.vue
+++ b/widgets/EodashMap/index.vue
@@ -33,6 +33,7 @@
         />
       </eox-map>
     </eox-map-compare>
+    <div ref="geoTarget" style="display: none"></div>
     <div
       v-if="enableCursorCoordinates"
       id="cursor-coordinates"
@@ -60,6 +61,9 @@
         "
         :enableZoom="(indicator || compareIndicator || poi) ? btnsProps.enableZoom : false
         "
+        :enableGeolocation="(indicator || compareIndicator || poi) ? btnsProps.enableGeolocation : false
+        "
+        :onGeolocationClick="centerOnPosition"
         :enableGlobe="(indicator || compareIndicator || poi) ? btnsProps.enableGlobe : false"
         :enableFeedback="(indicator || compareIndicator || poi) ? btnsProps.enableFeedback : false"
         :searchParams="btnsProps.searchParams"
@@ -154,6 +158,23 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
+  /** Show a geolocation control. */
+  enableGeolocation: {
+    type: Boolean,
+    default: true,
+  },
+  /** Options for the geolocation control. */
+  geolocationOptions: {
+    type: Object,
+    default: () => ({
+      style: {
+        "circle-radius": 12,
+        "circle-fill-color": "red",
+        "circle-stroke-color": "white",
+        "circle-stroke-width": 3,
+      },
+    }),
+  },
   /** Grid position of the floating button toolbar. `x` accepts responsive `"mobile/tablet/desktop"` column notation. */
   btnsPosition: {
     type: /** @type {import("vue").PropType<{ x: string | number; y: number; gap: number }>} */ (
@@ -178,6 +199,8 @@ const props = defineProps({
      * enableGlobe?: boolean;
      * enableMosaic?: boolean;
      * enableFeedback?: boolean;
+     * enableGeolocation?: boolean;
+     * geolocationOptions?: object;
      * enableCompareIndicators?: boolean | {
      *   compareTemplate?:string;
      *   fallbackTemplate?:string;
@@ -194,6 +217,15 @@ const props = defineProps({
       enableGlobe: true,
       enableMosaic: true,
       enableFeedback: true,
+      enableGeolocation: true,
+      geolocationOptions: {
+        style: {
+          "circle-radius": 12,
+          "circle-fill-color": "red",
+          "circle-stroke-color": "white",
+          "circle-stroke-width": 3,
+        },
+      },
       searchParams: {},
     }),
   },
@@ -239,6 +271,8 @@ const btnsProps = computed(() => ({
   enableGlobe: props.btns.enableGlobe ?? true,
   enableMosaic: props.btns.enableMosaic ?? true,
   enableFeedback: props.btns.enableFeedback ?? true,
+  enableGeolocation: props.btns.enableGeolocation ?? true,
+  geolocationOptions: props.btns.geolocationOptions ?? {},
   searchParams: props.btns.searchParams,
 }));
 
@@ -248,6 +282,7 @@ if (btnsProps.value.enableGlobe) {
 // Prepare containers for scale line and cursor coordinates
 const scaleLineRef = useTemplateRef("scale-line");
 const cursorCoordsRef = useTemplateRef("cursor-coords");
+const geoTarget = useTemplateRef("geoTarget");
 
 /** @type {import("vue").Ref<Exclude<import("@/types").EodashStyleJson["tooltip"], undefined>>} */
 const tooltipProperties = ref([]);
@@ -279,6 +314,19 @@ const controls = computed(() => {
     };
   }
 
+  if (props.enableGeolocation || btnsProps.value.enableGeolocation) {
+    const geoOptions = {
+      tracking: true,
+      trackHeading: true,
+      highAccuracy: true,
+      trackAccuracy: true,
+      ...props.geolocationOptions,
+      ...btnsProps.value.geolocationOptions,
+      target: geoTarget.value || undefined,
+    };
+    controlsObj.Geolocation = geoOptions;
+  }
+
   return controlsObj;
 });
 
@@ -306,6 +354,28 @@ const animationOptions = ref({
 const eoxMap = useTemplateRef("eoxMap");
 /** @type {import("vue").Ref<import("@eox/map").EOxMap | null>} */
 const compareMap = useTemplateRef("compareMap");
+
+/**
+ * Trigger geolocation centering.
+ * Exposed for use in EodashMapBtns.vue
+ */
+const centerOnPosition = () => {
+  const map = eoxMap.value?.map;
+  if (!map) return;
+  const control = /** @type {any} */ (
+    map
+      .getControls()
+      .getArray()
+      .find((c) => !!(/** @type {any} */ (c).centerOnPosition))
+  );
+  if (control) {
+    control.centerOnPosition();
+  }
+};
+
+defineExpose({
+  centerOnPosition,
+});
 
 const { selectedCompareStac } = storeToRefs(useSTAcStore());
 const showCompare = computed(() =>

--- a/widgets/EodashMap/index.vue
+++ b/widgets/EodashMap/index.vue
@@ -158,23 +158,6 @@ const props = defineProps({
     type: Boolean,
     default: true,
   },
-  /** Show a geolocation control. */
-  enableGeolocation: {
-    type: Boolean,
-    default: true,
-  },
-  /** Options for the geolocation control. */
-  geolocationOptions: {
-    type: Object,
-    default: () => ({
-      style: {
-        "circle-radius": 12,
-        "circle-fill-color": "red",
-        "circle-stroke-color": "white",
-        "circle-stroke-width": 3,
-      },
-    }),
-  },
   /** Grid position of the floating button toolbar. `x` accepts responsive `"mobile/tablet/desktop"` column notation. */
   btnsPosition: {
     type: /** @type {import("vue").PropType<{ x: string | number; y: number; gap: number }>} */ (
@@ -314,13 +297,12 @@ const controls = computed(() => {
     };
   }
 
-  if (props.enableGeolocation || btnsProps.value.enableGeolocation) {
+  if (btnsProps.value.enableGeolocation) {
     const geoOptions = {
       tracking: true,
       trackHeading: true,
       highAccuracy: true,
       trackAccuracy: true,
-      ...props.geolocationOptions,
       ...btnsProps.value.geolocationOptions,
       target: geoTarget.value || undefined,
     };
@@ -372,10 +354,6 @@ const centerOnPosition = () => {
     control.centerOnPosition();
   }
 };
-
-defineExpose({
-  centerOnPosition,
-});
 
 const { selectedCompareStac } = storeToRefs(useSTAcStore());
 const showCompare = computed(() =>

--- a/widgets/EodashMap/index.vue
+++ b/widgets/EodashMap/index.vue
@@ -61,7 +61,6 @@
         "
         :enableGeolocation="(indicator || compareIndicator || poi) ? btnsProps.enableGeolocation : false
         "
-        :onGeolocationClick="centerOnPosition"
         :enableGlobe="(indicator || compareIndicator || poi) ? btnsProps.enableGlobe : false"
         :enableFeedback="(indicator || compareIndicator || poi) ? btnsProps.enableFeedback : false"
         :searchParams="btnsProps.searchParams"
@@ -344,23 +343,6 @@ const eoxMap = useTemplateRef("eoxMap");
 /** @type {import("vue").Ref<import("@eox/map").EOxMap | null>} */
 const compareMap = useTemplateRef("compareMap");
 
-/**
- * Trigger geolocation centering.
- * Exposed for use in EodashMapBtns.vue
- */
-const centerOnPosition = () => {
-  const map = eoxMap.value?.map;
-  if (!map) return;
-  const control = /** @type {any} */ (
-    map
-      .getControls()
-      .getArray()
-      .find((c) => !!(/** @type {any} */ (c).centerOnPosition))
-  );
-  if (control) {
-    control.centerOnPosition();
-  }
-};
 watchPostEffect(() => assignLayers(eoxMap.value, eoxMapLayers.value));
 watchPostEffect(() =>
   assignLayers(compareMap.value, eoxMapCompareLayers.value),

--- a/widgets/EodashMap/methods/btns.js
+++ b/widgets/EodashMap/methods/btns.js
@@ -186,3 +186,17 @@ export const onCompareClick = (compareIndicators) => {
   setActiveTemplate(fallbackTemplate);
   triggerRef(selectedStac);
 };
+
+export const onGeolocationClick = () => {
+  const map = mapEl.value?.map;
+  if (!map) return;
+  const control = /** @type {any} */ (
+    map
+      .getControls()
+      .getArray()
+      .find((c) => !!(/** @type {any} */ (c).centerOnPosition))
+  );
+  if (control) {
+    control.centerOnPosition();
+  }
+};


### PR DESCRIPTION
Integrates the Geolocation control as new map button - by default shown

close https://github.com/eodash/eodash/issues/440



## Description

Integrates EOxMap Geolocation support into EodashMap. Configurable via props/config and uses a custom-styled button in the map toolbar instead of the default OpenLayers UI.

Config Example:
 ```js
   {                    
     type: "EodashMap",                                     
     props: {
       btns: { enableGeolocation: true }
     }
   }
```

<img width="577" height="709" alt="image" src="https://github.com/user-attachments/assets/c0d9ecd7-007f-4636-9266-faeb5967f1cd" />


## Checklist

- [x] I have performed a self review on my code
- [x] I added a test related to this feature/fix
- [x] I ran `npm run format` and `npm run check` pass
- [x] Docs under `docs/` are updated for any public API, config, or behavior change
- [ ] New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](https://eodash.github.io/eodash/eodash-store) reference is generated from it
- [x] New widget props are typed properly and they appear typed in the API reference
