### PR TITLE
chore: tests run on any PR branch

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,9 +1,6 @@
 name: Run Tests
 on:
   pull_request:
-    branches:
-      - "main"
-
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
should fix the fact that only commit made after PR is opened actually run tests in github PR stacks

## Description

<!-- What does this PR change, and why? -->

## Checklist

- [x] I have performed a self review on my code
- [ ] I added a test related to this feature/fix
- [ ] I ran `npm run format` and `npm run check` pass
- [ ] Docs under `docs/` are updated for any public API, config, or behavior change
- [ ] New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](https://eodash.github.io/eodash/eodash-store) reference is generated from it
- [ ] New widget props are typed properly and they appear typed in the API reference
