### PR TITLE
Feat/refactor mcp application

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -59,17 +59,17 @@ jobs:
         run: npm ci --prefer-offline --no-audit
       # the cli project runs in node, so it needs no browser
       - name: Cache Playwright browser 🎭
-        if: matrix.project != 'cli' && matrix.project != 'mcp'
+        if: matrix.project != 'cli'
         id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
       - name: Install Playwright browser 🎭
-        if: matrix.project != 'cli' && steps.playwright-cache.outputs.cache-hit != 'true' && matrix.project != 'mcp'
+        if: matrix.project != 'cli' && steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install chromium
       - name: Install Playwright system deps 🎭
-        if: matrix.project != 'cli' && matrix.project != 'mcp'
+        if: matrix.project != 'cli'
         run: npx playwright install-deps chromium
       - name: Run ${{ matrix.project }} tests 👀
         run: npm run test:${{ matrix.project }}

--- a/core/node/typedoc/fix-vue-props-jsdoc.js
+++ b/core/node/typedoc/fix-vue-props-jsdoc.js
@@ -139,12 +139,21 @@ function extractDefinePropsInfo(scriptContent, filename) {
         if (ts.isObjectLiteralExpression(prop.initializer)) {
           const defaultProp = prop.initializer.properties.find(
             (p) =>
-              ts.isPropertyAssignment(p) &&
+              (ts.isPropertyAssignment(p) || ts.isMethodDeclaration(p)) &&
               ts.isIdentifier(p.name) &&
               p.name.text === "default",
           );
           if (defaultProp) {
-            sourceDefault = defaultValueText(defaultProp.initializer, sf);
+            if (ts.isMethodDeclaration(defaultProp)) {
+              const ret = defaultProp.body?.statements.find((s) =>
+                ts.isReturnStatement(s),
+              );
+              sourceDefault = ret?.expression
+                ? ret.expression.getText(sf).replace(/\s+/g, " ").trim()
+                : defaultProp.getText(sf).replace(/\s+/g, " ").trim();
+            } else {
+              sourceDefault = defaultValueText(defaultProp.initializer, sf);
+            }
           }
         }
 

--- a/core/node/widgets.js
+++ b/core/node/widgets.js
@@ -1,0 +1,30 @@
+import { globSync } from "node:fs";
+
+/**
+ * Widgets present in widgets/ but intentionally excluded from public docs and MCP server catalog.
+ */
+export const EXCLUDED_WIDGETS = new Set([
+  "ExportState",
+  "PopUp",
+  "WidgetsContainer",
+]);
+
+/**
+ * Discovers built-in widget names by scanning widgets/ directory.
+ *
+ * @param {string} repoRoot - Absolute or relative path to repo root.
+ * @returns {string[]} Sorted array of widget component names.
+ */
+export function discoverWidgetNames(repoRoot = ".") {
+  const fileWidgets = globSync("widgets/*.vue", { cwd: repoRoot }).map((p) =>
+    p.replace(/^widgets[/\\]/, "").replace(/\.vue$/, ""),
+  );
+
+  const dirWidgets = globSync("widgets/*/index.vue", { cwd: repoRoot }).map(
+    (p) => p.replace(/^widgets[/\\]/, "").replace(/[/\\]index\.vue$/, ""),
+  );
+
+  return Array.from(new Set([...fileWidgets, ...dirWidgets]))
+    .filter((name) => !EXCLUDED_WIDGETS.has(name))
+    .sort();
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -115,7 +115,7 @@ The [Widgets](/widgets/) guide covers the three kinds of widgets and how to conf
 
 ::: tip Choosing the Right Template
 - **Static STAC Catalog** (e.g. `catalog.json`): Use `template: lite` (default). Static catalogs have fixed indicator trees and do not require item search widgets.
-- **Dynamic STAC API** (e.g. `api: true`): Use `template: explore` to provide item search and filter capabilities via `EodashItemCatalog` and `EodashItemFilter`.
+- **Dynamic STAC API** (e.g. `api: true`): Use `template: explore` to provide item search and discovery capabilities via `EodashItemCatalog` and `EodashLayerControl`.
 :::
 
 ## Deployment

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -27,13 +27,13 @@ The package exports four templates, each a [`Template`](/api/Configuration/inter
 | Template  | Recommended For | Layout | Source |
 | --------- | --------------- | ------ | ------ |
 | `lite`    | **Static STAC Catalogs** | Compact layout for non-experts: map with date picker, layer control, STAC info, and tools. | [lite.js](https://github.com/eodash/eodash/blob/main/templates/lite.js) |
-| `explore` | **Dynamic STAC APIs** | Catalog-driven layout pairing the item catalog and item filters with the map and layer control. | [explore.js](https://github.com/eodash/eodash/blob/main/templates/explore.js) |
+| `explore` | **Dynamic STAC APIs** | Catalog-driven layout pairing the item catalog and layer control with an interactive map. | [explore.js](https://github.com/eodash/eodash/blob/main/templates/explore.js) |
 | `expert`  | Advanced Analysis | The `lite` layout extended with charts and a processing widget. | [expert.js](https://github.com/eodash/eodash/blob/main/templates/expert.js) |
 | `compare` | Multi-dataset Comparison | Layout for comparing datasets, with charts, processing, and tools. | [compare.js](https://github.com/eodash/eodash/blob/main/templates/compare.js) |
 
 ::: tip Template Selection Rule of Thumb
 - For **Static STAC Catalogs** (hierarchical `catalog.json` without search API), use **`lite`** (default). Static catalogs do not need item query filters or full-text item discovery catalogs.
-- For **Dynamic STAC APIs** (`api: true` / searchable item endpoints), use **`explore`** to leverage `EodashItemCatalog` and `EodashItemFilter`.
+- For **Dynamic STAC APIs** (`api: true` / searchable item endpoints), use **`explore`** to leverage `EodashItemCatalog` and dynamic item discovery.
 :::
 
 Import a template and assign it to `template`:

--- a/docs/widgets/internal-widgets.data.js
+++ b/docs/widgets/internal-widgets.data.js
@@ -1,25 +1,13 @@
-import { globSync, readFileSync, existsSync } from "node:fs";
+import { readFileSync, existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
+import { discoverWidgetNames } from "../../core/node/widgets.js";
 
 const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "../..");
 const DOCS_DIR = join(REPO_ROOT, "docs");
 
-/** Widgets present in widgets/ but intentionally excluded from public docs. */
-const EXCLUDED = new Set(["ExportState", "PopUp"]);
-
 function resolveWidgetNames() {
-  const fileWidgets = globSync("widgets/*.vue", { cwd: REPO_ROOT }).map(
-    (p) => p.replace(/^widgets\//, "").replace(/\.vue$/, ""),
-  );
-
-  const dirWidgets = globSync("widgets/*/index.vue", { cwd: REPO_ROOT }).map(
-    (p) => p.replace(/^widgets\//, "").replace(/\/index\.vue$/, ""),
-  );
-
-  return [...fileWidgets, ...dirWidgets]
-    .filter((name) => !EXCLUDED.has(name))
-    .sort();
+  return discoverWidgetNames(REPO_ROOT);
 }
 
 function resolveRegisteredNames() {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11379,7 +11379,6 @@
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
-      "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -13674,8 +13673,10 @@
       "version": "1.0.0",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@vue/compiler-sfc": "^3.5.41",
         "cors": "^2.8.5",
         "express": "^5.2.1",
+        "typescript": "^6.0.3",
         "zod": "^3.24.1"
       },
       "bin": {

--- a/packages/mcp/generate-metadata.js
+++ b/packages/mcp/generate-metadata.js
@@ -4,12 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import ts from "typescript";
 import { parse as parseVueSFC } from "@vue/compiler-sfc";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const DEFAULT_REPO_ROOT = path.resolve(__dirname, "../..");
-
-const EXCLUDED_WIDGETS = new Set(["ExportState", "PopUp", "WidgetsContainer"]);
+import { discoverWidgetNames } from "../../core/node/widgets.js";
 
 // Known widget fallback categories & STAC extensions if not documented elsewhere
 const CATEGORY_MAP = {
@@ -42,42 +37,30 @@ const STAC_EXTENSIONS_MAP = {
     "eodash:merge_assets",
     "eodash:layerExclusive",
   ],
-  EodashItemCatalog: ["eo:cloud_cover", "datetime", "assets.thumbnail"],
-  EodashItemFilter: ["themes", "tags"],
-  EodashTimeSlider: ["extent.temporal", "datetime"],
-  EodashDatePicker: ["extent.temporal", "datetime"],
-  EodashProcess: ["eodash:jsonform", "links (rel=service)"],
-  EodashChart: [
-    "links (rel=service, type=application/json|text/csv)",
-    "eodash:vegadefinition",
-  ],
-  EodashStacInfo: ["sci:citation", "sci:doi", "sci:publication", "providers"],
+  EodashItemCatalog: ["eo:cloud_cover"],
+  EodashItemFilter: [],
+  EodashTimeSlider: [],
+  EodashDatePicker: [],
+  EodashProcess: ["eodash:jsonform"],
+  EodashChart: ["eodash:vegadefinition"],
+  EodashStacInfo: ["sci:citation", "sci:doi", "sci:publication"],
 };
 
-/**
- * 1. Dynamically discover widget names in widgets/
- */
-function discoverWidgetNames(repoRoot) {
-  const widgetsDir = path.join(repoRoot, "widgets");
-  if (!fs.existsSync(widgetsDir)) return [];
+const STAC_CORE_FIELDS_MAP = {
+  EodashMap: [],
+  EodashLayerControl: [],
+  EodashItemCatalog: ["datetime", "assets.thumbnail"],
+  EodashItemFilter: ["themes", "tags", "summaries"],
+  EodashTimeSlider: ["extent.temporal", "datetime"],
+  EodashDatePicker: ["extent.temporal", "datetime"],
+  EodashProcess: ["links (rel=service)"],
+  EodashChart: ["links (rel=service, type=application/json|text/csv)"],
+  EodashStacInfo: ["providers", "description", "title"],
+};
 
-  const entries = fs.readdirSync(widgetsDir, { withFileTypes: true });
-  const names = new Set();
-
-  for (const entry of entries) {
-    if (entry.isFile() && entry.name.endsWith(".vue")) {
-      const name = entry.name.replace(/\.vue$/, "");
-      if (!EXCLUDED_WIDGETS.has(name)) names.add(name);
-    } else if (entry.isDirectory()) {
-      const indexPath = path.join(widgetsDir, entry.name, "index.vue");
-      if (fs.existsSync(indexPath) && !EXCLUDED_WIDGETS.has(entry.name)) {
-        names.add(entry.name);
-      }
-    }
-  }
-
-  return Array.from(names).sort();
-}
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DEFAULT_REPO_ROOT = path.resolve(__dirname, "../..");
 
 /**
  * Recursively collect all files in a directory
@@ -906,6 +889,7 @@ export function buildMetadata(repoRoot = DEFAULT_REPO_ROOT) {
     const storeInteractions = analyzeStoreInteractions(name, repoRoot);
     const category = CATEGORY_MAP[name] || "General";
     const stacExtensions = STAC_EXTENSIONS_MAP[name] || [];
+    const stacCoreFields = STAC_CORE_FIELDS_MAP[name] || [];
     const isBackground = name === "EodashMap";
 
     // Extract first summary paragraph from markdown guide if available
@@ -948,6 +932,7 @@ export function buildMetadata(repoRoot = DEFAULT_REPO_ROOT) {
       props: props || [],
       storeInteractions,
       stacExtensions,
+      stacCoreFields,
       example,
       templateExample: templateExamples[name] || null,
       markdownGuide: guide,

--- a/packages/mcp/generate-metadata.js
+++ b/packages/mcp/generate-metadata.js
@@ -101,49 +101,90 @@ function collectFiles(dir) {
   return results;
 }
 
-/**
- * Clean and parse JSDoc comments attached to AST nodes
- */
-function cleanDoc(comment) {
-  if (!comment)
-    return { description: "", type: null, params: [], returns: null };
-  const lines = comment
-    .replace(/^\/\*\*?/, "")
-    .replace(/\*\/$/, "")
+function cleanMultilineType(typeStr) {
+  if (!typeStr) return null;
+  return typeStr
     .split("\n")
-    .map((l) => l.replace(/^\s*\*\s?/, "").trim())
-    .filter(Boolean);
+    .map((line) => line.replace(/^\s*\*\s?/, "").trim())
+    .filter(Boolean)
+    .join(" ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
 
-  let type = null;
-  let returns = null;
+function unwrapPropType(typeStr) {
+  if (!typeStr) return "unknown";
+  const cleaned = cleanMultilineType(typeStr);
+  const match = cleaned.match(
+    /^(?:import\(["']vue["']\)\.)?PropType<([\s\S]+)>$/,
+  );
+  if (match) return match[1].trim();
+  return cleaned;
+}
+
+/**
+ * Clean and parse JSDoc comments attached to AST nodes using TypeScript compiler API
+ */
+function getJsDocFromNode(node, sf) {
+  const tsType = ts.getJSDocType(node);
+  let type = tsType ? tsType.getText(sf) : null;
+  let description = "";
   const params = [];
-  const descLines = [];
+  let returns = null;
 
-  for (const line of lines) {
-    const typeMatch = line.match(/^@type\s+\{([^}]+)\}/);
-    const paramMatch = line.match(
-      /^@param\s+\{([^}]+)\}\s+(\[?\w+\]?)(\s+.*)?/,
-    );
-    const returnMatch = line.match(/^@returns?\s+\{([^}]+)\}(\s+.*)?/);
-
-    if (typeMatch) {
-      type = typeMatch[1];
-    } else if (paramMatch) {
-      params.push({
-        name: paramMatch[2].replace(/^\[|\]$/g, ""),
-        type: paramMatch[1],
-        description: (paramMatch[3] || "").trim(),
-      });
-    } else if (returnMatch) {
-      returns = {
-        type: returnMatch[1],
-        description: (returnMatch[2] || "").trim(),
-      };
-    } else if (!line.startsWith("@")) {
-      descLines.push(line);
+  if (node.jsDoc) {
+    for (const doc of node.jsDoc) {
+      if (doc.comment) {
+        description =
+          typeof doc.comment === "string"
+            ? doc.comment
+            : doc.comment
+                .map((c) => (typeof c === "string" ? c : c.text || ""))
+                .join("");
+      }
+      for (const tag of doc.tags || []) {
+        if (ts.isJSDocTypeTag(tag) && tag.typeExpression?.type) {
+          type = tag.typeExpression.type.getText(sf);
+        } else if (ts.isJSDocParameterTag(tag)) {
+          const pComment = tag.comment
+            ? typeof tag.comment === "string"
+              ? tag.comment
+              : tag.comment
+                  .map((c) => (typeof c === "string" ? c : c.text || ""))
+                  .join("")
+            : "";
+          params.push({
+            name: tag.name?.getText(sf) || "",
+            type:
+              cleanMultilineType(tag.typeExpression?.type?.getText(sf)) ||
+              "any",
+            description: pComment.trim(),
+          });
+        } else if (ts.isJSDocReturnTag(tag)) {
+          const rComment = tag.comment
+            ? typeof tag.comment === "string"
+              ? tag.comment
+              : tag.comment
+                  .map((c) => (typeof c === "string" ? c : c.text || ""))
+                  .join("")
+            : "";
+          returns = {
+            type:
+              cleanMultilineType(tag.typeExpression?.type?.getText(sf)) ||
+              "any",
+            description: rComment.trim(),
+          };
+        }
+      }
     }
   }
-  return { description: descLines.join(" "), type, params, returns };
+
+  return {
+    description: description.trim(),
+    type: cleanMultilineType(type),
+    params,
+    returns,
+  };
 }
 
 /**
@@ -337,7 +378,7 @@ function extractExamplesFromTemplates(repoRoot) {
 /**
  * 4. AST-based reactive store inference from core/client/store/*.js
  */
-function parseStoreFileAst(filePath) {
+function parseTopLevelStoreAst(filePath) {
   if (!fs.existsSync(filePath)) return [];
   const content = fs.readFileSync(filePath, "utf8");
   const sf = ts.createSourceFile(
@@ -348,27 +389,31 @@ function parseStoreFileAst(filePath) {
   );
   const items = [];
 
-  function visit(node) {
-    // Variable statements: export const currentUrl = ref("");
-    if (ts.isVariableStatement(node)) {
-      const commentRanges = ts.getLeadingCommentRanges(content, node.pos);
-      const rawComment = commentRanges
-        ? commentRanges.map((r) => content.slice(r.pos, r.end)).join("\n")
-        : "";
-      const doc = cleanDoc(rawComment);
+  for (const stmt of sf.statements) {
+    if (ts.isVariableStatement(stmt)) {
+      const isExported = stmt.modifiers?.some(
+        (m) => m.kind === ts.SyntaxKind.ExportKeyword,
+      );
+      if (!isExported) continue;
 
-      for (const decl of node.declarationList.declarations) {
+      const doc = getJsDocFromNode(stmt, sf);
+
+      for (const decl of stmt.declarationList.declarations) {
         const name = decl.name.getText(sf);
-        let kind = "ref";
+        let kind = "value";
         let isFn = false;
 
         if (decl.initializer) {
-          const initText = decl.initializer.getText(sf);
-          if (initText.startsWith("shallowRef")) kind = "shallowRef";
-          else if (initText.startsWith("reactive")) kind = "reactive";
-          else if (
+          if (ts.isCallExpression(decl.initializer)) {
+            const callee = decl.initializer.expression.getText(sf);
+            if (
+              ["ref", "shallowRef", "reactive", "computed"].includes(callee)
+            ) {
+              kind = callee;
+            }
+          } else if (
             ts.isArrowFunction(decl.initializer) ||
-            initText.includes("=>")
+            ts.isFunctionExpression(decl.initializer)
           ) {
             isFn = true;
           }
@@ -379,7 +424,9 @@ function parseStoreFileAst(filePath) {
           if (isFn) inferredType = "Function";
           else if (kind === "shallowRef") inferredType = "ShallowRef<any>";
           else if (kind === "reactive") inferredType = "Reactive<object>";
-          else inferredType = "Ref<any>";
+          else if (kind === "computed") inferredType = "ComputedRef<any>";
+          else if (kind === "ref") inferredType = "Ref<any>";
+          else inferredType = "any";
         }
 
         items.push({
@@ -395,29 +442,157 @@ function parseStoreFileAst(filePath) {
       }
     }
 
-    // Function declarations: export async function registerProjection(...)
-    if (ts.isFunctionDeclaration(node) && node.name) {
-      const name = node.name.getText(sf);
-      const commentRanges = ts.getLeadingCommentRanges(content, node.pos);
-      const rawComment = commentRanges
-        ? commentRanges.map((r) => content.slice(r.pos, r.end)).join("\n")
-        : "";
-      const doc = cleanDoc(rawComment);
+    if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+      const isExported = stmt.modifiers?.some(
+        (m) => m.kind === ts.SyntaxKind.ExportKeyword,
+      );
+      if (!isExported) continue;
+
+      const name = stmt.name.getText(sf);
+      const doc = getJsDocFromNode(stmt, sf);
 
       items.push({
         name,
         category: "action",
-        type: "Function",
+        type: doc.type || "Function",
         description: doc.description || `Action ${name}`,
         ...(doc.params.length > 0 ? { params: doc.params } : {}),
         ...(doc.returns ? { returns: doc.returns } : {}),
       });
     }
-
-    ts.forEachChild(node, visit);
   }
 
-  visit(sf);
+  return items;
+}
+
+function parsePiniaStoreAst(filePath) {
+  if (!fs.existsSync(filePath)) return [];
+  const content = fs.readFileSync(filePath, "utf8");
+  const sf = ts.createSourceFile(
+    filePath,
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+  );
+  const items = [];
+
+  for (const stmt of sf.statements) {
+    if (ts.isVariableStatement(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        if (decl.initializer && ts.isCallExpression(decl.initializer)) {
+          const callee = decl.initializer.expression.getText(sf);
+          if (callee === "defineStore") {
+            const setupFn = decl.initializer.arguments[1];
+            if (
+              setupFn &&
+              (ts.isArrowFunction(setupFn) ||
+                ts.isFunctionExpression(setupFn)) &&
+              ts.isBlock(setupFn.body)
+            ) {
+              const scopeDecls = new Map();
+              let returnStmt = null;
+
+              for (const bodyStmt of setupFn.body.statements) {
+                if (ts.isVariableStatement(bodyStmt)) {
+                  const doc = getJsDocFromNode(bodyStmt, sf);
+                  for (const d of bodyStmt.declarationList.declarations) {
+                    const dName = d.name.getText(sf);
+                    let kind = "value";
+                    let isFn = false;
+
+                    if (d.initializer) {
+                      if (ts.isCallExpression(d.initializer)) {
+                        const cName = d.initializer.expression.getText(sf);
+                        if (
+                          [
+                            "ref",
+                            "shallowRef",
+                            "reactive",
+                            "computed",
+                          ].includes(cName)
+                        ) {
+                          kind = cName;
+                        }
+                      } else if (
+                        ts.isArrowFunction(d.initializer) ||
+                        ts.isFunctionExpression(d.initializer)
+                      ) {
+                        isFn = true;
+                      }
+                    }
+                    scopeDecls.set(dName, {
+                      name: dName,
+                      isFn,
+                      kind,
+                      doc,
+                    });
+                  }
+                } else if (
+                  ts.isFunctionDeclaration(bodyStmt) &&
+                  bodyStmt.name
+                ) {
+                  const fName = bodyStmt.name.getText(sf);
+                  const doc = getJsDocFromNode(bodyStmt, sf);
+                  scopeDecls.set(fName, {
+                    name: fName,
+                    isFn: true,
+                    kind: "function",
+                    doc,
+                  });
+                } else if (ts.isReturnStatement(bodyStmt)) {
+                  returnStmt = bodyStmt;
+                }
+              }
+
+              if (
+                returnStmt &&
+                returnStmt.expression &&
+                ts.isObjectLiteralExpression(returnStmt.expression)
+              ) {
+                for (const prop of returnStmt.expression.properties) {
+                  const pName = prop.name?.getText(sf);
+                  if (!pName) continue;
+                  const info = scopeDecls.get(pName);
+                  if (info) {
+                    let inferredType = info.doc.type;
+                    if (!inferredType) {
+                      if (info.isFn) inferredType = "Function";
+                      else if (info.kind === "shallowRef")
+                        inferredType = "ShallowRef<any>";
+                      else if (info.kind === "reactive")
+                        inferredType = "Reactive<object>";
+                      else if (info.kind === "computed")
+                        inferredType = "ComputedRef<any>";
+                      else if (info.kind === "ref") inferredType = "Ref<any>";
+                      else inferredType = "any";
+                    }
+
+                    items.push({
+                      name: pName,
+                      category: info.isFn ? "action" : "state",
+                      type: inferredType,
+                      description:
+                        info.doc.description ||
+                        (info.isFn
+                          ? `Action ${pName}`
+                          : `Reactive ${pName} state`),
+                      ...(info.doc.params.length > 0
+                        ? { params: info.doc.params }
+                        : {}),
+                      ...(info.doc.returns
+                        ? { returns: info.doc.returns }
+                        : {}),
+                    });
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   return items;
 }
 
@@ -429,9 +604,9 @@ function inferReactiveStoreMetadata(repoRoot) {
   return {
     description:
       "Global reactive store and Pinia store managing STAC endpoint, active collection, selected item, datetime, map instances, and chart states. Accessible via window.eodashStore or `import { store } from '@eodash/eodash'`.",
-    states: parseStoreFileAst(statesFile),
-    stacStore: parseStoreFileAst(stacFile),
-    actions: parseStoreFileAst(actionsFile),
+    states: parseTopLevelStoreAst(statesFile),
+    stacStore: parsePiniaStoreAst(stacFile),
+    actions: parseTopLevelStoreAst(actionsFile),
   };
 }
 
@@ -469,43 +644,53 @@ function extractPropsFromVueSfc(vueFilePath) {
           for (const prop of arg.properties) {
             if (ts.isPropertyAssignment(prop)) {
               const name = prop.name.getText(sf);
-              const commentRanges = ts.getLeadingCommentRanges(
-                scriptContent,
-                prop.pos,
-              );
-              const comment = commentRanges
-                ? commentRanges
-                    .map((r) => scriptContent.slice(r.pos, r.end))
-                    .join("\n")
-                : "";
-              const doc = cleanDoc(comment);
-
+              const doc = getJsDocFromNode(prop, sf);
+              let propType = doc.type ? unwrapPropType(doc.type) : "unknown";
               let defaultValue = null;
-              let propType = doc.type || "unknown";
+              let required = false;
 
               if (ts.isObjectLiteralExpression(prop.initializer)) {
                 for (const subProp of prop.initializer.properties) {
+                  const subDoc = getJsDocFromNode(subProp, sf);
                   if (ts.isPropertyAssignment(subProp)) {
                     const subName = subProp.name.getText(sf);
+                    if (subName === "required") {
+                      required =
+                        subProp.initializer.kind === ts.SyntaxKind.TrueKeyword;
+                    }
                     if (subName === "default") {
                       defaultValue = subProp.initializer.getText(sf);
                     }
-                    if (subName === "type" && propType === "unknown") {
-                      const typeComments = ts.getLeadingCommentRanges(
-                        scriptContent,
-                        subProp.pos,
+                    if (subName === "type") {
+                      if (subDoc.type) {
+                        propType = unwrapPropType(subDoc.type);
+                      } else {
+                        const innerDoc = getJsDocFromNode(
+                          subProp.initializer,
+                          sf,
+                        );
+                        if (innerDoc.type) {
+                          propType = unwrapPropType(innerDoc.type);
+                        } else if (propType === "unknown") {
+                          propType = subProp.initializer.getText(sf);
+                        }
+                      }
+                    }
+                  } else if (ts.isMethodDeclaration(subProp)) {
+                    const subName = subProp.name.getText(sf);
+                    if (subName === "default") {
+                      const ret = subProp.body?.statements.find((s) =>
+                        ts.isReturnStatement(s),
                       );
-                      const typeDoc = cleanDoc(
-                        typeComments
-                          ? typeComments
-                              .map((r) => scriptContent.slice(r.pos, r.end))
-                              .join("\n")
-                          : "",
-                      );
-                      if (typeDoc.type) propType = typeDoc.type;
-                      else propType = subProp.initializer.getText(sf);
+                      defaultValue = ret?.expression
+                        ? ret.expression.getText(sf)
+                        : subProp.getText(sf);
                     }
                   }
+                }
+              } else if (ts.isIdentifier(prop.initializer)) {
+                if (propType === "unknown") {
+                  propType = prop.initializer.getText(sf);
                 }
               }
 
@@ -514,7 +699,7 @@ function extractPropsFromVueSfc(vueFilePath) {
                 type: propType,
                 defaultValue,
                 description: doc.description,
-                required: defaultValue === null,
+                required,
               });
             }
           }

--- a/packages/mcp/generate-metadata.js
+++ b/packages/mcp/generate-metadata.js
@@ -952,7 +952,7 @@ export function buildMetadata(repoRoot = DEFAULT_REPO_ROOT) {
   const knownTemplateDescriptions = {
     lite: "Streamlined layout for static STAC Catalogs & public dissemination with minimal controls (Map, Header Tools, Layers, StacInfo, DatePicker). Recommended default for static catalogs.",
     explore:
-      "Feature-rich discovery layout for dynamic STAC APIs (ItemFilter, ItemCatalog explorer, Map, LayerControl, TimeSlider, StacInfo, and Process analysis). Recommended for searchable STAC APIs.",
+      "Discovery layout for dynamic STAC APIs featuring an interactive background Map, LayerControl, and an ItemCatalog explorer drawer.",
     expert:
       "Power-user dashboard with comprehensive layer manipulation and full analysis tooling.",
     compare:

--- a/packages/mcp/generate-metadata.js
+++ b/packages/mcp/generate-metadata.js
@@ -44,7 +44,7 @@ const STAC_EXTENSIONS_MAP = {
   ],
   EodashItemCatalog: ["eo:cloud_cover", "datetime", "assets.thumbnail"],
   EodashItemFilter: ["themes", "tags"],
-  EodashTimeSlider: ["cube:dimensions", "extent.temporal", "datetime"],
+  EodashTimeSlider: ["extent.temporal", "datetime"],
   EodashDatePicker: ["extent.temporal", "datetime"],
   EodashProcess: ["eodash:jsonform", "links (rel=service)"],
   EodashChart: [
@@ -209,6 +209,7 @@ function analyzeStoreInteractions(widgetName, repoRoot) {
 
   for (const file of filesToScan) {
     let scriptContent = "";
+    let templateContent = "";
     if (file.endsWith(".vue")) {
       const vueContent = fs.readFileSync(file, "utf8");
       try {
@@ -217,6 +218,7 @@ function analyzeStoreInteractions(widgetName, repoRoot) {
           (parsed.descriptor.scriptSetup?.content || "") +
           "\n" +
           (parsed.descriptor.script?.content || "");
+        templateContent = parsed.descriptor.template?.content || "";
       } catch {
         scriptContent = vueContent;
       }
@@ -231,38 +233,77 @@ function analyzeStoreInteractions(widgetName, repoRoot) {
       true,
     );
     const importedStoreVars = new Set();
+    const piniaStoreInstances = new Set();
 
     function visit(node) {
       // 1. Identify store imports
       if (ts.isImportDeclaration(node)) {
         const spec = node.moduleSpecifier.text;
-        if (spec.includes("store/states") || spec.includes("store")) {
+        if (
+          spec.includes("store/states") ||
+          spec.includes("store/actions") ||
+          spec.includes("@/store/states") ||
+          spec.includes("@/utils/states") ||
+          spec === "@/store" ||
+          spec === "@eodash/eodash"
+        ) {
           if (
             node.importClause?.namedBindings &&
             ts.isNamedImports(node.importClause.namedBindings)
           ) {
             for (const el of node.importClause.namedBindings.elements) {
-              importedStoreVars.add(el.name.text);
+              const varName = el.name.text;
+              if (varName !== "useSTAcStore" && varName !== "store") {
+                importedStoreVars.add(varName);
+              }
             }
           }
         }
       }
 
-      // 2. Detect store.<prop> or states.<prop> accesses
+      // 2. Identify pinia store instance or destructuring: const { selectedStac } = toRefs(useSTAcStore())
+      if (ts.isVariableDeclaration(node)) {
+        if (node.initializer && ts.isCallExpression(node.initializer)) {
+          const fnText = node.initializer.expression.getText(sf);
+          if (fnText === "useSTAcStore") {
+            if (ts.isIdentifier(node.name)) {
+              piniaStoreInstances.add(node.name.text);
+            }
+          } else if (fnText === "toRefs" || fnText === "storeToRefs") {
+            const innerArg = node.initializer.arguments[0];
+            if (innerArg && innerArg.getText(sf).includes("useSTAcStore")) {
+              if (ts.isObjectBindingPattern(node.name)) {
+                for (const el of node.name.elements) {
+                  if (ts.isIdentifier(el.name)) {
+                    importedStoreVars.add(el.name.text);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+
+      // 3. Detect store.<prop>, states.<prop>, or piniaInstance.<prop> accesses
       if (ts.isPropertyAccessExpression(node)) {
         const propName = node.name.text;
         const target = node.expression.getText(sf);
         if (
           target === "store" ||
           target === "store.states" ||
-          target === "states"
+          target === "states" ||
+          piniaStoreInstances.has(target)
         ) {
           if (
             ![
               "init",
+              "loadSTAC",
               "loadSelectedSTAC",
               "loadSelectedCompareSTAC",
               "resetSelectedCompareSTAC",
+              "$reset",
+              "$patch",
+              "$subscribe",
             ].includes(propName)
           ) {
             if (
@@ -278,7 +319,7 @@ function analyzeStoreInteractions(widgetName, repoRoot) {
         }
       }
 
-      // 3. Detect importedStoreVar.value = ... (mutations)
+      // 4. Detect importedStoreVar.value = ... (mutations)
       if (
         ts.isBinaryExpression(node) &&
         node.operatorToken.kind === ts.SyntaxKind.EqualsToken
@@ -294,11 +335,44 @@ function analyzeStoreInteractions(widgetName, repoRoot) {
         }
       }
 
-      // 4. Detect importedStoreVar reads
+      // 5. Detect importedStoreVar reads (ignoring imports, definitions, callee positions, write targets)
       if (ts.isIdentifier(node)) {
-        if (importedStoreVars.has(node.text)) {
-          if (!writes.has(node.text)) {
-            reads.add(node.text);
+        const varName = node.text;
+        if (importedStoreVars.has(varName)) {
+          // Ignore if part of import specifier
+          let isImport = false;
+          let p = node.parent;
+          while (p) {
+            if (ts.isImportDeclaration(p) || ts.isImportSpecifier(p)) {
+              isImport = true;
+              break;
+            }
+            p = p.parent;
+          }
+
+          // Ignore if in callee position: varName(...)
+          const isCallee =
+            ts.isCallExpression(node.parent) && node.parent.expression === node;
+
+          // Ignore if property name in object literal without shorthand
+          const isObjectKey =
+            ts.isPropertyAssignment(node.parent) && node.parent.name === node;
+
+          // Ignore if LHS of assignment
+          const isLhsAssignment =
+            (ts.isBinaryExpression(node.parent) &&
+              node.parent.left === node &&
+              node.parent.operatorToken.kind === ts.SyntaxKind.EqualsToken) ||
+            (ts.isPropertyAccessExpression(node.parent) &&
+              node.parent.expression === node &&
+              node.parent.name.text === "value" &&
+              ts.isBinaryExpression(node.parent.parent) &&
+              node.parent.parent.left === node.parent &&
+              node.parent.parent.operatorToken.kind ===
+                ts.SyntaxKind.EqualsToken);
+
+          if (!isImport && !isCallee && !isObjectKey && !isLhsAssignment) {
+            reads.add(varName);
           }
         }
       }
@@ -307,6 +381,15 @@ function analyzeStoreInteractions(widgetName, repoRoot) {
     }
 
     visit(sf);
+
+    if (templateContent) {
+      for (const varName of importedStoreVars) {
+        const regex = new RegExp(`\\b${varName}\\b`);
+        if (regex.test(templateContent)) {
+          reads.add(varName);
+        }
+      }
+    }
   }
 
   return {
@@ -897,7 +980,7 @@ export function buildMetadata(repoRoot = DEFAULT_REPO_ROOT) {
     gridSystem: {
       columns: 12,
       notation:
-        "x/y/w/h where coordinates can be numbers (1-12) or breakpoint strings 'mobile/tablet/desktop' (e.g. '12/9/10').",
+        "x is 0-indexed column (0–11), y is 0-indexed unbounded row, w is column span (1–12), h is row span. Coordinates and spans accept numbers or responsive breakpoint strings 'mobile/tablet/desktop' (e.g. '12/9/10').",
       examples: [
         { label: "Full width sidebar", layout: { x: 0, y: 0, w: 3, h: 12 } },
         {
@@ -918,17 +1001,16 @@ export function buildMetadata(repoRoot = DEFAULT_REPO_ROOT) {
     },
     customWidgetSystem: {
       description:
-        "eodash supports 3 types of custom widgets: 'web-component' (dynamic import or CDN URL), 'functional' (Vue component / render function), and 'iframe' (embedded HTML / notebook).",
+        "eodash supports 3 types of widgets: 'internal' (built-in eodash widgets), 'web-component' (custom elements via dynamic import or CDN URL), and 'iframe' (embedded external web app / notebook). In addition, 'functional' is a dynamic wrapper (defineWidget: (selectedSTAC) => Widget | null) executed reactively when selected STAC indicator changes.",
       types: [
         {
           type: "web-component",
           description:
-            "Loads any standard Custom Element via ESM dynamic import function or CDN URL. Provides lifecycle hooks onMounted(el, store) and onUnmounted(el, store).",
+            "Loads standard Custom Element via ESM dynamic import function or CDN URL. Provides lifecycle hooks onMounted(el, store) and onUnmounted(el, store).",
         },
         {
-          type: "functional",
-          description:
-            "Dynamic function `defineWidget: (selectedSTAC) => Widget | null` executed reactively when selected STAC indicator changes.",
+          type: "internal",
+          description: "Built-in eodash widget component registered by name.",
         },
         {
           type: "iframe",

--- a/packages/mcp/generators/config.js
+++ b/packages/mcp/generators/config.js
@@ -49,25 +49,36 @@ export function generateEodashConfig({
       brand.footerText || `${brand.name || "EO Dashboard"} - Built with eodash`,
   };
 
-  const isCustomTemplate = template === "custom" || customWidgets.length > 0;
+  const hasCustomWidgets = customWidgets.length > 0;
+  const isCustomTemplate = template === "custom" || hasCustomWidgets;
+  const baseTemplateName = template === "custom" ? null : template;
 
-  let imports = `import { deepmergeCustom } from "deepmerge-ts";\n`;
-  if (!isCustomTemplate) {
-    imports += `import { ${template} } from "@eodash/eodash/templates";\n`;
-  } else {
-    imports += `import { explore } from "@eodash/eodash/templates";\n`;
+  let imports = "";
+  if (baseTemplateName) {
+    imports += `import { ${baseTemplateName} } from "@eodash/eodash/templates";\n`;
   }
 
   let templateSection = "";
-  if (!isCustomTemplate) {
-    templateSection = `  template: ${template},`;
+  if (!hasCustomWidgets && baseTemplateName) {
+    templateSection = `  template: ${baseTemplateName},`;
+  } else if (hasCustomWidgets && baseTemplateName) {
+    const formattedWidgets = JSON.stringify(customWidgets, null, 4).replace(
+      /\n/g,
+      "\n    ",
+    );
+    templateSection = `  template: {
+    ...${baseTemplateName},
+    widgets: [
+      ...(${baseTemplateName}.widgets || []),
+      ...${formattedWidgets},
+    ],
+  },`;
   } else {
     const formattedWidgets = JSON.stringify(customWidgets, null, 4).replace(
       /\n/g,
       "\n    ",
     );
     templateSection = `  template: {
-    // Custom widget layout definition
     widgets: ${formattedWidgets},
   },`;
   }

--- a/packages/mcp/generators/dashboard.js
+++ b/packages/mcp/generators/dashboard.js
@@ -2,6 +2,7 @@ import {
   DEFAULT_STAC_ENDPOINT,
   DEFAULT_BRAND_NAME,
   getEodashVersion,
+  getAvailableTemplates,
 } from "../helpers.js";
 
 /**
@@ -17,6 +18,8 @@ export function scaffoldDashboard({
 } = {}) {
   const files = {};
   const eodashVersion = getEodashVersion();
+  const availableTemplates = getAvailableTemplates();
+  const templateImportList = availableTemplates.join(", ");
 
   const gitignore = `node_modules
 dist
@@ -26,7 +29,7 @@ dist
 *.local
 `;
 
-  const dockerfile = `FROM node:20-alpine AS builder
+  const dockerfileSpa = `FROM node:24-alpine AS builder
 WORKDIR /app
 COPY package*.json ./
 RUN npm ci
@@ -35,6 +38,20 @@ RUN npm run build
 
 FROM nginx:alpine
 COPY --from=builder /app/dist /usr/share/nginx/html
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+EXPOSE 80
+CMD ["nginx", "-g", "daemon off;"]
+`;
+
+  const dockerfileVitePress = `FROM node:24-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run docs:build
+
+FROM nginx:alpine
+COPY --from=builder /app/docs/.vitepress/dist /usr/share/nginx/html
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]
@@ -83,7 +100,7 @@ export default defineConfig({
 `;
 
     files["src/main.js"] = `import { createEodash } from "@eodash/eodash";
-import { explore, lite, expert, compare } from "@eodash/eodash/templates";
+import { ${templateImportList} } from "@eodash/eodash/templates";
 
 const selectedTemplate = ${template};
 
@@ -210,6 +227,31 @@ export default {
 };
 `;
 
+    files["docs/public/config.js"] = `export default {
+  id: "${name}",
+  stacEndpoint: "${stacEndpoint}",
+  brand: {
+    name: "${brandName}",
+    theme: {
+      colors: {
+        primary: "${brandColor}",
+      },
+    },
+    footerText: "${brandName} - Powered by eodash",
+  },
+  template: "${template}",
+};
+`;
+
+    files["docs/public/story-content.md"] = `# ${brandName} Story
+
+Welcome to the interactive narrative. This markdown content is rendered dynamically by \`<eox-storytelling>\`.
+
+## Key Indicators
+- **STAC Catalog**: [${stacEndpoint}](${stacEndpoint})
+- **Template Layout**: ${template}
+`;
+
     files["docs/index.md"] = `---
 layout: home
 hero:
@@ -234,8 +276,7 @@ layout: page
 
 <client-only>
   <eo-dash
-    stac-endpoint="${stacEndpoint}"
-    template="${template}"
+    config="/config.js"
     style="width: 100%; height: 800px; display: block;"
   ></eo-dash>
 </client-only>
@@ -248,15 +289,16 @@ Interactive indicators and story narrative combining markdown narratives and liv
 <client-only>
   <eox-storytelling
     show-nav
-    markdown-url="./story-content.md"
+    markdown-url="/story-content.md"
   ></eox-storytelling>
 </client-only>
 
-<eo-dash
-  stac-endpoint="${stacEndpoint}"
-  template="lite"
-  style="width: 100%; height: 500px; display: block; margin-top: 2rem;"
-></eo-dash>
+<client-only>
+  <eo-dash
+    config="/config.js"
+    style="width: 100%; height: 500px; display: block; margin-top: 2rem;"
+  ></eo-dash>
+</client-only>
 `;
 
     files["README.md"] = `# ${brandName} (VitePress Narratives)
@@ -296,6 +338,22 @@ npm run docs:dev
       2,
     );
 
+    files["config.js"] = `export default {
+  id: "${name}",
+  stacEndpoint: "${stacEndpoint}",
+  brand: {
+    name: "${brandName}",
+    theme: {
+      colors: {
+        primary: "${brandColor}",
+      },
+    },
+    footerText: "${brandName} - Powered by eodash",
+  },
+  template: "${template}",
+};
+`;
+
     files["index.html"] = `<!DOCTYPE html>
 <html lang="en">
   <head>
@@ -313,8 +371,7 @@ npm run docs:dev
   <body>
     <eo-dash
       id="${name}"
-      stac-endpoint="${stacEndpoint}"
-      template="${template}"
+      config="/config.js"
     ></eo-dash>
   </body>
 </html>
@@ -332,7 +389,10 @@ npm run dev
   }
 
   files[".gitignore"] = gitignore;
-  files["Dockerfile"] = dockerfile;
+  files["Dockerfile"] =
+    projectType === "vitepress-narratives"
+      ? dockerfileVitePress
+      : dockerfileSpa;
   files["nginx.conf"] = nginxConf;
 
   return {

--- a/packages/mcp/generators/dashboard.js
+++ b/packages/mcp/generators/dashboard.js
@@ -71,7 +71,8 @@ CMD ["nginx", "-g", "daemon off;"]
       2,
     );
 
-    files["eodash.config.js"] = `import { defineConfig } from "@eodash/eodash";
+    files["eodash.config.js"] =
+      `import { defineConfig } from "@eodash/eodash/config";
 
 export default defineConfig({
   entryPoint: "src/main.js",

--- a/packages/mcp/helpers.js
+++ b/packages/mcp/helpers.js
@@ -7,9 +7,17 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 const REPO_ROOT = path.resolve(__dirname, "../..");
 
-const rootPkg = JSON.parse(
-  fs.readFileSync(path.join(REPO_ROOT, "package.json"), "utf8"),
-);
+function getRootPackage() {
+  try {
+    const pkgPath = path.join(REPO_ROOT, "package.json");
+    if (fs.existsSync(pkgPath)) {
+      return JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+    }
+  } catch {
+    // fallback when root package.json is unreachable
+  }
+  return { version: "5.9.0" };
+}
 
 export const DEFAULT_STAC_ENDPOINT =
   "https://eoxhub-workspaces.github.io/eoxhub-test-catalog/catalog/catalog.json";
@@ -38,7 +46,8 @@ export function getAvailableTemplates() {
  * Gets the current @eodash/eodash version from the root package.json
  */
 export function getEodashVersion() {
-  return `^${rootPkg.version}`;
+  const rootPkg = getRootPackage();
+  return rootPkg.version ? `^${rootPkg.version}` : "^5.9.0";
 }
 
 /**
@@ -89,9 +98,9 @@ export default createEodash({
         type: "web-component",
         layout: { x: 0, y: 6, w: 6, h: 6 },
         widget: {
-          name: "my-custom-chart",
+          tagName: "my-custom-chart",
           // ESM import function or direct CDN bundle URL:
-          import: () => import("./src/widgets/MyCustomChart.js"),
+          link: () => import("./src/widgets/MyCustomChart.js"),
           properties: {
             theme: "dark",
             unit: "celsius",
@@ -248,7 +257,7 @@ export function generateLandingPage(widgets, _arch) {
       <div class="flex items-center space-x-3">
         <div class="bg-blue-600 text-white font-bold px-2.5 py-1 rounded">eo</div>
         <span class="font-bold text-slate-900 text-lg">eodash MCP Server</span>
-        <span class="text-xs font-mono bg-slate-100 text-slate-600 px-2 py-0.5 rounded">v${rootPkg.version}</span>
+        <span class="text-xs font-mono bg-slate-100 text-slate-600 px-2 py-0.5 rounded">v${getRootPackage().version}</span>
       </div>
       <div class="flex items-center space-x-2">
         <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">

--- a/packages/mcp/helpers.js
+++ b/packages/mcp/helpers.js
@@ -23,13 +23,18 @@ export const DEFAULT_STAC_ENDPOINT =
   "https://eoxhub-workspaces.github.io/eoxhub-test-catalog/catalog/catalog.json";
 export const DEFAULT_BRAND_NAME = "EOxHub Demo Dashboard";
 
+let cachedTemplates = null;
+let cachedMetadata = null;
+
 /**
  * Dynamically discovers available built-in templates from templates/*.js
  */
 export function getAvailableTemplates() {
+  if (cachedTemplates) return cachedTemplates;
   const templatesDir = path.join(REPO_ROOT, "templates");
   if (!fs.existsSync(templatesDir)) {
-    return ["explore", "lite", "expert", "compare"];
+    cachedTemplates = ["explore", "lite", "expert", "compare"];
+    return cachedTemplates;
   }
   const files = fs.readdirSync(templatesDir);
   const discovered = files
@@ -37,9 +42,11 @@ export function getAvailableTemplates() {
       (f) => f.endsWith(".js") && f !== "index.js" && f !== "baseConfig.js",
     )
     .map((f) => path.basename(f, ".js"));
-  return discovered.length > 0
-    ? discovered
-    : ["explore", "lite", "expert", "compare"];
+  cachedTemplates =
+    discovered.length > 0
+      ? discovered
+      : ["explore", "lite", "expert", "compare"];
+  return cachedTemplates;
 }
 
 /**
@@ -54,6 +61,7 @@ export function getEodashVersion() {
  * Loads cached metadata or rebuilds on-the-fly
  */
 export function getMetadata() {
+  if (cachedMetadata) return cachedMetadata;
   const widgetsFile = path.join(__dirname, "data/widgets-metadata.json");
   const archFile = path.join(__dirname, "data/architecture-metadata.json");
 
@@ -61,7 +69,8 @@ export function getMetadata() {
     try {
       const widgetsData = JSON.parse(fs.readFileSync(widgetsFile, "utf8"));
       const architectureData = JSON.parse(fs.readFileSync(archFile, "utf8"));
-      return { widgetsData, architectureData };
+      cachedMetadata = { widgetsData, architectureData };
+      return cachedMetadata;
     } catch (err) {
       console.warn("Could not read cached metadata, rebuilding:", err.message);
     }
@@ -69,10 +78,11 @@ export function getMetadata() {
 
   // Dynamic on-the-fly generation fallback
   const { widgetsMetadata, architectureMetadata } = buildMetadata(REPO_ROOT);
-  return {
+  cachedMetadata = {
     widgetsData: widgetsMetadata,
     architectureData: architectureMetadata,
   };
+  return cachedMetadata;
 }
 
 /**

--- a/packages/mcp/helpers.js
+++ b/packages/mcp/helpers.js
@@ -32,20 +32,36 @@ let cachedMetadata = null;
 export function getAvailableTemplates() {
   if (cachedTemplates) return cachedTemplates;
   const templatesDir = path.join(REPO_ROOT, "templates");
-  if (!fs.existsSync(templatesDir)) {
-    cachedTemplates = ["explore", "lite", "expert", "compare"];
-    return cachedTemplates;
+  if (fs.existsSync(templatesDir)) {
+    const files = fs.readdirSync(templatesDir);
+    const discovered = files
+      .filter(
+        (f) => f.endsWith(".js") && f !== "index.js" && f !== "baseConfig.js",
+      )
+      .map((f) => path.basename(f, ".js"));
+    if (discovered.length > 0) {
+      cachedTemplates = discovered;
+      return cachedTemplates;
+    }
   }
-  const files = fs.readdirSync(templatesDir);
-  const discovered = files
-    .filter(
-      (f) => f.endsWith(".js") && f !== "index.js" && f !== "baseConfig.js",
-    )
-    .map((f) => path.basename(f, ".js"));
-  cachedTemplates =
-    discovered.length > 0
-      ? discovered
-      : ["explore", "lite", "expert", "compare"];
+
+  // Standalone package fallback: read from pre-built architecture metadata if present
+  const archFile = path.join(__dirname, "data/architecture-metadata.json");
+  if (fs.existsSync(archFile)) {
+    try {
+      const arch = JSON.parse(fs.readFileSync(archFile, "utf8"));
+      if (arch.templateSystem?.builtInTemplates?.length) {
+        cachedTemplates = arch.templateSystem.builtInTemplates.map(
+          (t) => t.name,
+        );
+        return cachedTemplates;
+      }
+    } catch {
+      // fallback
+    }
+  }
+
+  cachedTemplates = ["explore", "lite", "expert", "compare"];
   return cachedTemplates;
 }
 

--- a/packages/mcp/helpers.js
+++ b/packages/mcp/helpers.js
@@ -133,8 +133,6 @@ export default createEodash({
   template: {
     widgets: [
       {
-        id: "dynamic-panel",
-        layout: { x: 9, y: 0, w: 3, h: 8 },
         defineWidget: (selectedSTAC) => {
           if (!selectedSTAC) return null;
 
@@ -205,7 +203,8 @@ const store = window.eodashStore;
 if (store) {
   // Read states
   console.log("Current STAC collection:", store.states.currentUrl.value);
-  console.log("Active OpenLayers map instance:", store.states.mapEl.value);
+  console.log("EOxMap custom element DOM node:", store.states.mapEl.value);
+  console.log("Underlying OpenLayers map instance:", store.states.mapEl.value?.map);
 
   // Hook into tooltip property formatting
   store.states.tooltipAdapter.value = ({ key, value }, mapId) => {

--- a/packages/mcp/index.js
+++ b/packages/mcp/index.js
@@ -191,6 +191,7 @@ export function createMcpServer() {
             "overview",
             "grid-layout",
             "templates",
+            "custom-widgets",
             "reactive-store",
             "all",
           ])
@@ -209,6 +210,8 @@ export function createMcpServer() {
         result = { gridSystem: architectureData.gridSystem };
       } else if (topic === "templates") {
         result = { templateSystem: architectureData.templateSystem };
+      } else if (topic === "custom-widgets") {
+        result = { customWidgetSystem: architectureData.customWidgetSystem };
       } else if (topic === "reactive-store") {
         result = { reactiveStore: architectureData.reactiveStore };
       }

--- a/packages/mcp/index.js
+++ b/packages/mcp/index.js
@@ -424,11 +424,19 @@ async function startServer() {
   });
 }
 
+function isDirectExecution() {
+  if (!process.argv[1]) return false;
+  try {
+    const realArgv1 = fs.realpathSync(path.resolve(process.argv[1]));
+    const realFilename = fs.realpathSync(__filename);
+    return realArgv1 === realFilename;
+  } catch {
+    return path.resolve(process.argv[1]) === path.resolve(__filename);
+  }
+}
+
 // Auto start if executed directly
-if (
-  process.argv[1] &&
-  path.resolve(process.argv[1]) === path.resolve(__filename)
-) {
+if (isDirectExecution()) {
   startServer().catch((err) => {
     console.error("Failed to start server:", err);
     process.exit(1);

--- a/packages/mcp/index.js
+++ b/packages/mcp/index.js
@@ -45,10 +45,10 @@ export function createMcpServer() {
     {
       name: pkg.name || "@eodash/mcp-server",
       version: pkg.version || "1.0.0",
-      instructions:
-        "This MCP server provides tools to inspect, configure, and scaffold @eodash/eodash instances, widgets, layouts, and STAC integrations.",
     },
     {
+      instructions:
+        "This MCP server provides tools to inspect, configure, and scaffold @eodash/eodash instances, widgets, layouts, and STAC integrations.",
       capabilities: {
         tools: {
           call: {},

--- a/packages/mcp/index.js
+++ b/packages/mcp/index.js
@@ -379,8 +379,42 @@ export function createExpressApp() {
   app.use(cors({ origin: "*" }));
   app.use(express.json());
 
-  app.get("/health", (req, res) => {
+  // Handle malformed JSON body errors in standard JSON-RPC format
+  app.use((err, _req, res, next) => {
+    if (err instanceof SyntaxError && err.status === 400 && "body" in err) {
+      return res.status(400).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32700,
+          message: "Parse error: malformed JSON",
+        },
+        id: null,
+      });
+    }
+    next(err);
+  });
+
+  app.get("/health", (_req, res) => {
     res.json({ message: "eodash MCP Server is running" });
+  });
+
+  app.get("/ui", (_req, res) => {
+    const { widgetsData, architectureData } = getMetadata();
+    res.setHeader("Content-Type", "text/html");
+    res.send(generateLandingPage(widgetsData, architectureData));
+  });
+
+  app.get("/", (_req, res) => {
+    res.setHeader("Allow", "POST");
+    res.status(405).json({
+      jsonrpc: "2.0",
+      error: {
+        code: -32600,
+        message:
+          "Method Not Allowed: MCP endpoint requires POST requests. Access UI landing page at /ui.",
+      },
+      id: null,
+    });
   });
 
   app.post("/", async (req, res) => {
@@ -400,13 +434,7 @@ export function createExpressApp() {
     }
   });
 
-  app.get("/", async (req, res) => {
-    const { widgetsData, architectureData } = getMetadata();
-    res.setHeader("Content-Type", "text/html");
-    res.send(generateLandingPage(widgetsData, architectureData));
-  });
-
-  app.delete("/", (req, res) => {
+  app.delete("/", (_req, res) => {
     res.status(200).json({ message: "Stateless session closed" });
   });
 

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -18,8 +18,10 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@vue/compiler-sfc": "^3.5.41",
     "cors": "^2.8.5",
     "express": "^5.2.1",
+    "typescript": "^6.0.3",
     "zod": "^3.24.1"
   }
 }

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -12,8 +12,20 @@
   "bin": {
     "eodash-mcp-server": "./index.js"
   },
+  "publishConfig": {
+    "access": "public"
+  },
+  "files": [
+    "index.js",
+    "helpers.js",
+    "generate-metadata.js",
+    "generators",
+    "data"
+  ],
   "scripts": {
     "generate": "node generate-metadata.js",
+    "prepack": "node generate-metadata.js",
+    "check": "tsc --noEmit",
     "start": "node index.js"
   },
   "dependencies": {

--- a/packages/mcp/tests/generators.test.js
+++ b/packages/mcp/tests/generators.test.js
@@ -21,6 +21,9 @@ describe("eodash Generators - scaffoldDashboard", () => {
     expect(res.files["src/main.js"]).toContain("https://example.com/stac");
     expect(res.files["src/main.js"]).toContain("Alpine Monitor");
     expect(res.files["eodash.config.js"]).toContain("entryPoint");
+    expect(res.files["eodash.config.js"]).toContain(
+      'import { defineConfig } from "@eodash/eodash/config"',
+    );
     expect(res.files["index.html"]).toBeDefined();
     expect(res.files["Dockerfile"]).toBeDefined();
     expect(res.files[".gitignore"]).toBeDefined();

--- a/packages/mcp/tests/generators.test.js
+++ b/packages/mcp/tests/generators.test.js
@@ -1,10 +1,37 @@
 import { describe, it, expect } from "vitest";
+import ts from "typescript";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createMcpServer } from "../index.js";
 import { scaffoldDashboard } from "../generators/dashboard.js";
 import { generateEodashConfig } from "../generators/config.js";
 import { getAvailableTemplates } from "../helpers.js";
+
+function assertValidJavaScript(filename, code) {
+  const sf = ts.createSourceFile(
+    filename,
+    code,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS,
+  );
+  // TypeScript parser attaches syntax errors directly to source file parse diagnostics
+  const diagnostics = sf.parseDiagnostics || [];
+  if (diagnostics.length > 0) {
+    const errMessages = diagnostics
+      .map((d) => `${d.messageText} at pos ${d.start}`)
+      .join("; ");
+    throw new Error(`Syntax error in generated file '${filename}': ${errMessages}\n\nCode:\n${code}`);
+  }
+}
+
+function assertValidJson(filename, content) {
+  try {
+    JSON.parse(content);
+  } catch (err) {
+    throw new Error(`Invalid JSON in generated file '${filename}': ${err.message}\n\nContent:\n${content}`);
+  }
+}
 
 async function createTestClientServer() {
   const server = createMcpServer();
@@ -175,6 +202,54 @@ describe("eodash Generators - generateEodashConfig", () => {
     );
     expect(resMerged.configCode).toContain("...lite,");
     expect(resMerged.configCode).toContain("custom-map");
+  });
+
+  it("verifies all scaffolded files parse as valid JS/JSON across all project types", () => {
+    const projectTypes = [
+      "standalone-spa",
+      "vitepress-narratives",
+      "web-component",
+    ];
+
+    for (const projectType of projectTypes) {
+      const scaffold = scaffoldDashboard({
+        name: `test-${projectType}`,
+        projectType,
+        template: "explore",
+      });
+
+      for (const [filename, content] of Object.entries(scaffold.files)) {
+        if (filename.endsWith(".js")) {
+          assertValidJavaScript(filename, content);
+        } else if (filename.endsWith(".json")) {
+          assertValidJson(filename, content);
+        }
+      }
+    }
+  });
+
+  it("verifies all generated config outputs parse as valid JavaScript AST", () => {
+    const templates = ["lite", "explore", "expert", "compare", "custom"];
+    for (const tpl of templates) {
+      const config = generateEodashConfig({
+        id: `test-config-${tpl}`,
+        template: tpl,
+        brand: { name: `Brand ${tpl}` },
+        customWidgets:
+          tpl === "custom"
+            ? [
+                {
+                  id: "custom-map",
+                  title: "Custom Map",
+                  layout: { x: 0, y: 0, w: 12, h: 6 },
+                  widget: { name: "EodashMap" },
+                },
+              ]
+            : [],
+      });
+
+      assertValidJavaScript("eodash.config.js", config.configCode);
+    }
   });
 });
 

--- a/packages/mcp/tests/generators.test.js
+++ b/packages/mcp/tests/generators.test.js
@@ -45,7 +45,11 @@ describe("eodash Generators - scaffoldDashboard", () => {
       "import.meta.env.SSR",
     );
     expect(res.files["docs/index.md"]).toContain("Climate Stories");
-    expect(res.files["docs/dashboard.md"]).toContain("<eo-dash");
+    expect(res.files["docs/dashboard.md"]).toContain('config="/config.js"');
+    expect(res.files["docs/public/config.js"]).toBeDefined();
+    expect(res.files["docs/public/story-content.md"]).toBeDefined();
+    expect(res.files["Dockerfile"]).toContain("npm run docs:build");
+    expect(res.files["Dockerfile"]).toContain("docs/.vitepress/dist");
     expect(res.files["docs/narratives/story-1.md"]).toContain(
       "<eox-storytelling",
     );
@@ -59,6 +63,8 @@ describe("eodash Generators - scaffoldDashboard", () => {
 
     expect(res.projectType).toBe("web-component");
     expect(res.files["index.html"]).toContain("<eo-dash");
+    expect(res.files["index.html"]).toContain('config="/config.js"');
+    expect(res.files["config.js"]).toBeDefined();
     expect(res.files["index.html"]).toContain("@eodash/eodash/webcomponent");
   });
 });
@@ -139,6 +145,19 @@ describe("eodash Generators - generateEodashConfig", () => {
     expect(res.configCode).toContain("custom-map");
     expect(res.configCode).toContain("catalog-panel");
     expect(res.configCode).toContain("EodashMap");
+
+    // Merging custom widgets with a base template
+    const resMerged = generateEodashConfig({
+      id: "extended-lite",
+      template: "lite",
+      customWidgets,
+    });
+    expect(resMerged.template).toBe("custom");
+    expect(resMerged.configCode).toContain(
+      'import { lite } from "@eodash/eodash/templates";',
+    );
+    expect(resMerged.configCode).toContain("...lite,");
+    expect(resMerged.configCode).toContain("custom-map");
   });
 });
 

--- a/packages/mcp/tests/generators.test.js
+++ b/packages/mcp/tests/generators.test.js
@@ -1,8 +1,25 @@
 import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createMcpServer } from "../index.js";
 import { scaffoldDashboard } from "../generators/dashboard.js";
 import { generateEodashConfig } from "../generators/config.js";
 import { getAvailableTemplates } from "../helpers.js";
+
+async function createTestClientServer() {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test-client", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return { server, client };
+}
 
 describe("eodash Generators - scaffoldDashboard", () => {
   it("generates standalone SPA boilerplate", () => {
@@ -162,15 +179,16 @@ describe("eodash Generators - generateEodashConfig", () => {
 });
 
 describe("eodash MCP Server - Generator Tool Execution", () => {
-  it("executes scaffold_dashboard MCP tool", async () => {
-    const server = createMcpServer();
-    const tool = server._registeredTools?.["scaffold_dashboard"];
-    expect(tool).toBeDefined();
+  it("executes scaffold_dashboard MCP tool via protocol", async () => {
+    const { client } = await createTestClientServer();
 
-    const res = await tool.handler({
-      name: "mcp-test-dash",
-      projectType: "standalone-spa",
-      template: "lite",
+    const res = await client.callTool({
+      name: "scaffold_dashboard",
+      arguments: {
+        name: "mcp-test-dash",
+        projectType: "standalone-spa",
+        template: "lite",
+      },
     });
 
     const body = JSON.parse(res.content[0].text);
@@ -178,15 +196,16 @@ describe("eodash MCP Server - Generator Tool Execution", () => {
     expect(body.files["src/main.js"]).toContain("lite");
   });
 
-  it("executes generate_eodash_config MCP tool", async () => {
-    const server = createMcpServer();
-    const tool = server._registeredTools?.["generate_eodash_config"];
-    expect(tool).toBeDefined();
+  it("executes generate_eodash_config MCP tool via protocol", async () => {
+    const { client } = await createTestClientServer();
 
-    const res = await tool.handler({
-      id: "test-generated-config",
-      template: "expert",
-      brand: { name: "Test Generator" },
+    const res = await client.callTool({
+      name: "generate_eodash_config",
+      arguments: {
+        id: "test-generated-config",
+        template: "expert",
+        brand: { name: "Test Generator" },
+      },
     });
 
     const body = JSON.parse(res.content[0].text);

--- a/packages/mcp/tests/mcp-server.test.js
+++ b/packages/mcp/tests/mcp-server.test.js
@@ -158,6 +158,29 @@ describe("eodash MCP Server - Metadata Generator", () => {
     expect(architectureMetadata.reactiveStore.actions.length).toBeGreaterThan(
       0,
     );
+
+    // Verify JSDoc types are not truncated at nested curly braces
+    const mapElState = architectureMetadata.reactiveStore.states.find(
+      (s) => s.name === "mapEl",
+    );
+    expect(mapElState).toBeDefined();
+    expect(mapElState.type).toContain("mapUpdateId?: number");
+
+    const tooltipAdapterState =
+      architectureMetadata.reactiveStore.states.find(
+        (s) => s.name === "tooltipAdapter",
+      );
+    expect(tooltipAdapterState).toBeDefined();
+    expect(tooltipAdapterState.type).toContain("param: {key: string, value: any}");
+
+    // Verify no function locals leaked into stacStore
+    const stacMemberNames = architectureMetadata.reactiveStore.stacStore.map(
+      (s) => s.name,
+    );
+    expect(stacMemberNames).toContain("stacEndpoint");
+    expect(stacMemberNames).toContain("init");
+    expect(stacMemberNames).not.toContain("isPOI");
+    expect(stacMemberNames).not.toContain("resp");
   });
 });
 

--- a/packages/mcp/tests/mcp-server.test.js
+++ b/packages/mcp/tests/mcp-server.test.js
@@ -1,3 +1,6 @@
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import http from "node:http";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
@@ -258,6 +261,43 @@ describe("eodash MCP Server - Metadata Generator", () => {
       "datetime",
     );
     expect(widgetsMetadata.EodashTimeSlider.stacExtensions).toHaveLength(0);
+  });
+
+  it("prevents drift between template widgets and metadata catalog", () => {
+    const { widgetsMetadata } = buildMetadata();
+    const knownWidgets = new Set(Object.keys(widgetsMetadata));
+    const templatesDir = path.resolve(__dirname, "../../../templates");
+
+    const templateFiles = fs
+      .readdirSync(templatesDir)
+      .filter((f) => f.endsWith(".js") && f !== "index.js" && f !== "baseConfig.js");
+
+    expect(templateFiles.length).toBeGreaterThanOrEqual(4);
+
+    for (const file of templateFiles) {
+      const content = fs.readFileSync(path.join(templatesDir, file), "utf8");
+      const sf = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true);
+
+      function traverse(node) {
+        if (
+          ts.isPropertyAssignment(node) &&
+          ts.isIdentifier(node.name) &&
+          node.name.text === "name" &&
+          ts.isStringLiteral(node.initializer)
+        ) {
+          const val = node.initializer.text;
+          if (val.startsWith("Eodash")) {
+            expect(
+              knownWidgets.has(val),
+              `Template ${file} references widget '${val}', but it is missing from metadata catalog.`,
+            ).toBe(true);
+          }
+        }
+        ts.forEachChild(node, traverse);
+      }
+
+      traverse(sf);
+    }
   });
 });
 

--- a/packages/mcp/tests/mcp-server.test.js
+++ b/packages/mcp/tests/mcp-server.test.js
@@ -95,6 +95,15 @@ describe("eodash MCP Server - Core Tools", () => {
     const resWc = await tool.handler({ type: "web-component" });
     const wcGuide = JSON.parse(resWc.content[0].text);
     expect(wcGuide["web-component"].lifecycleHooks.onMounted).toBeDefined();
+    expect(wcGuide["web-component"].example).toContain("tagName:");
+    expect(wcGuide["web-component"].example).toContain("link:");
+  });
+
+  it("server initialization passes instructions and capabilities in options", () => {
+    const server = createMcpServer();
+    expect(server.server._instructions).toBeTruthy();
+    expect(server.server._instructions).toContain("eodash");
+    expect(server.server._serverInfo.name).toBe("@eodash/mcp-server");
   });
 
   it("get_eodash_architecture returns grid layout, templates and reactive store details", async () => {
@@ -195,6 +204,22 @@ describe("eodash MCP Server - Metadata Generator", () => {
       const widget = widgetsMetadata[name];
       expect(widget.storeInteractions.reads).not.toContain("useSTAcStore");
     }
+
+    // Verify STAC extensions vs core fields split
+    expect(widgetsMetadata.EodashMap.stacExtensions).toContain("eox:flatstyle");
+    expect(widgetsMetadata.EodashItemCatalog.stacExtensions).toContain(
+      "eo:cloud_cover",
+    );
+    expect(widgetsMetadata.EodashItemCatalog.stacCoreFields).toContain(
+      "datetime",
+    );
+    expect(widgetsMetadata.EodashItemCatalog.stacExtensions).not.toContain(
+      "datetime",
+    );
+    expect(widgetsMetadata.EodashTimeSlider.stacCoreFields).toContain(
+      "datetime",
+    );
+    expect(widgetsMetadata.EodashTimeSlider.stacExtensions).toHaveLength(0);
   });
 });
 

--- a/packages/mcp/tests/mcp-server.test.js
+++ b/packages/mcp/tests/mcp-server.test.js
@@ -128,7 +128,14 @@ describe("eodash MCP Server - Core Tools", () => {
     const gridRes = await tool.handler({ topic: "grid-layout" });
     const gridArch = JSON.parse(gridRes.content[0].text);
     expect(gridArch.gridSystem).toBeDefined();
+    expect(gridArch.gridSystem.notation).toContain("0–11");
     expect(gridArch.templateSystem).toBeUndefined();
+
+    // Custom widget types
+    const widgetTypeRes = await tool.handler({ topic: "custom-widgets" });
+    const widgetTypeArch = JSON.parse(widgetTypeRes.content[0].text);
+    const types = widgetTypeArch.customWidgetSystem.types.map((t) => t.type);
+    expect(types).toEqual(["web-component", "internal", "iframe"]);
   });
 });
 
@@ -166,12 +173,13 @@ describe("eodash MCP Server - Metadata Generator", () => {
     expect(mapElState).toBeDefined();
     expect(mapElState.type).toContain("mapUpdateId?: number");
 
-    const tooltipAdapterState =
-      architectureMetadata.reactiveStore.states.find(
-        (s) => s.name === "tooltipAdapter",
-      );
+    const tooltipAdapterState = architectureMetadata.reactiveStore.states.find(
+      (s) => s.name === "tooltipAdapter",
+    );
     expect(tooltipAdapterState).toBeDefined();
-    expect(tooltipAdapterState.type).toContain("param: {key: string, value: any}");
+    expect(tooltipAdapterState.type).toContain(
+      "param: {key: string, value: any}",
+    );
 
     // Verify no function locals leaked into stacStore
     const stacMemberNames = architectureMetadata.reactiveStore.stacStore.map(
@@ -181,6 +189,12 @@ describe("eodash MCP Server - Metadata Generator", () => {
     expect(stacMemberNames).toContain("init");
     expect(stacMemberNames).not.toContain("isPOI");
     expect(stacMemberNames).not.toContain("resp");
+
+    // Verify store reads do not count useSTAcStore or function imports as reads
+    for (const name of widgetNames) {
+      const widget = widgetsMetadata[name];
+      expect(widget.storeInteractions.reads).not.toContain("useSTAcStore");
+    }
   });
 });
 

--- a/packages/mcp/tests/mcp-server.test.js
+++ b/packages/mcp/tests/mcp-server.test.js
@@ -1,20 +1,43 @@
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
 import http from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { createMcpServer, createExpressApp } from "../index.js";
 import { buildMetadata } from "../generate-metadata.js";
 
+async function createTestClientServer() {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test-client", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return { server, client };
+}
+
 describe("eodash MCP Server - Core Tools", () => {
-  it("initializes MCP server and registers tools", () => {
-    const server = createMcpServer();
-    expect(server).toBeDefined();
+  it("initializes MCP server and delivers instructions via protocol handshake", async () => {
+    const { client } = await createTestClientServer();
+    const instructions = client.getInstructions();
+    expect(instructions).toBeTruthy();
+    expect(instructions).toContain("eodash");
+
+    const tools = await client.listTools();
+    expect(tools.tools.length).toBeGreaterThanOrEqual(6);
   });
 
   it("list_widgets tool returns all widgets and supports filtering by category", async () => {
-    const server = createMcpServer();
-    const listWidgetsTool = server._registeredTools?.["list_widgets"];
-    expect(listWidgetsTool).toBeDefined();
+    const { client } = await createTestClientServer();
 
-    const allRes = await listWidgetsTool.handler({});
+    const allRes = await client.callTool({
+      name: "list_widgets",
+      arguments: {},
+    });
     const allWidgets = JSON.parse(allRes.content[0].text);
     expect(allWidgets.length).toBeGreaterThanOrEqual(10);
 
@@ -22,8 +45,11 @@ describe("eodash MCP Server - Core Tools", () => {
     expect(mapWidget).toBeDefined();
     expect(mapWidget.isBackground).toBe(true);
 
-    const filteredRes = await listWidgetsTool.handler({
-      category: "Visualization",
+    const filteredRes = await client.callTool({
+      name: "list_widgets",
+      arguments: {
+        category: "Visualization",
+      },
     });
     const filteredWidgets = JSON.parse(filteredRes.content[0].text);
     expect(filteredWidgets.length).toBeGreaterThanOrEqual(2);
@@ -33,11 +59,12 @@ describe("eodash MCP Server - Core Tools", () => {
   });
 
   it("get_widget_details returns full props and bindings for EodashMap", async () => {
-    const server = createMcpServer();
-    const tool = server._registeredTools?.["get_widget_details"];
-    expect(tool).toBeDefined();
+    const { client } = await createTestClientServer();
 
-    const res = await tool.handler({ widgetName: "EodashMap" });
+    const res = await client.callTool({
+      name: "get_widget_details",
+      arguments: { widgetName: "EodashMap" },
+    });
     const details = JSON.parse(res.content[0].text);
     expect(details.name).toBe("EodashMap");
     expect(details.props).toBeDefined();
@@ -52,18 +79,23 @@ describe("eodash MCP Server - Core Tools", () => {
   });
 
   it("get_widget_details verifies props and bindings for EodashItemCatalog and EodashProcess", async () => {
-    const server = createMcpServer();
-    const tool = server._registeredTools?.["get_widget_details"];
+    const { client } = await createTestClientServer();
 
     // Catalog widget
-    const catalogRes = await tool.handler({ widgetName: "EodashItemCatalog" });
+    const catalogRes = await client.callTool({
+      name: "get_widget_details",
+      arguments: { widgetName: "EodashItemCatalog" },
+    });
     const catalog = JSON.parse(catalogRes.content[0].text);
     expect(catalog.name).toBe("EodashItemCatalog");
     expect(catalog.props.some((p) => p.name === "filters")).toBe(true);
     expect(catalog.storeInteractions.writes).toContain("selectedItem");
 
     // Process widget
-    const processRes = await tool.handler({ widgetName: "EodashProcess" });
+    const processRes = await client.callTool({
+      name: "get_widget_details",
+      arguments: { widgetName: "EodashProcess" },
+    });
     const proc = JSON.parse(processRes.content[0].text);
     expect(proc.name).toBe("EodashProcess");
     expect(proc.props.some((p) => p.name === "enableCompare")).toBe(true);
@@ -71,9 +103,11 @@ describe("eodash MCP Server - Core Tools", () => {
   });
 
   it("get_widget_details handles unknown widget gracefully", async () => {
-    const server = createMcpServer();
-    const tool = server._registeredTools?.["get_widget_details"];
-    const res = await tool.handler({ widgetName: "NonExistentWidget" });
+    const { client } = await createTestClientServer();
+    const res = await client.callTool({
+      name: "get_widget_details",
+      arguments: { widgetName: "NonExistentWidget" },
+    });
     expect(res.isError).toBe(true);
     expect(res.content[0].text).toContain(
       "Widget 'NonExistentWidget' not found",
@@ -81,37 +115,35 @@ describe("eodash MCP Server - Core Tools", () => {
   });
 
   it("get_custom_widget_guide returns complete templates for custom widgets", async () => {
-    const server = createMcpServer();
-    const tool = server._registeredTools?.["get_custom_widget_guide"];
-    expect(tool).toBeDefined();
+    const { client } = await createTestClientServer();
 
-    const resAll = await tool.handler({ type: "all" });
+    const resAll = await client.callTool({
+      name: "get_custom_widget_guide",
+      arguments: { type: "all" },
+    });
     const guides = JSON.parse(resAll.content[0].text);
     expect(guides["web-component"]).toBeDefined();
     expect(guides["functional"]).toBeDefined();
     expect(guides["iframe"]).toBeDefined();
     expect(guides["eox-elements"]).toBeDefined();
 
-    const resWc = await tool.handler({ type: "web-component" });
+    const resWc = await client.callTool({
+      name: "get_custom_widget_guide",
+      arguments: { type: "web-component" },
+    });
     const wcGuide = JSON.parse(resWc.content[0].text);
     expect(wcGuide["web-component"].lifecycleHooks.onMounted).toBeDefined();
     expect(wcGuide["web-component"].example).toContain("tagName:");
     expect(wcGuide["web-component"].example).toContain("link:");
   });
 
-  it("server initialization passes instructions and capabilities in options", () => {
-    const server = createMcpServer();
-    expect(server.server._instructions).toBeTruthy();
-    expect(server.server._instructions).toContain("eodash");
-    expect(server.server._serverInfo.name).toBe("@eodash/mcp-server");
-  });
-
   it("get_eodash_architecture returns grid layout, templates and reactive store details", async () => {
-    const server = createMcpServer();
-    const tool = server._registeredTools?.["get_eodash_architecture"];
-    expect(tool).toBeDefined();
+    const { client } = await createTestClientServer();
 
-    const res = await tool.handler({ topic: "all" });
+    const res = await client.callTool({
+      name: "get_eodash_architecture",
+      arguments: { topic: "all" },
+    });
     const arch = JSON.parse(res.content[0].text);
     expect(arch.gridSystem.columns).toBe(12);
     const templateNames = arch.templateSystem.builtInTemplates.map(
@@ -134,14 +166,20 @@ describe("eodash MCP Server - Core Tools", () => {
     ).toBeDefined();
 
     // Partial topic filtering
-    const gridRes = await tool.handler({ topic: "grid-layout" });
+    const gridRes = await client.callTool({
+      name: "get_eodash_architecture",
+      arguments: { topic: "grid-layout" },
+    });
     const gridArch = JSON.parse(gridRes.content[0].text);
     expect(gridArch.gridSystem).toBeDefined();
     expect(gridArch.gridSystem.notation).toContain("0–11");
     expect(gridArch.templateSystem).toBeUndefined();
 
     // Custom widget types
-    const widgetTypeRes = await tool.handler({ topic: "custom-widgets" });
+    const widgetTypeRes = await client.callTool({
+      name: "get_eodash_architecture",
+      arguments: { topic: "custom-widgets" },
+    });
     const widgetTypeArch = JSON.parse(widgetTypeRes.content[0].text);
     const types = widgetTypeArch.customWidgetSystem.types.map((t) => t.type);
     expect(types).toEqual(["web-component", "internal", "iframe"]);

--- a/packages/mcp/tests/mcp-server.test.js
+++ b/packages/mcp/tests/mcp-server.test.js
@@ -289,14 +289,37 @@ describe("eodash MCP Server - HTTP Endpoints", () => {
     expect(body.message).toBe("eodash MCP Server is running");
   });
 
-  it("GET / returns 200 HTML landing page with widget overview", async () => {
+  it("GET / returns 405 Method Not Allowed per MCP Streamable HTTP spec", async () => {
     const res = await fetch(`${baseUrl}/`);
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("POST");
+    const body = await res.json();
+    expect(body.error.code).toBe(-32600);
+  });
+
+  it("GET /ui returns 200 HTML landing page with widget overview", async () => {
+    const res = await fetch(`${baseUrl}/ui`);
     expect(res.status).toBe(200);
     expect(res.headers.get("content-type")).toContain("text/html");
     const html = await res.text();
     expect(html).toContain("eodash MCP Server");
     expect(html).toContain("Available Widgets");
     expect(html).toContain("EodashMap");
+  });
+
+  it("POST / with malformed JSON body returns 400 with standard JSON-RPC parse error", async () => {
+    const res = await fetch(`${baseUrl}/`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+      },
+      body: "{ malformed json: true",
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error.code).toBe(-32700);
+    expect(body.error.message).toContain("Parse error");
   });
 
   it("DELETE / returns 200 stateless status", async () => {

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -4,6 +4,8 @@
     "moduleResolution": "bundler",
     "target": "ESNext",
     "allowJs": true,
+    "checkJs": false,
+    "maxNodeModuleJsDepth": 0,
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "noEmit": true,

--- a/packages/mcp/tsconfig.json
+++ b/packages/mcp/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "target": "ESNext",
+    "allowJs": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.js"],
+  "exclude": ["node_modules", "../../node_modules"]
+}

--- a/typedoc.config.json
+++ b/typedoc.config.json
@@ -8,6 +8,7 @@
   "sortEntryPoints": false,
   "docsRoot": "./docs",
   "out": "docs/api",
+  "json": "dist/typedoc.json",
   "tsconfig": "tsconfig.typedoc.json",
   "plugin": [
     "typedoc-plugin-vue",


### PR DESCRIPTION
## Description

Overhaul of mcp-server addressing the provided feedback.

 - Standalone Package Architecture: Declared missing runtime dependencies (typescript, @vue/compiler-sfc), resolved symlinked binary execution with fs.realpathSync, added files whitelist and prepack hook in packages/mcp/package.json, and added standalone fallback for bundled data/*.json metadata.
 - AST & Metadata Accuracy: Migrated JSDoc type extraction to TypeScript Compiler AST (ts.createSourceFile) to preserve nested types without truncation; restricted Pinia store traversal to top-level setup return expressions; added support for Vue prop default() method declarations and explicit required: true detection; filtered out false-positive store reads from imports/callees; separated STAC metadata into stacExtensions and stacCoreFields.
 - Single Source of Truth: **Consolidated widget discovery into core/node/widgets.js, shared across TypeDoc documentation and MCP metadata generation**.
 - Protocol & HTTP Compliance: Transferred instructions during client handshake via McpServer options; added Express JSON parse error handler errors; moved HTML UI to GET /ui and returned 405 on GET / per MCP Streamable HTTP spec.                                                                                          
 - Scaffold & Generator Overhaul: Dynamic template discovery; merge custom widgets into selected base templates (...template.widgets); standardized web component scaffolds on <eo-dash config="/config.js">; updated Dockerfiles to node:24-alpine; emitted missing storytelling narrative assets.
 - Testing & Anti-Drift Guardrails: Converted test suite to official @modelcontextprotocol/sdk/client + InMemoryTransport linked pair; added TypeScript AST syntax assertions for all scaffolded files; added drift assertion tests between templates/*.js and the metadata catalog.
 - Tooling & Typecheck Safety: Configured packages/mcp/tsconfig.json with checkJs: false and maxNodeModuleJsDepth: 0 to prevent TypeScript recursive generic type inference heap OOM during npm run check.

## Checklist

- [x] I have performed a self review on my code
- [x] I added a test related to this feature/fix
- [x] I ran `npm run format` and `npm run check` pass
- [x] Docs under `docs/` are updated for any public API, config, or behavior change
- [ ] New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](https://eodash.github.io/eodash/eodash-store) reference is generated from it
- [ ] New widget props are typed properly and they appear typed in the API reference
