### PR TITLE
Feat/mcp stateless

### DIFF
--- a/core/client/components/DashboardLayout.vue
+++ b/core/client/components/DashboardLayout.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-main class="pa-0">
+  <v-main>
     <eox-layout
       :mediaBreakpoints="[0, 960, 1921]"
       :gap="gap"

--- a/core/node/cli/globals.js
+++ b/core/node/cli/globals.js
@@ -126,9 +126,10 @@ export async function getUserConfig(
 
   const forCommand = config?.[/** @type {"dev" | "preview"} */ (command)];
 
+  const port = options.port ?? forCommand?.port;
   return {
     base: options.base ?? config?.base,
-    port: Number(options.port ?? forCommand?.port),
+    port: port !== undefined ? Number(port) : undefined,
     host: options.host ?? forCommand?.host,
     open: options.open ?? forCommand?.open,
     cacheDir: options.cacheDir ?? config?.cacheDir,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,6 +113,11 @@ export default {
 
 The [Widgets](/widgets/) guide covers the three kinds of widgets and how to configure each. The [Templates](/templates) page explains how to start from a maintained template rather than an empty grid.
 
+::: tip Choosing the Right Template
+- **Static STAC Catalog** (e.g. `catalog.json`): Use `template: lite` (default). Static catalogs have fixed indicator trees and do not require item search widgets.
+- **Dynamic STAC API** (e.g. `api: true`): Use `template: explore` to provide item search and filter capabilities via `EodashItemCatalog` and `EodashItemFilter`.
+:::
+
 ## Deployment
 
 A configuration takes effect once it reaches a browser. eodash supports two deployment modes, and the same configuration object is used for both.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -24,12 +24,17 @@ The return value is a plain configuration object. Export it directly, or pass it
 
 The package exports four templates, each a [`Template`](/api/Configuration/interfaces/Template.html) describing a grid layout:
 
-| Template  | Layout | Source |
-| --------- | ------ | ------ |
-| `lite`    | A compact layout for non-experts: the map with a date picker, layer control, STAC info, and tools. | [lite.js](https://github.com/eodash/eodash/blob/main/templates/lite.js) |
-| `expert`  | The `lite` layout extended with charts and a processing widget. | [expert.js](https://github.com/eodash/eodash/blob/main/templates/expert.js) |
-| `compare` | A layout for comparing datasets, with charts, processing, and tools. | [compare.js](https://github.com/eodash/eodash/blob/main/templates/compare.js) |
-| `explore` | A catalog-driven layout pairing the item catalog with the map and layer control. | [explore.js](https://github.com/eodash/eodash/blob/main/templates/explore.js) |
+| Template  | Recommended For | Layout | Source |
+| --------- | --------------- | ------ | ------ |
+| `lite`    | **Static STAC Catalogs** | Compact layout for non-experts: map with date picker, layer control, STAC info, and tools. | [lite.js](https://github.com/eodash/eodash/blob/main/templates/lite.js) |
+| `explore` | **Dynamic STAC APIs** | Catalog-driven layout pairing the item catalog and item filters with the map and layer control. | [explore.js](https://github.com/eodash/eodash/blob/main/templates/explore.js) |
+| `expert`  | Advanced Analysis | The `lite` layout extended with charts and a processing widget. | [expert.js](https://github.com/eodash/eodash/blob/main/templates/expert.js) |
+| `compare` | Multi-dataset Comparison | Layout for comparing datasets, with charts, processing, and tools. | [compare.js](https://github.com/eodash/eodash/blob/main/templates/compare.js) |
+
+::: tip Template Selection Rule of Thumb
+- For **Static STAC Catalogs** (hierarchical `catalog.json` without search API), use **`lite`** (default). Static catalogs do not need item query filters or full-text item discovery catalogs.
+- For **Dynamic STAC APIs** (`api: true` / searchable item endpoints), use **`explore`** to leverage `EodashItemCatalog` and `EodashItemFilter`.
+:::
 
 Import a template and assign it to `template`:
 

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -20,20 +20,21 @@ Generate widget and architecture metadata from the codebase:
 npm run mcp:generate
 ```
 
-### 2. Run Server (HTTP / Streamable HTTP)
+### 2. Run Server (Stateless HTTP)
 
 ```bash
 npm run mcp:start
 # or custom port:
-node mcp-server/index.js --port 3001
+node packages/mcp/index.js --port 3001
 ```
 
+- Operates in stateless MCP mode (`sessionIdGenerator: undefined`, `enableJsonResponse: true`), returning direct JSON-RPC responses over HTTP POST without session state or open SSE streams.
 - Open `http://localhost:3001` in your browser to view the interactive server landing page and tool catalog.
 - Health check endpoint: `http://localhost:3001/health`.
 
 ### 3. MCP Client Configuration
 
-Connect your MCP client (Claude Desktop, cursor, inspector, or agents) via Streamable HTTP:
+Connect your MCP client (Claude Desktop, Cursor, Pi MCP adapter, MCP Inspector, or custom agents) via Streamable HTTP:
 
 #### MCP Inspector
 
@@ -41,7 +42,7 @@ Connect your MCP client (Claude Desktop, cursor, inspector, or agents) via Strea
 npx @modelcontextprotocol/inspector
 ```
 
-Connect to `http://localhost:3001` via Streamable HTTP / SSE transport.
+Connect to `http://localhost:3001` via Streamable HTTP.
 
 #### Claude Desktop Configuration (`claude_desktop_config.json`)
 
@@ -63,6 +64,8 @@ Connect to `http://localhost:3001` via Streamable HTTP / SSE transport.
 | `get_widget_details`      | Get full TypeScript props, defaults, store reads/writes, STAC extensions, example config, and markdown guide for a specific widget. |
 | `get_custom_widget_guide` | Detailed guides and templates for Web Component, Functional, and IFrame custom widgets.                                             |
 | `get_eodash_architecture` | Architecture reference covering the 12-column grid, templates, Pinia store states, and deployment modes.                            |
+| `scaffold_dashboard`      | Scaffold boilerplate for standalone SPA, VitePress narrative docs, or embedded web component dashboard projects.                    |
+| `generate_eodash_config`  | Generate type-safe eodash configuration with STAC endpoints, brand theme, layout template, and custom widgets.                      |
 
 ## Running Tests
 

--- a/packages/mcp/generate-metadata.js
+++ b/packages/mcp/generate-metadata.js
@@ -697,9 +697,9 @@ export function buildMetadata(repoRoot = DEFAULT_REPO_ROOT) {
     : ["lite", "explore", "expert", "compare"];
 
   const knownTemplateDescriptions = {
-    lite: "Streamlined view for public dissemination with minimal controls (Map, Header Tools, Layers, StacInfo, DatePicker).",
+    lite: "Streamlined layout for static STAC Catalogs & public dissemination with minimal controls (Map, Header Tools, Layers, StacInfo, DatePicker). Recommended default for static catalogs.",
     explore:
-      "Feature-rich discovery layout featuring ItemFilter, Catalog explorer, Map, LayerControl, TimeSlider, StacInfo, and Process analysis.",
+      "Feature-rich discovery layout for dynamic STAC APIs (ItemFilter, ItemCatalog explorer, Map, LayerControl, TimeSlider, StacInfo, and Process analysis). Recommended for searchable STAC APIs.",
     expert:
       "Power-user dashboard with comprehensive layer manipulation and full analysis tooling.",
     compare:

--- a/packages/mcp/generators/config.js
+++ b/packages/mcp/generators/config.js
@@ -6,7 +6,7 @@ import { DEFAULT_STAC_ENDPOINT, DEFAULT_BRAND_NAME } from "../helpers.js";
 export function generateEodashConfig({
   id = "demo-dashboard",
   stacEndpoint = DEFAULT_STAC_ENDPOINT,
-  template = "explore",
+  template = "lite",
   brand = {},
   customWidgets = [],
   options = {},

--- a/packages/mcp/generators/dashboard.js
+++ b/packages/mcp/generators/dashboard.js
@@ -11,7 +11,7 @@ export function scaffoldDashboard({
   name = "my-eo-dashboard",
   projectType = "standalone-spa",
   stacEndpoint = DEFAULT_STAC_ENDPOINT,
-  template = "explore",
+  template = "lite",
   brandName = DEFAULT_BRAND_NAME,
   brandColor = "#002742",
 } = {}) {
@@ -59,8 +59,8 @@ CMD ["nginx", "-g", "daemon off;"]
         private: true,
         type: "module",
         scripts: {
-          dev: "eodash dev --entryPoint eodash.config.js",
-          build: "eodash build --entryPoint eodash.config.js",
+          dev: "eodash dev",
+          build: "eodash build",
           preview: "eodash preview",
         },
         dependencies: {
@@ -71,13 +71,22 @@ CMD ["nginx", "-g", "daemon off;"]
       2,
     );
 
-    files["eodash.config.js"] = `import { deepmergeCustom } from "deepmerge-ts";
+    files["eodash.config.js"] = `import { defineConfig } from "@eodash/eodash";
+
+export default defineConfig({
+  entryPoint: "src/main.js",
+  dev: {
+    port: 3000,
+  },
+});
+`;
+
+    files["src/main.js"] = `import { createEodash } from "@eodash/eodash";
 import { explore, lite, expert, compare } from "@eodash/eodash/templates";
 
 const selectedTemplate = ${template};
 
-/** @type {import("@eodash/eodash").Eodash} */
-export default {
+export default createEodash({
   id: "${name}",
   stacEndpoint: "${stacEndpoint}",
   brand: {
@@ -92,7 +101,7 @@ export default {
     footerText: "${brandName} - Powered by eodash",
   },
   template: selectedTemplate,
-};
+});
 `;
 
     files["index.html"] = `<!DOCTYPE html>

--- a/packages/mcp/index.js
+++ b/packages/mcp/index.js
@@ -252,9 +252,9 @@ export function createMcpServer() {
           .describe("Default STAC catalog or STAC API endpoint URL."),
         template: templateEnum
           .optional()
-          .default("explore")
+          .default("lite")
           .describe(
-            `Default eodash layout template (${availableTemplates.join(", ")}).`,
+            `Default eodash layout template (${availableTemplates.join(", ")}). Use 'lite' (default) for static STAC Catalogs, or 'explore' for dynamic STAC APIs.`,
           ),
         brandName: z
           .string()
@@ -286,7 +286,7 @@ export function createMcpServer() {
     "generate_eodash_config",
     {
       description:
-        "Generate a complete, type-safe eodash configuration (eodash.config.js / baseConfig.js) with STAC endpoint, brand styling, template selection (explore/lite/expert/compare), custom widget placements, and runtime options.",
+        "Generate a complete, type-safe eodash configuration (eodash.config.js / baseConfig.js) with STAC endpoint, brand styling, template selection (lite/explore/expert/compare), custom widget placements, and runtime options.",
       inputSchema: z.object({
         id: z
           .string()
@@ -302,9 +302,9 @@ export function createMcpServer() {
           ),
         template: configTemplateEnum
           .optional()
-          .default("explore")
+          .default("lite")
           .describe(
-            `Template layout preset (${availableTemplates.join(", ")}) or 'custom'.`,
+            `Template layout preset (${availableTemplates.join(", ")}) or 'custom'. Use 'lite' (default) for static STAC Catalogs, or 'explore' for dynamic STAC APIs.`,
           ),
         brand: z
           .object({

--- a/packages/mcp/index.js
+++ b/packages/mcp/index.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 import { z } from "zod";
-import { randomUUID } from "crypto";
 import express from "express";
 import cors from "cors";
 import fs from "node:fs";
@@ -9,7 +8,6 @@ import { fileURLToPath } from "node:url";
 
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { scaffoldDashboard } from "./generators/dashboard.js";
 import { generateEodashConfig } from "./generators/config.js";
 import {
@@ -375,79 +373,38 @@ export function createMcpServer() {
 export function createExpressApp() {
   const app = express();
 
-  app.use(
-    cors({
-      origin: "*",
-      exposedHeaders: ["mcp-session-id", "Mcp-Session-Id"],
-    }),
-  );
+  app.use(cors({ origin: "*" }));
   app.use(express.json());
 
   app.get("/health", (req, res) => {
     res.json({ message: "eodash MCP Server is running" });
   });
 
-  const transports = {};
-
   app.post("/", async (req, res) => {
-    const sessionId = req.headers["mcp-session-id"];
-    let transport = transports[sessionId];
-
-    if (!transport) {
-      if (isInitializeRequest(req.body)) {
-        transport = new StreamableHTTPServerTransport({
-          sessionIdGenerator: () => randomUUID(),
-          onsessioninitialized: (newSessionId) => {
-            transports[newSessionId] = transport;
-            transport.onclose = () => {
-              delete transports[newSessionId];
-            };
-          },
-        });
-        const server = createMcpServer();
-        await server.connect(transport);
-        await transport.handleRequest(req, res, req.body);
-        return;
-      } else {
-        res.status(400).json({ error: "No session found" });
-        return;
+    try {
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: undefined,
+        enableJsonResponse: true,
+      });
+      const server = createMcpServer();
+      await server.connect(transport);
+      await transport.handleRequest(req, res, req.body);
+    } catch (err) {
+      console.error("Error handling MCP request:", err);
+      if (!res.headersSent) {
+        res.status(500).json({ error: err.message || "Internal server error" });
       }
     }
-    await transport.handleRequest(req, res, req.body);
   });
 
   app.get("/", async (req, res) => {
-    const sessionId = req.headers["mcp-session-id"];
-    const transport = transports[sessionId];
-    if (!transport) {
-      const accept = req.headers.accept || "";
-      if (accept.includes("text/event-stream")) {
-        res.writeHead(200, {
-          "Content-Type": "text/event-stream",
-          "Cache-Control": "no-cache",
-          Connection: "keep-alive",
-        });
-        res.write(": welcome\n\n");
-        res.end();
-        return;
-      }
-
-      const { widgetsData, architectureData } = getMetadata();
-      res.setHeader("Content-Type", "text/html");
-      res.send(generateLandingPage(widgetsData, architectureData));
-      return;
-    }
-    await transport.handleRequest(req, res);
+    const { widgetsData, architectureData } = getMetadata();
+    res.setHeader("Content-Type", "text/html");
+    res.send(generateLandingPage(widgetsData, architectureData));
   });
 
-  app.delete("/", async (req, res) => {
-    const sessionId = req.headers["mcp-session-id"];
-    const transport = transports[sessionId];
-    if (!transport) {
-      res.status(400).send("No session found");
-      return;
-    }
-    await transport.handleRequest(req, res);
+  app.delete("/", (req, res) => {
+    res.status(200).json({ message: "Stateless session closed" });
   });
 
   return app;

--- a/packages/mcp/tests/generators.test.js
+++ b/packages/mcp/tests/generators.test.js
@@ -17,9 +17,10 @@ describe("eodash Generators - scaffoldDashboard", () => {
     expect(res.projectType).toBe("standalone-spa");
     expect(res.name).toBe("alpine-monitor");
     expect(res.files["package.json"]).toBeDefined();
-    expect(res.files["eodash.config.js"]).toContain("alpine-monitor");
-    expect(res.files["eodash.config.js"]).toContain("https://example.com/stac");
-    expect(res.files["eodash.config.js"]).toContain("Alpine Monitor");
+    expect(res.files["src/main.js"]).toContain("alpine-monitor");
+    expect(res.files["src/main.js"]).toContain("https://example.com/stac");
+    expect(res.files["src/main.js"]).toContain("Alpine Monitor");
+    expect(res.files["eodash.config.js"]).toContain("entryPoint");
     expect(res.files["index.html"]).toBeDefined();
     expect(res.files["Dockerfile"]).toBeDefined();
     expect(res.files[".gitignore"]).toBeDefined();
@@ -152,7 +153,7 @@ describe("eodash MCP Server - Generator Tool Execution", () => {
 
     const body = JSON.parse(res.content[0].text);
     expect(body.name).toBe("mcp-test-dash");
-    expect(body.files["eodash.config.js"]).toContain("lite");
+    expect(body.files["src/main.js"]).toContain("lite");
   });
 
   it("executes generate_eodash_config MCP tool", async () => {

--- a/packages/mcp/tests/mcp-server.test.js
+++ b/packages/mcp/tests/mcp-server.test.js
@@ -199,14 +199,61 @@ describe("eodash MCP Server - HTTP Endpoints", () => {
     expect(html).toContain("EodashMap");
   });
 
-  it("POST / without valid session or init request returns 400", async () => {
+  it("DELETE / returns 200 stateless status", async () => {
+    const res = await fetch(`${baseUrl}/`, { method: "DELETE" });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.message).toContain("Stateless");
+  });
+
+  it("POST / without required Accept header returns 406", async () => {
     const res = await fetch(`${baseUrl}/`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ jsonrpc: "2.0", method: "invalid", id: 1 }),
+      body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
     });
-    expect(res.status).toBe(400);
-    const body = await res.json();
-    expect(body.error).toBe("No session found");
+    expect(res.status).toBe(406);
+  });
+
+  it("POST / executes JSON-RPC tools/list and tools/call statelessly without session header", async () => {
+    const headers = {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    };
+
+    // 1. tools/list direct call
+    const listRes = await fetch(`${baseUrl}/`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "tools/list",
+        params: {},
+      }),
+    });
+    expect(listRes.status).toBe(200);
+    const listBody = await listRes.json();
+    expect(listBody.result?.tools?.length).toBeGreaterThanOrEqual(6);
+
+    // 2. tools/call direct call
+    const callRes = await fetch(`${baseUrl}/`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 2,
+        method: "tools/call",
+        params: {
+          name: "list_widgets",
+          arguments: {},
+        },
+      }),
+    });
+    expect(callRes.status).toBe(200);
+    const callBody = await callRes.json();
+    expect(callBody.result?.content?.[0]?.type).toBe("text");
+    const widgets = JSON.parse(callBody.result.content[0].text);
+    expect(widgets.length).toBeGreaterThanOrEqual(10);
   });
 });


### PR DESCRIPTION
## Description                                                                                                                                                                         
Refactors the MCP server to use stateless HTTP transport mode and includes CLI/scaffolding improvements:
 - Stateless MCP Transport: Configured StreamableHTTPServerTransport with sessionIdGenerator: undefined and enableJsonResponse: true.
 - Simplified Server Lifecycle: Removed in-memory transports map, UUID session generation, and session validation routing. POST / handles JSON-RPC requests directly with standard JSON responses.
 - Scaffold & Template Updates:
     - Default template set to lite for static STAC catalogs, and explore for dynamic STAC APIs.
     - Separated src/main.js (dashboard definition) and eodash.config.js (cli config) in SPA boilerplate generation.
 - CLI & Layout Fixes: Fixed commander port parsing fallback and preserved Vuetify layout padding on `<v-main>` - _I've double checked and this was necessary fix for header and footer "overlapping" with the main app content in SPA deployment. Does not influence the vitepress (webcomponent) usually due to `noLayout: true`_
 - Documentation & Tests: Updated MCP documentation and test suite for stateless JSON-RPC endpoints and boilerplate output.                                                                                         
## Checklist
 - [x] I have performed a self review on my code                                                                                                                                     
 - [x] I added a test related to this feature/fix                                                                                                                                    
 - [x] I ran npm run format and npm run check pass                                                                                                                                   
 - [x] Docs under docs/ are updated for any public API, config, or behavior change                                                                                                   
 - [ ] New store states / actions / stac have JSDoc. Eodash Store (https://eodash.github.io/eodash/eodash-store) reference is generated from it                                      
 - [ ] New widget props are typed properly and they appear typed in the API reference                                                                                                

