### PR TITLE
fix: remove `layerConfig` from base layers and overlays

### DIFF
--- a/core/client/eodashSTAC/EodashCollection.js
+++ b/core/client/eodashSTAC/EodashCollection.js
@@ -16,6 +16,7 @@ import {
   extractLayerLegend,
   extractLayerTimeValues,
   replaceLayer,
+  isBaseLayerOrOverlay,
 } from "./helpers";
 import { getLayers, registerProjection } from "@/store/actions";
 import {
@@ -539,11 +540,9 @@ export class EodashCollection {
   static async getIndicatorLayers(indicator) {
     const indicatorAssets = Object.keys(indicator?.assets ?? {}).reduce(
       (assets, ast) => {
-        if (
-          indicator.assets?.[ast].roles?.includes("baselayer") ||
-          indicator.assets?.[ast].roles?.includes("overlay")
-        ) {
-          assets[ast] = indicator.assets[ast];
+        const asset = indicator.assets?.[ast];
+        if (asset && isBaseLayerOrOverlay(asset)) {
+          assets[ast] = asset;
         }
         return assets;
       },

--- a/core/client/eodashSTAC/createLayers.js
+++ b/core/client/eodashSTAC/createLayers.js
@@ -22,6 +22,7 @@ import {
   normalizeNodata,
   resolveRenders,
   applyRasterFormValue,
+  isBaseLayerOrOverlay,
 } from "./helpers";
 import { handleAuthenticationOfLink } from "./auth";
 import log from "loglevel";
@@ -196,10 +197,8 @@ export async function createLayersFromAssets(
         stacObject.id,
         geoTIFFIdx[i],
       );
-      if (
-        assets[assetName]?.roles?.includes("overlay") ||
-        assets[assetName]?.roles?.includes("baselayer")
-      ) {
+      const isBaseOrOverlay = isBaseLayerOrOverlay(assets[assetName]);
+      if (isBaseOrOverlay) {
         // to prevent them being removed by date change on main dataset
         assetLayerId = assetName;
       }
@@ -220,7 +219,7 @@ export async function createLayersFromAssets(
         properties: {
           id: assetLayerId,
           title: assets[assetName]?.title || title,
-          layerConfig,
+          ...(!isBaseOrOverlay && { layerConfig }),
           layerDatetime,
         },
         style,
@@ -257,10 +256,8 @@ export async function createLayersFromAssets(
       )?.default ?? ["b04", "b03", "b02"];
 
       let assetLayerId = createAssetID(collectionId, stacObject.id, zarrIdx[i]);
-      if (
-        assets[assetName]?.roles?.includes("overlay") ||
-        assets[assetName]?.roles?.includes("baselayer")
-      ) {
+      const isBaseOrOverlay = isBaseLayerOrOverlay(assets[assetName]);
+      if (isBaseOrOverlay) {
         assetLayerId = assetName;
       }
 
@@ -271,7 +268,7 @@ export async function createLayersFromAssets(
         properties: {
           id: assetLayerId,
           title: assets[assetName]?.title || title,
-          layerConfig,
+          ...(!isBaseOrOverlay && { layerConfig }),
           layerDatetime,
         },
         source: {
@@ -312,10 +309,8 @@ export async function createLayersFromAssets(
         stacObject.id,
         geoJsonIdx[i],
       );
-      if (
-        assets[assetName]?.roles?.includes("overlay") ||
-        assets[assetName]?.roles?.includes("baselayer")
-      ) {
+      const isBaseOrOverlay = isBaseLayerOrOverlay(assets[assetName]);
+      if (isBaseOrOverlay) {
         // to prevent them being removed by date change on main dataset
         assetLayerId = assetName;
       }
@@ -348,12 +343,13 @@ export async function createLayersFromAssets(
           id: assetLayerId,
           title: assets[assetName]?.title || title,
           layerDatetime,
-          ...(layerConfig && {
-            layerConfig: {
-              ...layerConfig,
-              style,
-            },
-          }),
+          ...(layerConfig &&
+            !isBaseOrOverlay && {
+              layerConfig: {
+                ...layerConfig,
+                style,
+              },
+            }),
         },
         ...(!style?.variables && { style }),
         interactions: [],
@@ -385,10 +381,8 @@ export async function createLayersFromAssets(
         map,
       );
       let assetLayerId = createAssetID(collectionId, stacObject.id, fgbIdx[i]);
-      if (
-        assets[assetName]?.roles?.includes("overlay") ||
-        assets[assetName]?.roles?.includes("baselayer")
-      ) {
+      const isBaseOrOverlay = isBaseLayerOrOverlay(assets[assetName]);
+      if (isBaseOrOverlay) {
         // to prevent them being removed by date change on main dataset
         assetLayerId = assetName;
       }
@@ -422,12 +416,13 @@ export async function createLayersFromAssets(
           id: assetLayerId,
           title: assets[assetName]?.title || title,
           layerDatetime,
-          ...(layerConfig && {
-            layerConfig: {
-              ...layerConfig,
-              style,
-            },
-          }),
+          ...(layerConfig &&
+            !isBaseOrOverlay && {
+              layerConfig: {
+                ...layerConfig,
+                style,
+              },
+            }),
         },
         ...(!style?.variables && { style }),
         interactions: [],
@@ -498,14 +493,18 @@ export const createLayersFromLinks = async (
       wmsLink,
       viewProjectionCode,
     );
-    const rasterForm = await fetchRasterForm(
-      /** @type {string|object|undefined} */ (
-        wmsLink?.["eodash:rasterform"] ||
-          item?.["eodash:rasterform"] ||
-          collection?.["eodash:rasterform"]
-      ),
-      item,
-    );
+    // base layers and overlays are built without a layerConfig
+    const isBaseOrOverlay = isBaseLayerOrOverlay(wmsLink);
+    const rasterForm = isBaseOrOverlay
+      ? undefined
+      : await fetchRasterForm(
+          /** @type {string|object|undefined} */ (
+            wmsLink?.["eodash:rasterform"] ||
+              item?.["eodash:rasterform"] ||
+              collection?.["eodash:rasterform"]
+          ),
+          item,
+        );
     let { layerConfig } = extractLayerConfig(
       collectionId,
       {},
@@ -542,12 +541,7 @@ export const createLayersFromLinks = async (
         },
       },
     };
-    if (
-      // @ts-expect-error missing type definition, can be accessed like this
-      wmsLink.roles?.includes("baselayer") ||
-      // @ts-expect-error missing type definition, can be accessed like this
-      wmsLink.roles?.includes("overlay")
-    ) {
+    if (isBaseOrOverlay) {
       // @ts-expect-error no type for eox-map
       json.preload = Infinity;
     }
@@ -584,15 +578,18 @@ export const createLayersFromLinks = async (
 
     await registerProjection(wmtsLinkProjection);
 
-    const rasterForm = await fetchRasterForm(
-      /** @type {string|object|undefined} */ (
-        wmtsLink?.["eodash:rasterform"] ||
-          item?.["eodash:rasterform"] ||
-          collection?.["eodash:rasterform"]
-      ),
-      item,
-    );
-    const returnedLayerConfig = extractLayerConfig(
+    // base layers and overlays are built without a layerConfig
+    const rasterForm = isBaseLayerOrOverlay(wmtsLink)
+      ? undefined
+      : await fetchRasterForm(
+          /** @type {string|object|undefined} */ (
+            wmtsLink?.["eodash:rasterform"] ||
+              item?.["eodash:rasterform"] ||
+              collection?.["eodash:rasterform"]
+          ),
+          item,
+        );
+    const { layerConfig } = extractLayerConfig(
       collectionId,
       {},
       rasterForm,
@@ -623,7 +620,7 @@ export const createLayersFromLinks = async (
         id: linkId,
         title: wmtsLink.title || title || item.id,
         layerDatetime,
-        layerConfig: returnedLayerConfig.layerConfig,
+        ...(layerConfig && { layerConfig }),
       },
       source: {
         type: "WMTSCapabilities",
@@ -652,14 +649,18 @@ export const createLayersFromLinks = async (
     const xyzLinkProjection =
       /** @type {number | string | {name: string, def: string} | undefined} */
       (xyzLink?.["proj:epsg"] || xyzLink?.["eodash:proj4_def"]);
-    const rasterForm = await fetchRasterForm(
-      /** @type {string|object|undefined} */ (
-        xyzLink?.["eodash:rasterform"] ||
-          item?.["eodash:rasterform"] ||
-          collection?.["eodash:rasterform"]
-      ),
-      item,
-    );
+    // base layers and overlays are built without a layerConfig
+    const isBaseOrOverlay = isBaseLayerOrOverlay(xyzLink);
+    const rasterForm = isBaseOrOverlay
+      ? undefined
+      : await fetchRasterForm(
+          /** @type {string|object|undefined} */ (
+            xyzLink?.["eodash:rasterform"] ||
+              item?.["eodash:rasterform"] ||
+              collection?.["eodash:rasterform"]
+          ),
+          item,
+        );
     let { layerConfig } = extractLayerConfig(
       collectionId,
       {},
@@ -698,7 +699,7 @@ export const createLayersFromLinks = async (
         title: xyzLink.title || title || item.id,
         roles: xyzLink.roles,
         layerDatetime,
-        layerConfig,
+        ...(layerConfig && { layerConfig }),
       },
       source: {
         type: "XYZ",
@@ -727,12 +728,7 @@ export const createLayersFromLinks = async (
         ...tmsOptions,
       };
     }
-    if (
-      // @ts-expect-error missing type definition, can be accessed like this
-      xyzLink.roles?.includes("baselayer") ||
-      // @ts-expect-error missing type definition, can be accessed like this
-      xyzLink.roles?.includes("overlay")
-    ) {
+    if (isBaseOrOverlay) {
       // @ts-expect-error no type for eox-map
       json.preload = Infinity;
     }
@@ -780,14 +776,17 @@ export const createLayersFromLinks = async (
       (tilejsonLink?.["proj:epsg"] || tilejsonLink?.["eodash:proj4_def"]);
     await registerProjection(tilejsonProjection);
     const projectionCode = getProjectionCode(tilejsonProjection || "EPSG:3857");
-    const rasterForm = await fetchRasterForm(
-      /** @type {string|object|undefined} */ (
-        tilejsonLink?.["eodash:rasterform"] ||
-          item?.["eodash:rasterform"] ||
-          collection?.["eodash:rasterform"]
-      ),
-      item,
-    );
+    // base layers and overlays are built without a layerConfig
+    const rasterForm = isBaseLayerOrOverlay(tilejsonLink)
+      ? undefined
+      : await fetchRasterForm(
+          /** @type {string|object|undefined} */ (
+            tilejsonLink?.["eodash:rasterform"] ||
+              item?.["eodash:rasterform"] ||
+              collection?.["eodash:rasterform"]
+          ),
+          item,
+        );
     const { layerConfig } = extractLayerConfig(
       collectionId,
       {},
@@ -811,7 +810,7 @@ export const createLayersFromLinks = async (
         title: tilejsonLink.title || title || item.id,
         roles: tilejsonLink.roles,
         layerDatetime,
-        layerConfig,
+        ...(layerConfig && { layerConfig }),
       },
       source: {
         type: "XYZ",
@@ -888,12 +887,13 @@ export const createLayersFromLinks = async (
         title: vectorTileLink.title || title || item.id,
         roles: vectorTileLink.roles,
         layerDatetime,
-        ...(layerConfig && {
-          layerConfig: {
-            ...layerConfig,
-            style,
-          },
-        }),
+        ...(layerConfig &&
+          !isBaseLayerOrOverlay(vectorTileLink) && {
+            layerConfig: {
+              ...layerConfig,
+              style,
+            },
+          }),
       },
       source: {
         type: "VectorTile",

--- a/core/client/eodashSTAC/helpers.js
+++ b/core/client/eodashSTAC/helpers.js
@@ -546,6 +546,16 @@ export const extractRoles = (properties, linkOrAsset) => {
 };
 
 /**
+ * Whether a STAC link or asset is rendered as a baselayer or an overlay
+ * @param {import("stac-ts").StacLink | import("stac-ts").StacAsset | undefined} linkOrAsset
+ * @returns {boolean}
+ * */
+export const isBaseLayerOrOverlay = (linkOrAsset) => {
+  const roles = /** @type {string[] | undefined} */ (linkOrAsset?.roles);
+  return !!roles?.some((role) => role === "baselayer" || role === "overlay");
+};
+
+/**
  * Extracts a single non-link style JSON from a STAC Item optionally for a selected key mapping
  * @param { import("stac-ts").StacItem | import("stac-ts").StacCollection | null | undefined} stacObject
  * @param {string | undefined} linkKey
@@ -884,10 +894,7 @@ export const createLayerID = (collectionId, itemId, link, projectionCode) => {
   let lId = `${collectionId ?? ""};:;${itemId ?? ""};:;${linkId ?? ""};:;${projectionCode ?? ""}`;
   // If we are looking at base layers and overlays we remove the collection and item part
   // as we want to make sure tiles are not reloaded when switching layers
-  if (
-    /** @type {string[]} */
-    (link.roles)?.find((r) => ["baselayer", "overlay"].includes(r))
-  ) {
+  if (isBaseLayerOrOverlay(link)) {
     lId = `${linkId ?? ""};:;${projectionCode ?? ""}`;
   }
   log.debug("Generated Layer ID", lId);

--- a/docs/STAC.md
+++ b/docs/STAC.md
@@ -257,13 +257,13 @@ type EodashStyleJson = import("ol/style/flat").FlatStyleLike & {
 };
 ```
 
-Form values persist across layer rebuilds, and definitions support `${...}` item templating — see [Layer Configuration Forms](/widgets/internal-widgets/EodashLayerControl#layer-configuration-forms).
+Form values persist across layer rebuilds, and definitions support `${...}` item templating — see [Layer Configuration Forms](/widgets/internal-widgets/EodashLayerControl#layer-configuration-forms). Links and assets with a `"baselayer"` or `"overlay"` role do not get the form.
 
 ### eodash Raster Form
 
 The `eodash:rasterform` property allows providing visualization controls for tiled layers (WMS, WMTS, XYZ) that do not use OpenLayers Flat Styles. 
 
-It can be defined at the **Collection**, **Item**, or **Link** level. When present on a link or asset, it creates a configuration form in the layer control. 
+It can be defined at the **Collection**, **Item**, or **Link** level. When present on a link or asset, it creates a configuration form in the layer control. Links and assets with a `"baselayer"` or `"overlay"` role are skipped and do not get the form.
 
 - **For WMS**: Updating form values triggers a call to the source's `updateParams` method (e.g., updating `STYLES` or custom vendor parameters).
 - **For XYZ**: Updating form values triggers a refresh of the tile URL with the new parameters injected into the query string.

--- a/docs/widgets/internal-widgets/EodashLayerControl.md
+++ b/docs/widgets/internal-widgets/EodashLayerControl.md
@@ -36,7 +36,7 @@ widget: {
 
 ## Layer Configuration Forms
 
-Layers can expose configuration forms in the panel, defined through [eodash Flat Styles](/STAC#eodash-flat-styles) or [`eodash:rasterform`](/STAC#eodash-raster-form) in the STAC metadata.
+Layers can expose configuration forms in the panel, defined through [eodash Flat Styles](/STAC#eodash-flat-styles) or [`eodash:rasterform`](/STAC#eodash-raster-form) in the STAC metadata. Only data layers get a form, base layers and overlays are built without the form.
 
 ### State persistence
 

--- a/tests/unit/eodashSTAC/create-layers.test.js
+++ b/tests/unit/eodashSTAC/create-layers.test.js
@@ -503,6 +503,121 @@ describe("EodashCollection.buildJsonArray", () => {
     });
   });
 
+  describe("base layers and overlays", () => {
+    const rasterform = { jsonform: { type: "object", properties: {} } };
+
+    // one link per tileUrl loop, each carrying a rasterform so that a
+    // layerConfig would be built if the layer was not a base layer / overlay
+    const RASTER_FORM_LINKS = {
+      wms: { rel: "wms", href: "https://wms", title: "WMS", "wms:layers": "L" },
+      wmts: {
+        rel: "wmts",
+        href: "https://wmts",
+        title: "WMTS",
+        "wmts:layer": "lyr",
+      },
+      xyz: { rel: "xyz", href: "https://xyz/{z}/{x}/{y}", title: "XYZ" },
+      tilejson: { rel: "tilejson", href: "https://tj.json", title: "TJ" },
+    };
+    const rels = Object.keys(RASTER_FORM_LINKS);
+
+    /**
+     * @param {string} rel
+     * @param {Record<string, any>} [over]
+     */
+    const buildLink = (rel, over = {}) =>
+      build(
+        makeItem({
+          links: [
+            {
+              .../** @type {Record<string, any>} */ (RASTER_FORM_LINKS)[rel],
+              "eodash:rasterform": rasterform,
+              ...over,
+            },
+          ],
+        }),
+        { extras: { "https://tj.json": { tiles: ["https://t/{z}/{x}/{y}"] } } },
+      );
+
+    test.each(rels)("attaches a layerConfig to a data %s link", async (rel) => {
+      const [layer] = await buildLink(rel);
+
+      expect(layer.properties.layerConfig).toBeDefined();
+    });
+
+    test.each(rels)(
+      "omits the layerConfig of a %s baselayer link",
+      async (rel) => {
+        const [layer] = await buildLink(rel, { roles: ["baselayer"] });
+
+        expect(layer.properties.group).toBe("baselayer");
+        expect(layer.properties).not.toHaveProperty("layerConfig");
+      },
+    );
+
+    test("omits the layerConfig of an overlay link", async () => {
+      const [layer] = await buildLink("xyz", { roles: ["overlay"] });
+
+      expect(layer.properties.group).toBe("overlay");
+      expect(layer.properties).not.toHaveProperty("layerConfig");
+    });
+
+    test.each(["wms", "xyz"])("preloads a %s baselayer", async (rel) => {
+      const [layer] = await buildLink(rel, { roles: ["baselayer"] });
+
+      expect(layer.preload).toBe(Infinity);
+    });
+
+    test("skips the rasterform request of a baselayer link", async () => {
+      const [layer] = await build(
+        makeItem({
+          links: [
+            {
+              ...RASTER_FORM_LINKS.xyz,
+              roles: ["baselayer"],
+              "eodash:rasterform": "https://form.json",
+            },
+          ],
+        }),
+        { extras: { "https://form.json": rasterform } },
+      );
+
+      expect(layer.properties).not.toHaveProperty("layerConfig");
+      expect(axiosMock.get).not.toHaveBeenCalledWith("https://form.json");
+    });
+
+    test("omits the layerConfig of a baselayer asset", async () => {
+      serveUrls(axiosMock, {
+        "https://style.json": { jsonform: { type: "object" } },
+      });
+
+      const [layer] = await EodashCollection.getIndicatorLayers(
+        /** @type {any} */ ({
+          id: "ind",
+          links: [
+            {
+              rel: "style",
+              href: "https://style.json",
+              "asset:keys": ["base"],
+            },
+          ],
+          assets: {
+            base: {
+              type: "image/tiff",
+              href: "https://base.tif",
+              roles: ["baselayer"],
+            },
+          },
+        }),
+      );
+
+      expect(layer.properties.group).toBe("baselayer");
+      // the jsonform style resolved, it just did not end up as a layerConfig
+      expect(axiosMock.get).toHaveBeenCalledWith("https://style.json");
+      expect(layer.properties).not.toHaveProperty("layerConfig");
+    });
+  });
+
   describe("STAC fallback", () => {
     test("falls back to a STAC layer when nothing is supported", async () => {
       const item = makeItem({ links: [{ rel: "self", href: "https://self" }] });


### PR DESCRIPTION
## Description
This introduces a new helper `isBaseOrOverlayer` and adds a check before fetching rasterforms and applying the `layerConfig` to skip base layers and overlays
Close #436 

## Checklist

- [x] I have performed a self review on my code
- [x] I added a test related to this feature/fix
- [x] I ran `npm run format` and `npm run check` pass
- [x] Docs under `docs/` are updated for any public API, config, or behavior change
- [ ] ~New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](https://eodash.github.io/eodash/eodash-store) reference is generated from it~
- [ ] ~New widget props are typed properly and they appear typed in the API reference~
