### PR TITLE
chore: Initial monorepo restructure

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -12,12 +12,17 @@ jobs:
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
       - name: Set up NPM 🔧
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
       - name: Install dependencies 🔧
         run: npm ci
+      - name: Detect which package changed ⚙️
+        id: changed
+        run: node core/node/scripts/changedPackages.js ${{ github.event.pull_request.base.sha }}
       - name: Build and publish package 🚀
-        run: |
-          npx pkg-pr-new publish --comment=update
+        if: steps.changed.outputs.paths != ''
+        run: npx pkg-pr-new publish --comment=update ${{ steps.changed.outputs.paths }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,9 +28,14 @@ jobs:
           cache: "npm"
       - name: Install dependencies 👨🏻‍💻
         run: npm ci --prefer-offline --no-audit
-      - name: Publish package on NPM 📦
-        run: npm publish
-        if: ${{ steps.release.outputs.release_created }}
+      - name: Publish released packages on NPM 📦
+        run: |
+          set -euo pipefail
+          for path in $(jq -r '.[]' <<< '${{ steps.release.outputs.paths_released }}'); do
+            echo "publishing $path"
+            (cd "$path" && npm publish)
+          done
+        if: ${{ steps.release.outputs.releases_created == 'true' }}
       - name: Build and publish package 🚀
         run: |
           npx pkg-pr-new publish --comment=update

--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,8 +7,31 @@ on:
   workflow_dispatch:
 
 jobs:
-  test:
+  scope:
+    name: Detect which package changed ⚙️
+    runs-on: ubuntu-24.04
+    outputs:
+      app: ${{ steps.changed.outputs.app }}
+      packages: ${{ steps.changed.outputs.packages }}
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+      - name: Work out which suites to run 🔍
+        id: changed
+        # Comma separated package directory names, e.g. "mcp,stac". A package
+        # belongs here only when it reads the app's sources (core/, widgets/,
+        # templates/) instead of importing the built package, so that a change
+        # to the app runs its suite too. Leave empty when none do.
+        env:
+          RUN_ON_APP_CHANGE: ""
+        run: node core/node/scripts/changedPackages.js ${{ github.event.pull_request.base.sha }}
+
+  app:
     name: ${{ matrix.project }} tests
+    needs: scope
+    if: needs.scope.outputs.app == 'true'
     runs-on: ubuntu-24.04
     # continue-on-error: ${{ !matrix.blocking }}
     strategy:
@@ -50,3 +73,29 @@ jobs:
         run: npx playwright install-deps chromium
       - name: Run ${{ matrix.project }} tests 👀
         run: npm run test:${{ matrix.project }}
+
+  # One job for every workspace package, so adding `packages/<name>` with a
+  # matching `test:<name>` script is the whole registration.
+  packages:
+    name: ${{ matrix.package }} tests
+    needs: scope
+    if: needs.scope.outputs.packages != '[]'
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        package: ${{ fromJson(needs.scope.outputs.packages) }}
+    steps:
+      - name: Checkout 🛎
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup node env 🏗
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          check-latest: true
+          cache: "npm"
+      - name: Install dependencies 👨🏻‍💻
+        run: npm ci --prefer-offline --no-audit
+      # the packages run in node, so no browser is needed here
+      - name: Run ${{ matrix.package }} tests 👀
+        run: npm run test:${{ matrix.package }}

--- a/core/node/scripts/changedPackages.js
+++ b/core/node/scripts/changedPackages.js
@@ -1,0 +1,139 @@
+import { execFileSync } from "node:child_process";
+import { appendFileSync, globSync, readFileSync } from "node:fs";
+import { basename, dirname } from "node:path";
+
+/**
+ * Which scopes (`app` plus each workspace package) a branch touched, so CI
+ * runs only those suites.
+ *
+ * Usage: `node core/node/scripts/changedPackages.js <baseRef>` from the repo
+ * root. Writes `<scope>=true|false` lines plus `scopes=<json array>` to
+ * `$GITHUB_OUTPUT` and stdout. No base ref: everything counts as changed. A
+ * git failure exits non-zero on purpose: better a red job than an empty diff
+ * silently skipping every suite.
+ */
+
+/** The app itself: everything the workspaces do not own. */
+const APP = "app";
+
+/**
+ * No single scope owns these, so a change runs everything (`.github/`: CI
+ * edits must still prove the suites pass).
+ */
+const SHARED = [
+  "package.json",
+  "package-lock.json",
+  "vitest.config.js",
+  "tests/support/",
+  ".github/",
+];
+
+/** The app's sources; unlisted root files (docs/, Dockerfile, ...) map to no scope. */
+const APP_PATHS = ["core/", "widgets/", "templates/", "tests/"];
+
+/**
+ * Package directory names whose suites also run when the app's sources change,
+ * because they read those sources rather than importing the built package.
+ * Comma separated, set by the workflow; empty when no package does.
+ */
+const RUN_ON_APP_CHANGE = (process.env.RUN_ON_APP_CHANGE ?? "")
+  .split(",")
+  .map((scope) => scope.trim())
+  .filter(Boolean);
+
+const [baseRef] = process.argv.slice(2);
+const scopes = [APP, ...workspaceScopes()];
+const changed = baseRef ? scopesOf(changedFiles(baseRef)) : new Set(scopes);
+
+report(changed);
+
+/**
+ * Scope names: the directory name of every workspace package. Matching on the
+ * manifest skips a directory npm does not consider a workspace yet, and yields
+ * nothing at all while `packages/` is still absent.
+ *
+ * @returns {string[]}
+ */
+function workspaceScopes() {
+  /** @type {string[]} */
+  const workspaces =
+    JSON.parse(readFileSync("package.json", "utf-8")).workspaces ?? [];
+  return workspaces
+    .flatMap((glob) => globSync(`${glob}/package.json`))
+    .map((manifest) => basename(dirname(manifest)));
+}
+
+/**
+ * @param {string} baseRef what the branch is merging into, e.g. `origin/main`
+ * @returns {string[]} paths, relative to the repository root
+ */
+function changedFiles(baseRef) {
+  // -z keeps unicode paths unquoted; --no-renames lists both sides of a move.
+  return execFileSync(
+    "git",
+    ["diff", "--name-only", "-z", "--no-renames", `${baseRef}...HEAD`],
+    { encoding: "utf-8" },
+  )
+    .split("\0")
+    .filter(Boolean);
+}
+
+/**
+ * @param {string[]} files
+ * @returns {Set<string>} the scopes those files belong to
+ */
+function scopesOf(files) {
+  if (files.some((file) => SHARED.some((path) => file.startsWith(path)))) {
+    return new Set(scopes);
+  }
+  const touched = new Set();
+  let appSourcesChanged = false;
+  for (const file of files) {
+    const [, scope] = file.match(/^packages\/([^/]+)\//) ?? [];
+    if (scope && scopes.includes(scope)) {
+      // the app imports the packages, so its suites cover their changes too
+      touched.add(scope);
+      touched.add(APP);
+    } else if (APP_PATHS.some((path) => file.startsWith(path))) {
+      touched.add(APP);
+      appSourcesChanged = true;
+    }
+  }
+  // a package that reads the app's sources, rather than importing the built
+  // package, only proves it still works by running against the changed app.
+  // Keyed off the sources, not the `app` scope, which a package change also sets.
+  if (appSourcesChanged) {
+    RUN_ON_APP_CHANGE.filter((scope) => scopes.includes(scope)).forEach(
+      (scope) => touched.add(scope),
+    );
+  }
+  return touched;
+}
+
+/** @param {Set<string>} changed */
+function report(changed) {
+  const touched = scopes.filter((scope) => changed.has(scope));
+  const paths = touched.map((scope) =>
+    scope === APP ? "." : `./packages/${scope}`,
+  );
+  const lines = [
+    `${APP}=${changed.has(APP)}`,
+    // drives the packages job's matrix, so the app is not one of its entries
+    `packages=${JSON.stringify(touched.filter((scope) => scope !== APP))}`,
+    // ready to hand to a tool that takes package directories, e.g. pkg-pr-new
+    `paths=${paths.join(" ")}`,
+  ].join("\n");
+
+  if (process.env.GITHUB_OUTPUT) {
+    appendFileSync(process.env.GITHUB_OUTPUT, `${lines}\n`);
+  }
+  // "nothing ran" has to be visible: gating is only safe when a skipped suite
+  // is stated rather than inferred from a green check.
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    appendFileSync(
+      process.env.GITHUB_STEP_SUMMARY,
+      `Suites to run: ${touched.join(", ") || "none"}\n`,
+    );
+  }
+  console.log(lines);
+}

--- a/core/node/scripts/createPrereleaseTag.js
+++ b/core/node/scripts/createPrereleaseTag.js
@@ -2,9 +2,9 @@ import { execSync } from "child_process";
 
 const PRERELEASE_TYPE = "beta";
 
-// latest tag from git
+// latest tag from git, matched by the app's tag
 const latestTag = execSync(
-  "git describe --tags `git rev-list --tags --max-count=1`",
+  "git describe --tags --abbrev=0 --match 'eodash-v*'",
   { encoding: "utf-8" },
 )
   .toString()

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,9 @@
     "": {
       "name": "@eodash/eodash",
       "version": "5.9.0",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eox/chart": "^1.2.0",
         "@eox/drawtools": "^1.6.0",
@@ -59,6 +62,7 @@
         "@vue/devtools-api": "^8.1.5",
         "pkg-pr-new": "^0.0.87",
         "prettier": "^3.9.6",
+        "rolldown": "^1.2.3",
         "terminate": "^2.8.0",
         "tsc-alias": "^1.9.1",
         "typedoc": "^0.28.20",

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "@eodash/eodash",
   "version": "5.9.0",
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "types": "./dist/types/core/client/types.d.ts",
   "files": [
     "core/client",

--- a/tsconfig.typedoc.json
+++ b/tsconfig.typedoc.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
-  "include": ["dist/**/*.d.ts", "core/node/typedoc/widgets.ts"],
+  "include": [
+    "dist/**/*.d.ts",
+    "packages/*/dist/**/*.d.ts",
+    "core/node/typedoc/widgets.ts"
+  ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## Description
Converts the repo to npm workspaces so packages can live under `packages/` alongside the app, and scopes CI so a branch runs only the suites it affects.
This lands the shared structure once, so packages can be added as independent PRs instead of each one restructuring the build.

- Packages are discovered from the `packages/*` glob, and a package's directory name is its CI scope. Registering one needs no workflow changes.
- `run_tests.yml` resolves which scopes a branch touched, then runs the app matrix and one job per affected package.
- A package change runs the app's suites too, since the app imports the packages. A package that reads app sources instead of importing them can opt into the reverse direction by listing its directory in `RUN_ON_APP_CHANGE`.
- Release tooling handles more than one package. The npm publish step now gates on `releases_created` rather than `release_created`, because the latter is the root package's output and would skip publishing when only a package released. Dev prereleases publish just the packages a PR touched.

For contributors, adding a package under `packages/<name>`:

1. Add the package directory with its`package.json` in `packages/<dir>`. 
2. `npm install` at the root, and commit the `package-lock.json` change. Workspaces share the root lock.
3. A `test:<name>` script in the root `package.json` named after the directory, and a vitest project covering `packages/<name>/tests/` in `vitest.config.js`.
4. One entry each in `release-please-config.json` and `.release-please-manifest.json`, with the manifest version matching the package's own.
5. If the package ships types: its own `tsconfig.json` with `include`,`rootDir` and `outDir` overrides, a `build:types` script, and an entry poin `typedoc.config.json`.
6. If the package reads the app's sources rather than importing from it its directory name in `RUN_ON_APP_CHANGE` in `run_tests.yml`.

A new package's first publish is manual (`npm publish --access public`). CI publishes through npm trusted publishing, which is configured per package on npmjs.com and cannot perform the first one.

The first package to land should also appends `npm run check --workspaces --if-present` to `check`, and `npm run build:types --workspaces --if-present` to `docs:generate`. Both exit 1 when no workspace exists, which is why they are not in place yet.

## Checklist

- [x] I have performed a self review on my code
- [ ] ~I added a test related to this feature/fix~
- [x] I ran `npm run format` and `npm run check` pass
- [ ] ~Docs under `docs/` are updated for any public API, config, or behavior change~
- [ ] ~New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](https://eodash.github.io/eodash/eodash-store) reference is generated from it~
- [ ] ~New widget props are typed properly and they appear typed in the API reference~
