### PR TITLE
fix: handling of response.contents for VEGA provided by "Whatever Origin" proxy

### DIFF
--- a/core/client/plugins/axios.js
+++ b/core/client/plugins/axios.js
@@ -104,6 +104,22 @@ function installErrorInterceptors() {
 }
 
 /**
+ * Checks if the response has a `contents` property that is a valid JSON string.
+ * Such structure is provided by CORS workaround from Whatever-Origin API.
+ * @param {any} data
+ */
+const parseResponseData = (data) => {
+  if (data && typeof data.contents === "string") {
+    try {
+      return JSON.parse(data.contents);
+    } catch (_e) {
+      return data;
+    }
+  }
+  return data;
+};
+
+/**
  * axios swallows `JSON.parse` failures and hands back the raw string, so a
  * malformed file reaches callers as a success. Skipped when the caller asked
  * for a non-JSON `responseType`.
@@ -111,6 +127,7 @@ function installErrorInterceptors() {
  * @param {import("axios").AxiosResponse} response
  */
 function reportParseFailure(response) {
+  response.data = parseResponseData(response.data);
   const body =
     !response.config.responseType && typeof response.data === "string"
       ? response.data

--- a/docs/STAC.md
+++ b/docs/STAC.md
@@ -341,6 +341,7 @@ Standard links without an `endpoint` property are processed immediately.
 - `type: "application/json"` - JSON data injected into Vega spec
   - Supports `method: "GET"` or `"POST"`
   - For POST: use `body` property pointing to a JSON file, can be a Mustache template
+  - If the response contains a `contents` property that is a valid JSON string, eodash will automatically parse it and use it as the chart data (this response structure is used in Whatever Origin API). Otherwise, the whole response is used.
 - `type: "text/csv"` - CSV data loaded as `data.url` in Vega spec
 - Optional `eox:flatstyle` on the link can point to a style JSON whose variables are also available for Mustache templating (e.g., thresholds, palette names)
 

--- a/tests/unit/EodashProcess/outputs.test.js
+++ b/tests/unit/EodashProcess/outputs.test.js
@@ -277,15 +277,11 @@ describe("processCharts", () => {
   });
 
   test("unwraps data from the 'contents' property if it's a valid JSON string", async () => {
-    const wrappedData = {
-      contents: JSON.stringify([{ x: 1, y: 2 }]),
-      status: { url: "...", http_code: 200 },
-    };
     axiosMock.get.mockImplementation((/** @type {string} */ url) =>
       Promise.resolve(
         url.includes("spec")
           ? { data: { mark: "line", data: { values: [] } } }
-          : { data: wrappedData },
+          : { data: [{ x: 1, y: 2 }] },
       ),
     );
 

--- a/tests/unit/EodashProcess/outputs.test.js
+++ b/tests/unit/EodashProcess/outputs.test.js
@@ -276,6 +276,28 @@ describe("processCharts", () => {
     expect(dataValues).toEqual({ A: [{ a: 1 }], B: [{ b: 2 }] });
   });
 
+  test("unwraps data from the 'contents' property if it's a valid JSON string", async () => {
+    const wrappedData = {
+      contents: JSON.stringify([{ x: 1, y: 2 }]),
+      status: { url: "...", http_code: 200 },
+    };
+    axiosMock.get.mockImplementation((/** @type {string} */ url) =>
+      Promise.resolve(
+        url.includes("spec")
+          ? { data: { mark: "line", data: { values: [] } } }
+          : { data: wrappedData },
+      ),
+    );
+
+    const [spec] = await processCharts({
+      links: L_CHART_JSON_GET,
+      jsonformValue: {},
+      specUrl: "https://x/spec.json",
+    });
+
+    expect(spec.data.values).toEqual([{ x: 1, y: 2 }]);
+  });
+
   test("uses custom-endpoint data when the handler returns some", async () => {
     axiosMock.get.mockResolvedValue({
       data: { mark: "line", data: { values: [] } },

--- a/tests/unit/plugins/axios.test.js
+++ b/tests/unit/plugins/axios.test.js
@@ -169,6 +169,19 @@ describe("described resources", () => {
     expect(errorState.value.severity).toBe("warning");
   });
 
+  test("unwraps data from the 'contents' property if it's a valid JSON string", async () => {
+    const wrappedData = {
+      contents: JSON.stringify({ id: "wrapped" }),
+    };
+    await commands.serveResponses({
+      "wrapped.json": { body: JSON.stringify(wrappedData) },
+    });
+
+    const { data } = await axios.get(url("wrapped"));
+
+    expect(data).toEqual({ id: "wrapped" });
+  });
+
   test.each([
     ["eodash:vegadefinition", "chart definition", "warning"],
     ["eodash:jsonform", "process form definition", "error"],

--- a/widgets/EodashProcess/methods/outputs.js
+++ b/widgets/EodashProcess/methods/outputs.js
@@ -94,7 +94,7 @@ export async function processCharts({
                 ...(jsonformValue ?? {}),
               }),
             )
-            .then((resp) => parseResponseData(resp.data));
+            .then((resp) => resp.data);
           // assign to spec datasets, assuming spec.data is InlineData
           // Always assign values as an object with string keys
           if (spec.data) {
@@ -160,23 +160,6 @@ export async function processCharts({
 }
 
 /**
- * Checks if the response has a `contents` property that is a valid JSON string. Such structure is provided by CORS workaround from Whatever-Origin API.
- * If so, parses and returns it. Otherwise returns the original data.
- * @param {any} data
- */
-const parseResponseData = (data) => {
-  if (data && typeof data.contents === "string") {
-    try {
-      const parsed = JSON.parse(data.contents);
-      return parsed;
-    } catch (_e) {
-      return data;
-    }
-  }
-  return data;
-};
-
-/**
  *
  * @param {import("vega-lite").TopLevelSpec} spec
  * @param {object} injectables
@@ -210,11 +193,7 @@ async function injectVegaInlineData(
             { ...jsonformValue, [match]: value },
             flatstyleUrl,
           );
-          dataValues.push(
-            await axios
-              .get(dataUrl)
-              .then((resp) => parseResponseData(resp.data)),
-          );
+          dataValues.push(await axios.get(dataUrl).then((resp) => resp.data));
         }
       }
       /** @type {import("vega-lite/types_unstable/data.js").InlineData} */
@@ -225,7 +204,7 @@ async function injectVegaInlineData(
     const dataUrl = await renderDataUrl(url, jsonformValue, flatstyleUrl);
     /** @type {import("vega-lite/types_unstable/data.js").InlineData} */
     (spec.data).values = await axios.get(dataUrl).then((resp) => {
-      return parseResponseData(resp.data);
+      return resp.data;
     });
   } else if (link.method == "POST") {
     // get body template to be used in POST request, check first if available
@@ -274,11 +253,7 @@ async function injectVegaInlineData(
             index,
           );
           const body = renderJsonBodyTemplate(bodyTemplate, requestContext);
-          responses.push(
-            await axios
-              .post(url, body)
-              .then((resp) => parseResponseData(resp.data)),
-          );
+          responses.push(await axios.post(url, body).then((resp) => resp.data));
         }
       }
       /** @type {import("vega-lite/types_unstable/data.js").InlineData} */
@@ -291,7 +266,7 @@ async function injectVegaInlineData(
     });
     /** @type {import("vega-lite/types_unstable/data.js").InlineData} */
     (spec.data).values = await axios.post(url, body).then((resp) => {
-      return parseResponseData(resp.data);
+      return resp.data;
     });
   }
   return spec;

--- a/widgets/EodashProcess/methods/outputs.js
+++ b/widgets/EodashProcess/methods/outputs.js
@@ -169,7 +169,7 @@ const parseResponseData = (data) => {
     try {
       const parsed = JSON.parse(data.contents);
       return parsed;
-    } catch (e) {
+    } catch (_e) {
       return data;
     }
   }

--- a/widgets/EodashProcess/methods/outputs.js
+++ b/widgets/EodashProcess/methods/outputs.js
@@ -94,7 +94,7 @@ export async function processCharts({
                 ...(jsonformValue ?? {}),
               }),
             )
-            .then((resp) => resp.data);
+            .then((resp) => parseResponseData(resp.data));
           // assign to spec datasets, assuming spec.data is InlineData
           // Always assign values as an object with string keys
           if (spec.data) {
@@ -160,6 +160,23 @@ export async function processCharts({
 }
 
 /**
+ * Checks if the response has a `contents` property that is a valid JSON string. Such structure is provided by CORS workaround from Whatever-Origin API.
+ * If so, parses and returns it. Otherwise returns the original data.
+ * @param {any} data
+ */
+const parseResponseData = (data) => {
+  if (data && typeof data.contents === "string") {
+    try {
+      const parsed = JSON.parse(data.contents);
+      return parsed;
+    } catch (e) {
+      return data;
+    }
+  }
+  return data;
+};
+
+/**
  *
  * @param {import("vega-lite").TopLevelSpec} spec
  * @param {object} injectables
@@ -193,7 +210,11 @@ async function injectVegaInlineData(
             { ...jsonformValue, [match]: value },
             flatstyleUrl,
           );
-          dataValues.push(await axios.get(dataUrl).then((resp) => resp.data));
+          dataValues.push(
+            await axios
+              .get(dataUrl)
+              .then((resp) => parseResponseData(resp.data)),
+          );
         }
       }
       /** @type {import("vega-lite/types_unstable/data.js").InlineData} */
@@ -204,7 +225,7 @@ async function injectVegaInlineData(
     const dataUrl = await renderDataUrl(url, jsonformValue, flatstyleUrl);
     /** @type {import("vega-lite/types_unstable/data.js").InlineData} */
     (spec.data).values = await axios.get(dataUrl).then((resp) => {
-      return resp.data;
+      return parseResponseData(resp.data);
     });
   } else if (link.method == "POST") {
     // get body template to be used in POST request, check first if available
@@ -253,7 +274,11 @@ async function injectVegaInlineData(
             index,
           );
           const body = renderJsonBodyTemplate(bodyTemplate, requestContext);
-          responses.push(await axios.post(url, body).then((resp) => resp.data));
+          responses.push(
+            await axios
+              .post(url, body)
+              .then((resp) => parseResponseData(resp.data)),
+          );
         }
       }
       /** @type {import("vega-lite/types_unstable/data.js").InlineData} */
@@ -266,7 +291,7 @@ async function injectVegaInlineData(
     });
     /** @type {import("vega-lite/types_unstable/data.js").InlineData} */
     (spec.data).values = await axios.post(url, body).then((resp) => {
-      return resp.data;
+      return parseResponseData(resp.data);
     });
   }
   return spec;


### PR DESCRIPTION
## Description

Adds special handling for parsing responses from https://github.com/reynaldichernando/Whatever-Origin API to VEGA with `contents` property being a JSON string in the Axios plugin.
```
{
    "contents": "{\n  \"parameters\": {\n    \"x\": \"13.900148558251688\",\n    \"y\": \"47.58716723289092\",\n    \"epsg\": \"4326\"\n  },\n  \"data\": {\n    \"basiswindgeschwindigkeit\": \"31.5\",\n    \"blitzdichte\": \"2\",\n    \"erdbeben\": \"1\",\n    \"erdbeben_agr\": \"0.38\",\n    \"hagel\": \"3\",\n    \"hitze\": \"0.00\",\n    \"hochwasser\": \"\",\n    \"lawinen\": \"\",\n    \"oberflaechenabfluss_d\": \"1\",\n    \"oberflaechenabfluss_v\": \"1\",\n    \"rutschungen\": \"2\",\n    \"schneelast\": \"8.5\",\n    \"windspitzen\": \"12\"\n  }\n}",
    "status": {
        "url": "bla",
        "content_type": "application/json",
        "http_code": 200
    }
}
```

- miscellaneous edit fix of expert template to get mapBtns positions right 

## Checklist

- [x] I have performed a self review on my code
- [x] I added a test related to this feature/fix
- [x] I ran `npm run format` and `npm run check` pass
- [x] Docs under `docs/` are updated for any public API, config, or behavior change
- [ ] New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](https://eodash.github.io/eodash/eodash-store) reference is generated from it
- [ ] New widget props are typed properly and they appear typed in the API reference
