### PR TITLE
Feat/mcp generate layer styles, discover curated examples, validate collection schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,5 @@ docs/**/*.timestamp-*.mjs
 .vitest-attachments
 
 # mcp generated data
-packages/mcp/data
+packages/mcp/data/*-metadata.json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13674,6 +13674,8 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@vue/compiler-sfc": "^3.5.41",
+        "ajv": "^8.20.0",
+        "ajv-formats": "^3.0.1",
         "cors": "^2.8.5",
         "express": "^5.2.1",
         "typescript": "^6.0.3",
@@ -13682,6 +13684,28 @@
       "bin": {
         "eodash-mcp-server": "index.js"
       }
+    },
+    "packages/mcp/node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "packages/mcp/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
     },
     "packages/mcp/node_modules/zod": {
       "version": "3.25.76",

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -2,11 +2,14 @@
 
 Model Context Protocol (MCP) server for `@eodash/eodash`.
 
-Provides intelligent assistance, introspection, type-safe widget definitions, layout orchestration, and configuration generators for coding agents and developers working on `eodash`-based dashboards.
+Provides intelligent assistance, introspection, type-safe widget definitions, layout orchestration, layer style generation, curated example discovery, catalog validation, and configuration generators for coding agents and developers working on `eodash`-based dashboards.
 
 ## Features
 
-- **Widget Introspection**: Query built-in widgets (`EodashMap`, `EodashItemCatalog`, `EodashItemFilter`, `EodashLayerControl`, `EodashTimeSlider`, `EodashDatePicker`, `EodashProcess`, `EodashChart`, `EodashStacInfo`, `EodashTools`, `EodashLayoutSwitcher`) with complete TypeScript prop signatures, defaults, descriptions, and usage snippets.
+- **Widget Introspection & Schema**: Query built-in widgets (`EodashMap`, `EodashItemCatalog`, `EodashItemFilter`, `EodashLayerControl`, `EodashTimeSlider`, `EodashDatePicker`, `EodashProcess`, `EodashChart`, `EodashStacInfo`, `EodashTools`, `EodashLayoutSwitcher`) with structured JSON schemas for complex props (e.g., `EodashMap.btns`), TypeScript signatures, defaults, and usage snippets.
+- **Layer Style & Visualization Generator**: Generate OpenLayers styles (`vector-flatstyle` for GeoJSON/FlatGeobuf/MVT, `raster-flatstyle` for client-side COG/GeoTIFF rendering) and dynamic forms (`rasterform` for TiTiler/WMS/XYZ). Supports remote colormap palette fetching (viridis, magma, plasma, etc.) and dynamic slider track calculation (~1.5x headroom on default max).
+- **Curated Examples Discovery**: Query working dashboard examples, layer styles, and catalog configs filtered by category, data type, feature tags, and weighted free-text search.
+- **Catalog Schema Validation**: Validate EODash catalog collections and indicators against official schemas (`collection-schema.json`, `indicator-schema.json`) and business rules (enforcing URL strings for `Style`, rejecting `Resources[].Flatstyle`, checking `keep_oneof_values: false` on branching JSON-Editor forms).
 - **Custom Widget Guidance**: Detailed guides and code templates for Web Component (`type: "web-component"`), Functional (`defineWidget: (selectedSTAC) => ...`), and IFrame widgets, including direct integration with `@eox/*` components and the reactive Pinia `eodashStore`.
 - **Architecture & Layout Reference**: Detailed explanation of the 12-column responsive grid system, coordinate syntax (`"mobile/tablet/desktop"`), built-in templates (`lite`, `explore`, `expert`, `compare`), reactive state flows, and SPA vs `<eo-dash>` web component deployments.
 
@@ -58,14 +61,17 @@ Connect to `http://localhost:3001` via Streamable HTTP.
 
 ## Registered Tools
 
-| Tool                      | Description                                                                                                                         |
-| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
-| `list_widgets`            | List all built-in eodash widgets with category, background capability, prop count, and store bindings.                              |
-| `get_widget_details`      | Get full TypeScript props, defaults, store reads/writes, STAC extensions, example config, and markdown guide for a specific widget. |
-| `get_custom_widget_guide` | Detailed guides and templates for Web Component, Functional, and IFrame custom widgets.                                             |
-| `get_eodash_architecture` | Architecture reference covering the 12-column grid, templates, Pinia store states, and deployment modes.                            |
-| `scaffold_dashboard`      | Scaffold boilerplate for standalone SPA, VitePress narrative docs, or embedded web component dashboard projects.                    |
-| `generate_eodash_config`  | Generate type-safe eodash configuration with STAC endpoints, brand theme, layout template, and custom widgets.                      |
+| Tool                      | Description                                                                                                                                           |
+| ------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `list_widgets`            | List all built-in eodash widgets with category, background capability, prop count, store bindings, and filter by capability tags or free-text search. |
+| `get_widget_details`      | Get full TypeScript props, JSON schemas for complex props, defaults, store bindings, STAC extensions, and usage snippets for a specific widget.       |
+| `get_custom_widget_guide` | Detailed guides and templates for Web Component, Functional, and IFrame custom widgets.                                                               |
+| `get_eodash_architecture` | Architecture reference covering the 12-column grid, templates, Pinia store states, and deployment modes.                                              |
+| `scaffold_dashboard`      | Scaffold boilerplate for standalone SPA, VitePress narrative docs, or embedded web component dashboard projects (returns in-memory file tree).        |
+| `generate_eodash_config`  | Generate type-safe eodash configuration with STAC endpoints, brand theme, layout template, and custom widgets (returns in-memory file content).       |
+| `generate_layer_style`    | Generate complete OpenLayers styles (`vector-flatstyle`, `raster-flatstyle` for COG) and dynamic forms (`rasterform`) with colormaps and sliders.     |
+| `find_examples`           | Search and discover working eodash dashboard examples, layer styles, and catalog configs with category, data type, and feature filters.               |
+| `validate_catalog_config` | Validate catalog collection and indicator configurations against official eodash schemas and business rules.                                          |
 
 ## Running Tests
 

--- a/packages/mcp/data/examples.json
+++ b/packages/mcp/data/examples.json
@@ -226,13 +226,13 @@
     }
   },
   {
-    "id": "raster-webgl-cog-single-band-normalized",
-    "title": "Single-Band COG Normalized WebGLTile FlatStyle with Min/Max Sliders",
-    "category": "raster-webgl-flatstyle",
+    "id": "raster-cog-single-band-normalized",
+    "title": "Single-Band COG Normalized FlatStyle with Min/Max Sliders",
+    "category": "raster-flatstyle",
     "dataType": "cog",
     "geometryType": "raster",
     "features": [
-      "webgl-shader",
+      "client-side-rendering",
       "interpolate-color",
       "dynamic-variables",
       "jsonform",
@@ -241,14 +241,14 @@
     "tags": [
       "cog",
       "geotiff",
-      "webgl",
+      "raster-flatstyle",
       "sar",
       "rcm",
       "radar",
       "polartep",
       "cerulean"
     ],
-    "description": "OpenLayers WebGLTile FlatStyle for single-band GeoTIFF / COG (e.g. SAR Sigma0, DEM Elevation, Temperature) with client-side GPU normalization, colormap interpolation, and reactive min/max sliders.",
+    "description": "OpenLayers FlatStyle for single-band GeoTIFF / COG (e.g. SAR Sigma0, DEM Elevation, Temperature) with client-side normalization, colormap interpolation, and reactive min/max sliders.",
     "targetContext": "Host as JSON file on assets endpoint, reference in STAC Item link with 'eox:flatstyle' or in catalog collection 'Resources[].Style'.",
     "code": {
       "legend": {
@@ -314,22 +314,22 @@
     }
   },
   {
-    "id": "raster-webgl-cog-rgb-composite",
-    "title": "Sentinel-2 True Color RGB COG WebGLTile FlatStyle",
-    "category": "raster-webgl-flatstyle",
+    "id": "raster-cog-rgb-composite",
+    "title": "Sentinel-2 True Color RGB COG FlatStyle",
+    "category": "raster-flatstyle",
     "dataType": "cog",
     "geometryType": "raster",
-    "features": ["webgl-shader", "rgb-composite", "divisor-variable"],
+    "features": ["rgb-composite", "divisor-variable"],
     "tags": [
       "cog",
       "sentinel-2",
       "rgb",
       "true-color",
-      "webgl",
+      "raster-flatstyle",
       "crop-circles",
       "style-editor"
     ],
-    "description": "WebGLTile FlatStyle combining Bands 4 (Red), 3 (Green), and 2 (Blue) into a true-color satellite image composite with brightness divisor variables.",
+    "description": "Raster FlatStyle combining Bands 4 (Red), 3 (Green), and 2 (Blue) into a true-color satellite image composite with brightness divisor variables.",
     "targetContext": "Host as JSON file on assets endpoint, reference in STAC Item link with 'eox:flatstyle' or in catalog collection 'Resources[].Style'.",
     "code": {
       "variables": {
@@ -352,14 +352,22 @@
     }
   },
   {
-    "id": "raster-webgl-cog-ndvi-index-math",
-    "title": "On-the-Fly NDVI Band Math COG WebGLTile FlatStyle",
-    "category": "raster-webgl-flatstyle",
+    "id": "raster-cog-ndvi-index-math",
+    "title": "On-the-Fly NDVI Band Math COG FlatStyle",
+    "category": "raster-flatstyle",
     "dataType": "cog",
     "geometryType": "raster",
-    "features": ["webgl-shader", "band-math", "ndvi", "interpolate-color"],
-    "tags": ["cog", "ndvi", "band-math", "sentinel-2", "eopf", "eodash-assets"],
-    "description": "Calculates Normalized Difference Vegetation Index (B8 - B4)/(B8 + B4) in GPU shader with continuous color interpolation from soil to dense vegetation.",
+    "features": ["band-math", "ndvi", "interpolate-color"],
+    "tags": [
+      "cog",
+      "ndvi",
+      "band-math",
+      "sentinel-2",
+      "eopf",
+      "eodash-assets",
+      "raster-flatstyle"
+    ],
+    "description": "Calculates Normalized Difference Vegetation Index (B8 - B4)/(B8 + B4) client-side with continuous color interpolation from soil to dense vegetation.",
     "targetContext": "Host as JSON file on assets endpoint, reference in STAC Item link with 'eox:flatstyle'.",
     "code": {
       "color": [

--- a/packages/mcp/data/examples.json
+++ b/packages/mcp/data/examples.json
@@ -1,0 +1,903 @@
+[
+  {
+    "id": "vector-flatstyle-ice-charts-categorical",
+    "title": "Categorical Ice Charts Polygon FlatStyle with Legend",
+    "category": "vector-flatstyle",
+    "dataType": "vector",
+    "geometryType": "polygon",
+    "features": ["legend", "categorical-match", "tooltip"],
+    "tags": [
+      "ice-charts",
+      "categorical",
+      "match-expression",
+      "legend",
+      "cerulean",
+      "deside",
+      "vector-tiles"
+    ],
+    "description": "Polygon OpenLayers FlatStyle for sea ice classification charts with categorical 'match' expressions, WMO concentration colors, and custom tooltips. Valid for GeoJSON, FlatGeobuf, and Vector Tiles.",
+    "targetContext": "Host as JSON file on assets endpoint, reference in STAC Item link with 'eox:flatstyle' or in catalog collection 'Style'.",
+    "code": {
+      "fill-color": [
+        "match",
+        ["get", "POLY_TYPE"],
+        "I",
+        [
+          "match",
+          ["get", "CT"],
+          "92",
+          "rgba(149, 2, 140, 1.0)",
+          "91",
+          "rgba(224, 150, 224, 1.0)",
+          "89",
+          "rgba(255, 0, 0, 1.0)",
+          "81",
+          "rgba(255, 125, 7, 1.0)",
+          "70",
+          "rgba(255, 255, 0, 1.0)",
+          "40",
+          "rgba(140, 255, 159, 1.0)",
+          "10",
+          "rgba(125, 175, 224, 1.0)",
+          "02",
+          "rgba(0, 100, 255, 1.0)",
+          "rgba(0, 0, 0, 0.0)"
+        ],
+        "rgba(0, 0, 0, 0.0)"
+      ],
+      "stroke-color": "rgba(50, 50, 50, 0.4)",
+      "stroke-width": 0.5,
+      "legend": [
+        {
+          "title": "WMO Sea Ice Total Concentration",
+          "scaleType": "categorical",
+          "markType": "square",
+          "domain": [
+            "Fast Ice (92)",
+            "Consolidated (91)",
+            "Very Close (89)",
+            "Close (81)",
+            "Open (70)",
+            "Very Open (40)",
+            "Open Water (10)",
+            "Ice Free (02)"
+          ],
+          "range": [
+            "rgba(149, 2, 140, 1.0)",
+            "rgba(224, 150, 224, 1.0)",
+            "rgba(255, 0, 0, 1.0)",
+            "rgba(255, 125, 7, 1.0)",
+            "rgba(255, 255, 0, 1.0)",
+            "rgba(140, 255, 159, 1.0)",
+            "rgba(125, 175, 224, 1.0)",
+            "rgba(0, 100, 255, 1.0)"
+          ]
+        }
+      ],
+      "tooltip": [
+        { "id": "CT", "title": "Total Concentration", "appendix": "/10" },
+        { "id": "CA", "title": "Partial Conc. A" },
+        { "id": "SA", "title": "Stage of Development A" }
+      ]
+    }
+  },
+  {
+    "id": "vector-flatstyle-station-points-interactive",
+    "title": "In Situ Air Quality Monitoring Stations with Dynamic Size and Tooltips",
+    "category": "vector-flatstyle",
+    "dataType": "point",
+    "geometryType": "point",
+    "features": ["circle-style", "dynamic-variables", "jsonform", "tooltip"],
+    "tags": [
+      "air-quality",
+      "stations",
+      "points",
+      "jsonform-slider",
+      "tooltip",
+      "ukif",
+      "austria"
+    ],
+    "description": "Point feature FlatStyle for air quality and sensor stations with variable circle radius controlled by a layer control JSONForm slider, dynamic stroke, and rich tooltip formatting.",
+    "targetContext": "Host as JSON file on assets endpoint, reference in STAC Item link with 'eox:flatstyle' or in catalog collection 'Resources[].Style'.",
+    "code": {
+      "variables": {
+        "pointRadius": 6,
+        "strokeWidth": 1.5
+      },
+      "circle-radius": ["var", "pointRadius"],
+      "circle-fill-color": [
+        "case",
+        [">", ["get", "pm25"], 50],
+        "#bc0106",
+        [">", ["get", "pm25"], 25],
+        "#e36c09",
+        [">", ["get", "pm25"], 10],
+        "#fcfb01",
+        "#3e9655"
+      ],
+      "circle-stroke-color": "#ffffff",
+      "circle-stroke-width": ["var", "strokeWidth"],
+      "legend": {
+        "title": "PM2.5 Air Quality Index (µg/m³)",
+        "scaleType": "categorical",
+        "markType": "circle",
+        "domain": [
+          "Good (<10)",
+          "Moderate (10-25)",
+          "Unhealthy (25-50)",
+          "Hazardous (>50)"
+        ],
+        "range": ["#3e9655", "#fcfb01", "#e36c09", "#bc0106"]
+      },
+      "jsonform": {
+        "type": "object",
+        "title": "Station Display Configuration",
+        "properties": {
+          "pointRadius": {
+            "title": "Point Size",
+            "type": "number",
+            "minimum": 3,
+            "maximum": 20,
+            "default": 6,
+            "format": "range"
+          }
+        }
+      },
+      "tooltip": [
+        { "id": "station_name", "title": "Station" },
+        { "id": "pm25", "title": "PM2.5", "appendix": " µg/m³", "decimals": 1 },
+        { "id": "time", "title": "Recorded At" }
+      ]
+    }
+  },
+  {
+    "id": "vector-flatstyle-threshold-filter-polygons",
+    "title": "Dynamic Threshold Filter FlatStyle with JSONForm Slider",
+    "category": "vector-flatstyle",
+    "dataType": "vector",
+    "geometryType": "polygon",
+    "features": [
+      "dynamic-variables",
+      "jsonform",
+      "threshold-filter",
+      "case-expression"
+    ],
+    "tags": [
+      "polygons",
+      "threshold",
+      "case-expression",
+      "jsonform",
+      "harshness",
+      "cerulean"
+    ],
+    "description": "Polygon FlatStyle filtering displayed polygons dynamically using a threshold variable connected to a JSONForm slider.",
+    "targetContext": "Host as JSON file on assets endpoint, reference in STAC Item link with 'eox:flatstyle' or in catalog collection 'Resources[].Style'.",
+    "code": {
+      "variables": {
+        "threshold": 3
+      },
+      "fill-color": [
+        "case",
+        [">=", ["get", "severity_index"], ["var", "threshold"]],
+        [
+          "interpolate",
+          ["linear"],
+          ["get", "severity_index"],
+          1,
+          "rgba(50, 136, 189, 0.6)",
+          3,
+          "rgba(254, 224, 139, 0.6)",
+          5,
+          "rgba(213, 62, 79, 0.8)"
+        ],
+        "rgba(0, 0, 0, 0)"
+      ],
+      "stroke-color": "#333333",
+      "stroke-width": 1,
+      "legend": {
+        "title": "Severity Risk Index",
+        "scaleType": "continuous",
+        "domainProperties": ["threshold", "maxThreshold"],
+        "range": [
+          "rgba(50, 136, 189, 0.6)",
+          "rgba(254, 224, 139, 0.6)",
+          "rgba(213, 62, 79, 0.8)"
+        ]
+      },
+      "jsonform": {
+        "type": "object",
+        "title": "Risk Filter",
+        "properties": {
+          "threshold": {
+            "title": "Minimum Severity Level",
+            "type": "number",
+            "minimum": 1,
+            "maximum": 5,
+            "step": 0.5,
+            "default": 3,
+            "format": "range"
+          }
+        }
+      },
+      "tooltip": [
+        { "id": "zone_id", "title": "Risk Zone" },
+        { "id": "severity_index", "title": "Severity Level", "decimals": 2 }
+      ]
+    }
+  },
+  {
+    "id": "raster-webgl-cog-single-band-normalized",
+    "title": "Single-Band COG Normalized WebGLTile FlatStyle with Min/Max Sliders",
+    "category": "raster-webgl-flatstyle",
+    "dataType": "cog",
+    "geometryType": "raster",
+    "features": [
+      "webgl-shader",
+      "interpolate-color",
+      "dynamic-variables",
+      "jsonform",
+      "legend-domainProperties"
+    ],
+    "tags": [
+      "cog",
+      "geotiff",
+      "webgl",
+      "sar",
+      "rcm",
+      "radar",
+      "polartep",
+      "cerulean"
+    ],
+    "description": "OpenLayers WebGLTile FlatStyle for single-band GeoTIFF / COG (e.g. SAR Sigma0, DEM Elevation, Temperature) with client-side GPU normalization, colormap interpolation, and reactive min/max sliders.",
+    "targetContext": "Host as JSON file on assets endpoint, reference in STAC Item link with 'eox:flatstyle' or in catalog collection 'Resources[].Style'.",
+    "code": {
+      "legend": {
+        "title": "Sigma0 Backscatter",
+        "range": [
+          "rgba(0, 0, 0, 1)",
+          "rgba(0, 113, 194, 1)",
+          "rgba(255, 255, 255, 1)"
+        ],
+        "domainProperties": ["vmin", "vmax"]
+      },
+      "variables": {
+        "vmin": 0,
+        "vmax": 1
+      },
+      "color": [
+        "case",
+        ["!=", ["band", 1], 0],
+        [
+          "interpolate",
+          ["linear"],
+          [
+            "/",
+            ["-", ["band", 1], ["var", "vmin"]],
+            ["-", ["var", "vmax"], ["var", "vmin"]]
+          ],
+          0,
+          [0, 0, 0, 1],
+          0.5,
+          [0, 113, 194, 1],
+          1,
+          [255, 255, 255, 1]
+        ],
+        ["color", 0, 0, 0, 0]
+      ],
+      "jsonform": {
+        "type": "object",
+        "title": "Backscatter Contrast",
+        "properties": {
+          "vminmax": {
+            "title": "Sigma0 Range",
+            "type": "object",
+            "properties": {
+              "vmin": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 5,
+                "format": "range",
+                "default": 0
+              },
+              "vmax": {
+                "type": "number",
+                "minimum": 0,
+                "maximum": 5,
+                "format": "range",
+                "default": 1
+              }
+            },
+            "format": "minmax"
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "raster-webgl-cog-rgb-composite",
+    "title": "Sentinel-2 True Color RGB COG WebGLTile FlatStyle",
+    "category": "raster-webgl-flatstyle",
+    "dataType": "cog",
+    "geometryType": "raster",
+    "features": ["webgl-shader", "rgb-composite", "divisor-variable"],
+    "tags": [
+      "cog",
+      "sentinel-2",
+      "rgb",
+      "true-color",
+      "webgl",
+      "crop-circles",
+      "style-editor"
+    ],
+    "description": "WebGLTile FlatStyle combining Bands 4 (Red), 3 (Green), and 2 (Blue) into a true-color satellite image composite with brightness divisor variables.",
+    "targetContext": "Host as JSON file on assets endpoint, reference in STAC Item link with 'eox:flatstyle' or in catalog collection 'Resources[].Style'.",
+    "code": {
+      "variables": {
+        "band1Divisor": 3000.0,
+        "band2Divisor": 3000.0,
+        "band3Divisor": 3000.0
+      },
+      "color": [
+        "case",
+        [">", ["band", 1], 0],
+        [
+          "array",
+          ["/", ["band", 1], ["var", "band1Divisor"]],
+          ["/", ["band", 2], ["var", "band2Divisor"]],
+          ["/", ["band", 3], ["var", "band3Divisor"]],
+          1
+        ],
+        ["color", 0, 0, 0, 0]
+      ]
+    }
+  },
+  {
+    "id": "raster-webgl-cog-ndvi-index-math",
+    "title": "On-the-Fly NDVI Band Math COG WebGLTile FlatStyle",
+    "category": "raster-webgl-flatstyle",
+    "dataType": "cog",
+    "geometryType": "raster",
+    "features": ["webgl-shader", "band-math", "ndvi", "interpolate-color"],
+    "tags": ["cog", "ndvi", "band-math", "sentinel-2", "eopf", "eodash-assets"],
+    "description": "Calculates Normalized Difference Vegetation Index (B8 - B4)/(B8 + B4) in GPU shader with continuous color interpolation from soil to dense vegetation.",
+    "targetContext": "Host as JSON file on assets endpoint, reference in STAC Item link with 'eox:flatstyle'.",
+    "code": {
+      "color": [
+        "case",
+        ["!=", ["+", ["band", 8], ["band", 4]], 0],
+        [
+          "interpolate",
+          ["linear"],
+          [
+            "/",
+            ["-", ["band", 8], ["band", 4]],
+            ["+", ["band", 8], ["band", 4]]
+          ],
+          -0.2,
+          [165, 0, 38, 1],
+          0.0,
+          [254, 224, 139, 1],
+          0.2,
+          [217, 239, 139, 1],
+          0.5,
+          [102, 189, 99, 1],
+          0.8,
+          [0, 104, 55, 1]
+        ],
+        ["color", 0, 0, 0, 0]
+      ],
+      "legend": {
+        "title": "Normalized Difference Vegetation Index (NDVI)",
+        "scaleType": "continuous",
+        "domain": [-0.2, 0.8],
+        "range": [
+          "rgba(165, 0, 38, 1)",
+          "rgba(254, 224, 139, 1)",
+          "rgba(217, 239, 139, 1)",
+          "rgba(102, 189, 99, 1)",
+          "rgba(0, 104, 55, 1)"
+        ]
+      }
+    }
+  },
+  {
+    "id": "rasterform-titiler-rescale-colormap",
+    "title": "TiTiler Dynamic Rescale & Colormap RasterForm with RemoveProperties",
+    "category": "rasterform",
+    "dataType": "xyz",
+    "geometryType": "raster",
+    "features": [
+      "rasterform",
+      "titiler",
+      "removeProperties",
+      "template-watch",
+      "legend-rangeProperty"
+    ],
+    "tags": [
+      "titiler",
+      "rasterform",
+      "rescale",
+      "colormap",
+      "xyz",
+      "cerulean",
+      "eodashboard"
+    ],
+    "description": "eodash:rasterform configuration for TiTiler XYZ tile layer. Uses 'removeProperties: [\"vminmax\"]' and template/watch to generate rescale URL parameter without polluting queries.",
+    "targetContext": "Define inside STAC link as 'eodash:rasterform' object, or reference as URL string.",
+    "code": {
+      "legend": {
+        "rangeProperty": "colormap_name",
+        "domainProperties": ["vmin", "vmax"]
+      },
+      "jsonform": {
+        "type": "object",
+        "title": "Tile Display Settings",
+        "options": {
+          "removeProperties": ["vminmax"]
+        },
+        "properties": {
+          "colormap_name": {
+            "title": "Colormap",
+            "type": "string",
+            "enum": [
+              "viridis",
+              "magma",
+              "plasma",
+              "inferno",
+              "cividis",
+              "rainbow",
+              "spectral"
+            ],
+            "default": "viridis"
+          },
+          "vminmax": {
+            "title": "Value Range",
+            "type": "object",
+            "properties": {
+              "vmin": {
+                "type": "number",
+                "format": "range",
+                "minimum": 0,
+                "maximum": 5000,
+                "default": 0
+              },
+              "vmax": {
+                "type": "number",
+                "format": "range",
+                "minimum": 0,
+                "maximum": 5000,
+                "default": 3000
+              }
+            },
+            "format": "minmax"
+          },
+          "rescale": {
+            "type": "string",
+            "template": "{{vminmax.vmin}},{{vminmax.vmax}}",
+            "watch": { "vminmax": "vminmax" },
+            "options": { "hidden": true }
+          }
+        }
+      }
+    }
+  },
+  {
+    "id": "rasterform-branching-multi-asset",
+    "title": "TiTiler Multi-Asset Branching RasterForm with keep_oneof_values: false",
+    "category": "rasterform",
+    "dataType": "xyz",
+    "geometryType": "raster",
+    "features": [
+      "rasterform",
+      "branching-oneof",
+      "keep_oneof_values_false",
+      "titiler"
+    ],
+    "tags": [
+      "branching",
+      "oneOf",
+      "keep_oneof_values",
+      "titiler",
+      "multi-asset",
+      "sentinel-2"
+    ],
+    "description": "Multi-asset branching form allowing users to toggle between True Color (RGB) and NDVI layers with distinct slider ranges, enforcing 'keep_oneof_values: false' to prevent state pollution.",
+    "targetContext": "Define inside STAC link as 'eodash:rasterform' object, or reference as URL string.",
+    "code": {
+      "legend": {
+        "rangeProperty": "colormap_name",
+        "domainProperties": ["vmin", "vmax"]
+      },
+      "jsonform": {
+        "type": "object",
+        "title": "Product Mode",
+        "options": {
+          "keep_oneof_values": false,
+          "removeProperties": ["vminmax"]
+        },
+        "oneOf": [
+          {
+            "title": "True Color (RGB)",
+            "properties": {
+              "assets": {
+                "type": "string",
+                "default": "visual",
+                "options": { "hidden": true }
+              }
+            }
+          },
+          {
+            "title": "NDVI (Vegetation)",
+            "properties": {
+              "assets": {
+                "type": "string",
+                "default": "ndvi",
+                "options": { "hidden": true }
+              },
+              "colormap_name": {
+                "title": "Color Ramp",
+                "type": "string",
+                "enum": ["viridis", "rdylgn", "spectral"],
+                "default": "rdylgn"
+              },
+              "vminmax": {
+                "title": "NDVI Range",
+                "type": "object",
+                "properties": {
+                  "vmin": {
+                    "type": "number",
+                    "format": "range",
+                    "minimum": -0.5,
+                    "maximum": 1,
+                    "default": 0,
+                    "step": 0.05
+                  },
+                  "vmax": {
+                    "type": "number",
+                    "format": "range",
+                    "minimum": -0.5,
+                    "maximum": 1,
+                    "default": 0.8,
+                    "step": 0.05
+                  }
+                },
+                "format": "minmax"
+              },
+              "rescale": {
+                "type": "string",
+                "template": "{{vminmax.vmin}},{{vminmax.vmax}}",
+                "watch": { "vminmax": "vminmax" },
+                "options": { "hidden": true }
+              }
+            }
+          }
+        ]
+      }
+    }
+  },
+  {
+    "id": "jsonform-bbox-drawtools-selector",
+    "title": "Interactive Bounding Box Map Drawing Form for Processes",
+    "category": "jsonform",
+    "dataType": "vector",
+    "geometryType": "polygon",
+    "features": ["bounding-box", "drawtools", "map-interaction"],
+    "tags": [
+      "jsonform",
+      "bounding-box",
+      "drawtools",
+      "eox-map",
+      "process-input",
+      "cerulean",
+      "ukif"
+    ],
+    "description": "JSONForm schema with interactive map bounding-box drawer linked to 'eox-map#main' in EPSG:4326 for OGC API Processes inputs.",
+    "targetContext": "Host as JSON file on assets endpoint, reference in catalog collection 'Process.JsonForm'.",
+    "code": {
+      "type": "object",
+      "properties": {
+        "bbox": {
+          "type": "array",
+          "title": "Select Area of Interest on Map",
+          "options": {
+            "autoStartSelection": false,
+            "drawtools": {
+              "for": "eox-map#main",
+              "projection": "EPSG:4326"
+            }
+          },
+          "format": "bounding-box"
+        },
+        "date_start": {
+          "title": "Start Date",
+          "type": "date",
+          "format": "date",
+          "default": "2025-01-01"
+        },
+        "date_end": {
+          "title": "End Date",
+          "type": "date",
+          "format": "date",
+          "default": "2026-03-01"
+        }
+      }
+    }
+  },
+  {
+    "id": "catalog-collection-cmems-wmts-timeseries",
+    "title": "CMEMS WMTS Time-Series Collection with OGC Process & Vega Chart",
+    "category": "catalog-collection",
+    "dataType": "wmts",
+    "geometryType": "raster",
+    "features": ["wmts", "time-series", "ogc-process", "vega-chart"],
+    "tags": [
+      "cmems",
+      "wmts",
+      "process",
+      "vega",
+      "oceanography",
+      "cerulean",
+      "deside"
+    ],
+    "description": "Complete eodash collection configuration for Copernicus Marine WMTS service with temporal query extent, dimensions, OGC process execution, and Vega timeseries chart.",
+    "targetContext": "Place in catalog 'collections/<collection-name>.json' for 'eodash_catalog' build.",
+    "code": {
+      "Name": "DIATO_diatoms",
+      "Title": "Mass concentration of diatoms in sea water",
+      "Description": "Copernicus Marine BGC monthly plankton concentration.",
+      "Themes": ["Aquaculture", "Marine Biology"],
+      "CollectionGroup": "F. Water Biology",
+      "Agency": ["Copernicus Marine", "ACRI-ST"],
+      "Resources": [
+        {
+          "EndPoint": "https://wmts.marine.copernicus.eu/teroWmts/OCEANCOLOUR_GLO_BGC_L4_NRT_009_102/cmems_obs-oc_glo_bgc-plankton_nrt_l4-multi-4km_P1M_202411",
+          "Type": "WMTSCapabilities",
+          "Name": "marinedatastore",
+          "LayerId": "OCEANCOLOUR_GLO_BGC_L4_NRT_009_102/cmems_obs-oc_glo_bgc-plankton_nrt_l4-multi-4km_P1M_202411/DIATO",
+          "Query": {
+            "Start": "2021-01-01T00:00:00Z",
+            "End": "2030-01-01T00:00:00Z"
+          },
+          "Dimensions": {
+            "style": "cmap:algae"
+          },
+          "Unit": "mg/m^3"
+        }
+      ],
+      "Process": {
+        "Name": "process_cmems",
+        "JsonForm": "https://raw.githubusercontent.com/gtif-cerulean/assets/main/jsonforms/cmems_jsonform.json",
+        "VegaDefinition": "https://raw.githubusercontent.com/gtif-cerulean/assets/main/chartdefs/DIATO.json",
+        "EndPoints": [
+          {
+            "Identifier": "process_cmems",
+            "Url": "https://cmems.gtif.eox.at/cmems?dataset_id=cmems_obs-oc_glo_bgc-plankton_nrt_l4-multi-4km_P1M&variables=DIATO&start_datetime={{date_start}}&end_datetime={{date_end}}&minimum_longitude={{bbox.0}}&minimum_latitude={{bbox.1}}&maximum_longitude={{bbox.2}}&maximum_latitude={{bbox.3}}&minimum_depth={{depth}}&maximum_depth={{depth}}",
+            "Type": "application/json"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "id": "catalog-collection-vector-stations-timeseries",
+    "title": "Vector In Situ GeoJSON Stations Collection with TimeSeries Endpoint",
+    "category": "catalog-collection",
+    "dataType": "vector",
+    "geometryType": "point",
+    "features": [
+      "geojson",
+      "time-entries",
+      "process",
+      "vega-chart",
+      "style-url"
+    ],
+    "tags": ["vector", "geojson", "in-situ", "air-quality", "ukif", "austria"],
+    "description": "eodash collection configuration for in situ point station GeoJSON files with static bbox, hosted style URL, and feature-level timeseries process.",
+    "targetContext": "Place in catalog 'collections/<collection-name>.json' for 'eodash_catalog' build.",
+    "code": {
+      "Name": "GMIF-air-quality-stations",
+      "Title": "GMif Air Pollution Stations",
+      "CollectionGroup": "Air Quality",
+      "Themes": ["Atmosphere", "Mobility"],
+      "Tags": ["Air Quality", "PM2.5"],
+      "Description": "Consolidated GMif PM2.5 in situ station GeoJSON layer.",
+      "Agency": ["ESA", "UK Space Agency"],
+      "Resources": [
+        {
+          "Name": "GeoJSON source",
+          "Style": "https://raw.githubusercontent.com/gtif-ukif/gtif-ukif-assets/main/collections/GMIF-air-quality/style.json",
+          "Bbox": [-9.7, 41.9, 9.5, 57.2],
+          "TimeEntries": [
+            {
+              "Time": "20250101",
+              "Assets": [
+                {
+                  "Identifier": "gmif_air_pollution_stations",
+                  "File": "https://workspace-ui-public.gtif-ukif.hub-otc.eox.at/api/public/share/public-share/stations.geojson"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "Process": {
+        "Name": "Station Time Series",
+        "JsonForm": "https://raw.githubusercontent.com/gtif-ukif/gtif-ukif-assets/main/defaults/gmif_air_quality_station_form.json",
+        "VegaDefinition": "https://raw.githubusercontent.com/gtif-ukif/gtif-ukif-assets/main/defaults/gmif_air_quality_station_vega.json",
+        "EndPoints": [
+          {
+            "Identifier": "timeseries",
+            "Url": "https://workspace-ui-public.gtif-ukif.hub-otc.eox.at/api/public/share/public-share/timeseries/{{feature}}.json",
+            "Method": "GET",
+            "Type": "application/json"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "id": "catalog-collection-post-process-cog-output",
+    "title": "POST Process Execution Collection Returning GeoTIFF Layer Styled with Flatstyle",
+    "category": "catalog-collection",
+    "dataType": "cog",
+    "geometryType": "raster",
+    "features": [
+      "post-process",
+      "eoxhub-workspaces",
+      "image-tiff",
+      "flatstyle-output"
+    ],
+    "tags": [
+      "post-process",
+      "ogc-processes",
+      "geotiff",
+      "harshness",
+      "cerulean"
+    ],
+    "description": "Collection triggering an asynchronous or on-demand WPS / OGC Process returning an image/tiff COG layer rendered dynamically with an OpenLayers FlatStyle.",
+    "targetContext": "Place in catalog 'collections/<collection-name>.json' for 'eodash_catalog' build.",
+    "code": {
+      "Name": "harshness_calculation",
+      "Title": "Arctic Harshness Index Calculation",
+      "CollectionGroup": "A. Algorithms",
+      "Description": "On-demand execution of harshness navigation risk algorithm.",
+      "Themes": ["Shipping", "Navigation"],
+      "Agency": ["C-CORE"],
+      "Resources": [
+        {
+          "Name": "Collection-only",
+          "OverwriteBBox": [-179, 55, 179, 89]
+        }
+      ],
+      "Process": {
+        "Name": "harshness",
+        "JsonForm": "https://raw.githubusercontent.com/gtif-cerulean/assets/main/jsonforms/harshness.json",
+        "EndPoints": [
+          {
+            "Identifier": "harshnesscollection",
+            "Url": "https://harshness-map.gtif.eox.at/processes/execute-create-harshness/execution",
+            "Method": "POST",
+            "EndPoint": "eoxhub_workspaces",
+            "Body": "https://raw.githubusercontent.com/gtif-cerulean/assets/main/body/harshness.json",
+            "Type": "image/tiff",
+            "Flatstyle": "https://raw.githubusercontent.com/gtif-cerulean/assets/main/styles/harshness.json"
+          }
+        ]
+      }
+    }
+  },
+  {
+    "id": "catalog-indicator-multi-collection",
+    "title": "Indicator Definition Grouping Multiple Collections with Filter Metadata",
+    "category": "catalog-indicator",
+    "dataType": "timeseries",
+    "geometryType": "raster",
+    "features": ["indicator", "subcodes", "themes", "eox-itemfilter-tags"],
+    "tags": [
+      "indicator",
+      "catalog",
+      "themes",
+      "subcode",
+      "eox-itemfilter",
+      "cerulean",
+      "race"
+    ],
+    "description": "Indicator grouping several STAC collections with rich filter metadata (subcodes, themes, satellites, sensors, tags) used by EOxItemFilter.",
+    "targetContext": "Place in catalog 'indicators/<indicator-name>.json' for 'eodash_catalog' build.",
+    "code": {
+      "Name": "shipping_traffic_and_routes",
+      "Title": "Maritime Shipping Traffic & Navigation Routes",
+      "Description": "Synthesizes vessel AIS density, optimal route corridors, and ice conditions.",
+      "CollectionGroup": "Navigation",
+      "Themes": ["Maritime", "Economy"],
+      "Tags": ["AIS", "Vessels", "Routes"],
+      "Satellite": ["Sentinel-1", "RADARSAT-Constellation"],
+      "Sensor": ["SAR"],
+      "Thumbnail": "https://assets.example.com/thumbnails/shipping.png",
+      "SubCode": "SHIPPING_ROUTES",
+      "Collections": [
+        "vessel_density_all",
+        "antarctica_ship_route",
+        "route_optimization"
+      ]
+    }
+  },
+  {
+    "id": "stac-item-web-map-links-roles",
+    "title": "STAC Item with Web Map Links, Roles (baselayer/overlay/data), and Projections",
+    "category": "stac-item",
+    "dataType": "xyz",
+    "geometryType": "raster",
+    "features": ["web-map-links", "roles", "baselayer", "proj-epsg"],
+    "tags": [
+      "stac-item",
+      "web-map-links",
+      "roles",
+      "baselayer",
+      "overlay",
+      "stac-api"
+    ],
+    "description": "Standard STAC Item link structure following web-map-links extension with 'roles' controlling layer group ('baselayer', 'overlay', 'data') and initial visibility ('visible').",
+    "targetContext": "Returned by STAC API /collections/{collectionId}/items endpoint or static catalog Item JSON.",
+    "code": {
+      "type": "Feature",
+      "stac_version": "1.0.0",
+      "id": "sentinel-2-mosaic-2025",
+      "properties": {
+        "datetime": "2025-06-01T00:00:00Z",
+        "proj:epsg": 3857
+      },
+      "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+          [
+            [-180, -85],
+            [180, -85],
+            [180, 85],
+            [-180, 85],
+            [-180, -85]
+          ]
+        ]
+      },
+      "links": [
+        {
+          "rel": "xyz",
+          "href": "https://s2maps-tiles.eu/wmts/1.0.0/osm_3857/default/g/{z}/{y}/{x}.jpeg",
+          "type": "image/jpeg",
+          "title": "OSM Background",
+          "roles": ["baselayer", "visible"]
+        },
+        {
+          "rel": "xyz",
+          "href": "https://tiles.example.com/{z}/{x}/{y}.png?rescale={{rescale}}&colormap_name={{colormap_name}}",
+          "type": "image/png",
+          "title": "Sentinel-2 NDVI Mosaic",
+          "roles": ["data", "visible"],
+          "eodash:rasterform": {
+            "legend": {
+              "rangeProperty": "colormap_name",
+              "domainProperties": ["vmin", "vmax"]
+            },
+            "jsonform": {
+              "type": "object",
+              "properties": {
+                "colormap_name": {
+                  "type": "string",
+                  "enum": ["viridis", "rdylgn"],
+                  "default": "rdylgn"
+                }
+              }
+            }
+          }
+        }
+      ],
+      "assets": {
+        "thumbnail": {
+          "href": "https://assets.example.com/thumbnails/mosaic.jpg",
+          "type": "image/jpeg",
+          "roles": ["thumbnail"]
+        }
+      }
+    }
+  }
+]

--- a/packages/mcp/generate-metadata.js
+++ b/packages/mcp/generate-metadata.js
@@ -21,6 +21,98 @@ const CATEGORY_MAP = {
   EodashLayoutSwitcher: "Layout & Orchestration",
 };
 
+const TAGS_MAP = {
+  EodashMap: [
+    "map",
+    "visualization",
+    "layers",
+    "openlayers",
+    "geo",
+    "spatial",
+    "globe",
+    "projection",
+  ],
+  EodashLayerControl: [
+    "layer",
+    "layers",
+    "control",
+    "visibility",
+    "opacity",
+    "visualization",
+    "legend",
+  ],
+  EodashItemCatalog: [
+    "catalog",
+    "stac",
+    "items",
+    "discovery",
+    "search",
+    "filter",
+    "collection",
+  ],
+  EodashItemFilter: [
+    "filter",
+    "filtering",
+    "selection",
+    "tag",
+    "theme",
+    "attribute",
+    "search",
+  ],
+  EodashTimeSlider: [
+    "time",
+    "temporal",
+    "slider",
+    "datetime",
+    "navigation",
+    "animation",
+    "range",
+  ],
+  EodashDatePicker: [
+    "time",
+    "temporal",
+    "date",
+    "picker",
+    "datetime",
+    "calendar",
+  ],
+  EodashProcess: [
+    "process",
+    "processing",
+    "analysis",
+    "jsonform",
+    "service",
+    "execution",
+    "wps",
+    "algorithms",
+  ],
+  EodashChart: [
+    "chart",
+    "vega",
+    "graph",
+    "timeseries",
+    "statistics",
+    "analysis",
+    "plot",
+  ],
+  EodashStacInfo: [
+    "info",
+    "stac",
+    "metadata",
+    "citation",
+    "branding",
+    "details",
+  ],
+  EodashTools: ["tools", "layout", "toolbar", "actions", "orchestration"],
+  EodashLayoutSwitcher: [
+    "layout",
+    "template",
+    "switcher",
+    "view",
+    "orchestration",
+  ],
+};
+
 const STAC_EXTENSIONS_MAP = {
   EodashMap: [
     "eox:flatstyle",
@@ -813,6 +905,75 @@ function stringifyType(t) {
   return t.type || "unknown";
 }
 
+function typeToSchema(t) {
+  if (!t) return { type: "unknown" };
+  if (t.type === "intrinsic") {
+    return { type: t.name === "any" ? "unknown" : t.name };
+  }
+  if (t.type === "literal") {
+    return { const: t.value };
+  }
+  if (t.type === "array") {
+    return { type: "array", items: typeToSchema(t.elementType) };
+  }
+  if (t.type === "tuple") {
+    return { type: "array", items: t.elements.map(typeToSchema) };
+  }
+  if (t.type === "union") {
+    return { anyOf: t.types.map(typeToSchema) };
+  }
+  if (t.type === "intersection") {
+    const merged = { type: "object", properties: {} };
+    for (const sub of t.types) {
+      const s = typeToSchema(sub);
+      if (s.properties) {
+        Object.assign(merged.properties, s.properties);
+      }
+    }
+    return Object.keys(merged.properties).length > 0
+      ? merged
+      : { type: "object" };
+  }
+  if (t.type === "reference") {
+    if (t.typeArguments && t.typeArguments.length > 0) {
+      return typeToSchema(t.typeArguments[0]);
+    }
+    return { type: t.name };
+  }
+  if (t.type === "reflection") {
+    if (t.declaration?.children) {
+      const properties = {};
+      const required = [];
+      for (const child of t.declaration.children) {
+        properties[child.name] = {
+          ...typeToSchema(child.type),
+          ...(child.comment?.summary
+            ? {
+                description: child.comment.summary
+                  .map((s) => s.text)
+                  .join("")
+                  .trim(),
+              }
+            : {}),
+        };
+        if (!child.flags?.isOptional) {
+          required.push(child.name);
+        }
+      }
+      return {
+        type: "object",
+        properties,
+        ...(required.length > 0 ? { required } : {}),
+      };
+    }
+    if (t.declaration?.signatures) {
+      return { type: "function" };
+    }
+    return { type: "object" };
+  }
+  return { type: typeof t === "string" ? t : "object" };
+}
+
 function parseTypedocWidgets(repoRoot) {
   const typedocPath = path.join(repoRoot, "dist/typedoc.json");
   if (!fs.existsSync(typedocPath)) {
@@ -828,6 +989,7 @@ function parseTypedocWidgets(repoRoot) {
       const props = (w.children || []).map((p) => ({
         name: p.name,
         type: stringifyType(p.type),
+        schema: typeToSchema(p.type),
         defaultValue: p.defaultValue ?? null,
         description:
           p.comment?.summary
@@ -888,6 +1050,7 @@ export function buildMetadata(repoRoot = DEFAULT_REPO_ROOT) {
     const guide = guides[name] || "";
     const storeInteractions = analyzeStoreInteractions(name, repoRoot);
     const category = CATEGORY_MAP[name] || "General";
+    const tags = TAGS_MAP[name] || [];
     const stacExtensions = STAC_EXTENSIONS_MAP[name] || [];
     const stacCoreFields = STAC_CORE_FIELDS_MAP[name] || [];
     const isBackground = name === "EodashMap";
@@ -927,6 +1090,7 @@ export function buildMetadata(repoRoot = DEFAULT_REPO_ROOT) {
     widgetsMetadata[name] = {
       name,
       category,
+      tags,
       summary,
       isBackground,
       props: props || [],

--- a/packages/mcp/generators/dashboard.js
+++ b/packages/mcp/generators/dashboard.js
@@ -396,9 +396,12 @@ npm run dev
   files["nginx.conf"] = nginxConf;
 
   return {
+    status: "generated_in_memory",
+    filesWrittenToDisk: false,
+    actionRequired: `IMPORTANT: Files are generated in memory and NOT written to disk yet. You MUST iterate over 'files' and write each file to disk under '${name}/' using your file-writing tool.`,
     projectType,
     name,
     files,
-    instructions: `Project '${name}' scaffolded with ${Object.keys(files).length} files. Run 'npm install' and 'npm run ${projectType === "vitepress-narratives" ? "docs:dev" : "dev"}' to start.`,
+    instructions: `Project '${name}' generated with ${Object.keys(files).length} files. Write files to disk, then run 'cd ${name} && npm install && npm run ${projectType === "vitepress-narratives" ? "docs:dev" : "dev"}'.`,
   };
 }

--- a/packages/mcp/generators/examples.js
+++ b/packages/mcp/generators/examples.js
@@ -35,12 +35,17 @@ export function findExamples({
 } = {}) {
   const allExamples = getExamples();
 
+  const normalizedCategory =
+    category === "raster-webgl-flatstyle" || category === "raster-cog"
+      ? "raster-flatstyle"
+      : category;
+
   let results = allExamples.map((ex) => {
     let score = 0;
 
     // Category filter
-    if (category && category !== "all") {
-      if (ex.category === category) {
+    if (normalizedCategory && normalizedCategory !== "all") {
+      if (ex.category === normalizedCategory) {
         score += 50;
       } else {
         return null; // Strict category filter if provided

--- a/packages/mcp/generators/examples.js
+++ b/packages/mcp/generators/examples.js
@@ -1,0 +1,129 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+let cachedExamples = null;
+
+/**
+ * Load examples registry from data/examples.json
+ */
+export function getExamples() {
+  if (cachedExamples) return cachedExamples;
+  const filePath = path.join(__dirname, "../data/examples.json");
+  try {
+    const raw = fs.readFileSync(filePath, "utf8");
+    cachedExamples = JSON.parse(raw);
+    return cachedExamples;
+  } catch (err) {
+    console.error("Failed to load examples registry:", err);
+    return [];
+  }
+}
+
+/**
+ * Search and retrieve curated eodash configuration snippets
+ */
+export function findExamples({
+  query,
+  category,
+  dataType,
+  feature,
+  limit = 5,
+} = {}) {
+  const allExamples = getExamples();
+
+  let results = allExamples.map((ex) => {
+    let score = 0;
+
+    // Category filter
+    if (category && category !== "all") {
+      if (ex.category === category) {
+        score += 50;
+      } else {
+        return null; // Strict category filter if provided
+      }
+    }
+
+    // DataType filter
+    if (dataType && dataType !== "all") {
+      if (ex.dataType === dataType) {
+        score += 30;
+      } else {
+        return null;
+      }
+    }
+
+    // Feature filter
+    if (feature && feature !== "all") {
+      if (ex.features && ex.features.includes(feature)) {
+        score += 30;
+      } else {
+        return null;
+      }
+    }
+
+    // Free text query matching
+    if (query && query.trim()) {
+      const q = query.toLowerCase().trim();
+      const terms = q.split(/\s+/);
+
+      let termMatches = 0;
+      for (const term of terms) {
+        let termFound = false;
+
+        if (ex.title && ex.title.toLowerCase().includes(term)) {
+          score += 25;
+          termFound = true;
+        }
+        if (ex.id && ex.id.toLowerCase().includes(term)) {
+          score += 20;
+          termFound = true;
+        }
+        if (ex.tags && ex.tags.some((t) => t.toLowerCase().includes(term))) {
+          score += 15;
+          termFound = true;
+        }
+        if (
+          ex.features &&
+          ex.features.some((f) => f.toLowerCase().includes(term))
+        ) {
+          score += 15;
+          termFound = true;
+        }
+        if (ex.description && ex.description.toLowerCase().includes(term)) {
+          score += 10;
+          termFound = true;
+        }
+
+        if (termFound) termMatches++;
+      }
+
+      // If text query provided, must match at least one term
+      if (termMatches === 0 && score === 0) {
+        return null;
+      }
+      score += termMatches * 10;
+    } else {
+      // Default base score when no text query
+      score += 10;
+    }
+
+    return { example: ex, score };
+  });
+
+  results = results
+    .filter((r) => r !== null)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, Math.min(20, Math.max(1, limit)))
+    .map((r) => r.example);
+
+  return {
+    totalFound: results.length,
+    query: query || null,
+    category: category || "all",
+    results,
+  };
+}

--- a/packages/mcp/generators/style.js
+++ b/packages/mcp/generators/style.js
@@ -1,0 +1,846 @@
+/**
+ * OpenLayers FlatStyle & eodash:rasterform Generator
+ *
+ * Generates valid styling definitions for:
+ * 1. OpenLayers Vector FlatStyle (ol/style/flat & ol/style/expressions) for vector & vector tile layers
+ * 2. OpenLayers WebGLTile FlatStyle for GeoTIFF / Cloud Optimized GeoTIFF (COG)
+ * 3. eodash:rasterform schemas for TiTiler / WMS / custom XYZ layers
+ *
+ * Includes STAC Item snippets, eodash_catalog collection snippets, and best practices.
+ */
+
+export const COLORMAPS_URL =
+  "https://raw.githubusercontent.com/eurodatacube/eodash-assets/refs/heads/main/defaults/colormaps.json";
+
+/**
+ * Fallback palettes for offline execution or tests
+ */
+export const FALLBACK_PALETTES = {
+  viridis: [
+    "#440154",
+    "#482878",
+    "#3e4a89",
+    "#31688e",
+    "#26828e",
+    "#1f9e89",
+    "#35b779",
+    "#6ece58",
+    "#b5de2b",
+    "#fde725",
+  ],
+  magma: [
+    "#000004",
+    "#180f3d",
+    "#440f76",
+    "#721f81",
+    "#9e2f7f",
+    "#cd4071",
+    "#f1605d",
+    "#fd9668",
+    "#feca8d",
+    "#fcfdbf",
+  ],
+  plasma: [
+    "#0d0887",
+    "#46039f",
+    "#7201a8",
+    "#9c179e",
+    "#bd3786",
+    "#d8576b",
+    "#ed7953",
+    "#fb9f3a",
+    "#fdca26",
+    "#f0f921",
+  ],
+};
+
+/** @type {Record<string, string[]> | null} */
+let cachedColormaps = null;
+
+/**
+ * Fetch full colormaps list from GitHub or fallback
+ * @returns {Promise<Record<string, string[]>>}
+ */
+export async function fetchColormaps() {
+  if (cachedColormaps) return cachedColormaps;
+  try {
+    const res = await fetch(COLORMAPS_URL);
+    if (res.ok) {
+      cachedColormaps = await res.json();
+      return cachedColormaps;
+    }
+  } catch {
+    // Network fallback
+  }
+  return FALLBACK_PALETTES;
+}
+
+/**
+ * Backward compatibility alias for PALETTES
+ */
+export const PALETTES = FALLBACK_PALETTES;
+
+/**
+ * Get color ramp array for a colormap name
+ * @param {string} name
+ * @returns {Promise<string[]>}
+ */
+export async function getColormapRamp(name) {
+  const maps = await fetchColormaps();
+  if (maps && maps[name]) {
+    return maps[name];
+  }
+  return FALLBACK_PALETTES[name] || FALLBACK_PALETTES.viridis;
+}
+
+/**
+ * Generate OpenLayers Vector FlatStyle for vector & vector tile layers
+ */
+export function generateVectorFlatStyle({
+  geometryType = "polygon",
+  mode = "single",
+  attribute = "value",
+  colormap = "viridis",
+  colors = [],
+  categories = [],
+  range = [0, 100],
+  min,
+  max,
+  vmin,
+  vmax,
+  fillColor = "rgba(0, 113, 194, 0.6)",
+  strokeColor = "#ffffff",
+  strokeWidth = 1.5,
+  pointRadius = 6,
+  tooltipFields = [],
+  interactiveSliders = false,
+} = {}) {
+  const isPoint = geometryType === "point";
+  const isLine = geometryType === "line";
+
+  /** @type {Record<string, any>} */
+  const style = {};
+  /** @type {Record<string, any>} */
+  const variables = {};
+  /** @type {Record<string, any>} */
+  let jsonform = null;
+  /** @type {any} */
+  let legend = null;
+
+  if (interactiveSliders) {
+    variables.strokeWidth = strokeWidth;
+
+    jsonform = {
+      type: "object",
+      title: "Layer Style Configuration",
+      properties: {
+        strokeWidth: {
+          type: "number",
+          title: "Stroke Width",
+          minimum: 0,
+          maximum: 10,
+          step: 0.5,
+          default: strokeWidth,
+          format: "range",
+        },
+      },
+    };
+  }
+
+  // 1. Single Mode
+  if (mode === "single") {
+    if (isPoint) {
+      style["circle-radius"] = pointRadius;
+      style["circle-fill-color"] = fillColor;
+      style["circle-stroke-color"] = strokeColor;
+      style["circle-stroke-width"] = interactiveSliders
+        ? ["var", "strokeWidth"]
+        : strokeWidth;
+    } else if (isLine) {
+      style["stroke-color"] = strokeColor || fillColor;
+      style["stroke-width"] = interactiveSliders
+        ? ["var", "strokeWidth"]
+        : strokeWidth;
+    } else {
+      // Polygon
+      style["fill-color"] = fillColor;
+      style["stroke-color"] = strokeColor;
+      style["stroke-width"] = interactiveSliders
+        ? ["var", "strokeWidth"]
+        : strokeWidth;
+    }
+
+    legend = {
+      domain: ["Feature"],
+      range: [fillColor || strokeColor],
+      scaleType: "categorical",
+    };
+  }
+
+  // 2. Categorical Match Mode
+  if (mode === "categorical") {
+    const cats =
+      categories.length > 0
+        ? categories
+        : [
+            { value: "A", label: "Category A", color: "#1f77b4" },
+            { value: "B", label: "Category B", color: "#ff7f0e" },
+            { value: "C", label: "Category C", color: "#2ca02c" },
+          ];
+
+    const matchExpression = ["match", ["get", attribute]];
+    for (const cat of cats) {
+      matchExpression.push(cat.value, cat.color);
+    }
+    matchExpression.push("rgba(128, 128, 128, 0.5)"); // Fallback color
+
+    if (isPoint) {
+      style["circle-radius"] = pointRadius;
+      style["circle-fill-color"] = matchExpression;
+      style["circle-stroke-color"] = strokeColor;
+      style["circle-stroke-width"] = interactiveSliders
+        ? ["var", "strokeWidth"]
+        : strokeWidth;
+    } else if (isLine) {
+      style["stroke-color"] = matchExpression;
+      style["stroke-width"] = interactiveSliders
+        ? ["var", "strokeWidth"]
+        : strokeWidth;
+    } else {
+      style["fill-color"] = matchExpression;
+      style["stroke-color"] = strokeColor;
+      style["stroke-width"] = interactiveSliders
+        ? ["var", "strokeWidth"]
+        : strokeWidth;
+    }
+
+    legend = {
+      domain: cats.map((c) => c.label || String(c.value)),
+      range: cats.map((c) => c.color),
+      scaleType: "categorical",
+    };
+  }
+
+  // 3. Graduated Mode (Linear Interpolation)
+  if (mode === "graduated") {
+    let palette = colors;
+    if (!palette || palette.length <= 1) {
+      palette =
+        cachedColormaps?.[colormap] ||
+        FALLBACK_PALETTES[colormap] ||
+        FALLBACK_PALETTES.viridis;
+    }
+    const effectiveRange =
+      range && range.length === 2
+        ? range
+        : [vmin ?? min ?? 0, vmax ?? max ?? 100];
+    const [minVal, maxVal] = effectiveRange;
+    const step = (maxVal - minVal) / (palette.length - 1);
+
+    const interpolateExpression = [
+      "interpolate",
+      ["linear"],
+      ["get", attribute],
+    ];
+    for (let i = 0; i < palette.length; i++) {
+      const val = minVal + step * i;
+      interpolateExpression.push(Number(val.toFixed(2)), palette[i]);
+    }
+
+    if (isPoint) {
+      style["circle-radius"] = pointRadius;
+      style["circle-fill-color"] = interpolateExpression;
+      style["circle-stroke-color"] = strokeColor;
+      style["circle-stroke-width"] = interactiveSliders
+        ? ["var", "strokeWidth"]
+        : strokeWidth;
+    } else if (isLine) {
+      style["stroke-color"] = interpolateExpression;
+      style["stroke-width"] = interactiveSliders
+        ? ["var", "strokeWidth"]
+        : strokeWidth;
+    } else {
+      style["fill-color"] = interpolateExpression;
+      style["stroke-color"] = strokeColor;
+      style["stroke-width"] = interactiveSliders
+        ? ["var", "strokeWidth"]
+        : strokeWidth;
+    }
+
+    legend = {
+      domain: [minVal, maxVal],
+      range: palette,
+      scaleType: "continuous",
+    };
+  }
+
+  // Attach tooltips if configured
+  if (tooltipFields && tooltipFields.length > 0) {
+    style.tooltip = tooltipFields.map((f) => {
+      const item = { id: f.id };
+      if (f.title) item.title = f.title;
+      if (f.appendix) item.appendix = f.appendix;
+      if (typeof f.decimals === "number") item.decimals = f.decimals;
+      return item;
+    });
+  }
+
+  if (Object.keys(variables).length > 0) {
+    style.variables = variables;
+  }
+  if (jsonform) {
+    style.jsonform = jsonform;
+  }
+  if (legend) {
+    style.legend = legend;
+  }
+
+  return style;
+}
+
+/**
+ * Generate OpenLayers WebGLTile FlatStyle for GeoTIFF / COG layers
+ */
+export async function generateRasterWebglStyle({
+  mode = "single-band-normalized",
+  bands = [1],
+  bandIndex,
+  redBand,
+  greenBand,
+  blueBand,
+  range,
+  vmin,
+  vmax,
+  min,
+  max,
+  sliderMin,
+  sliderMax,
+  defaultMin,
+  defaultMax,
+  colorMap,
+  colormap,
+  customColors,
+  interactiveMinMax = true,
+} = {}) {
+  const effectiveColormap = colormap || colorMap || "viridis";
+  const palette = customColors || (await getColormapRamp(effectiveColormap));
+  const style = {};
+
+  const effectiveDefaultMin = defaultMin ?? range?.[0] ?? vmin ?? min ?? 0;
+  const effectiveDefaultMax = defaultMax ?? range?.[1] ?? vmax ?? max ?? 250;
+
+  const effectiveSliderMin =
+    sliderMin ??
+    (min !== undefined && vmin !== undefined && min < vmin
+      ? min
+      : effectiveDefaultMin < 0
+        ? Math.round(effectiveDefaultMin * 1.5)
+        : effectiveDefaultMin === 0
+          ? 0
+          : Math.round(effectiveDefaultMin * 0.5));
+
+  const effectiveSliderMax =
+    sliderMax ??
+    (max !== undefined && vmax !== undefined && max > vmax
+      ? max
+      : effectiveDefaultMax > 0
+        ? Math.round(effectiveDefaultMax * 1.5)
+        : effectiveDefaultMax === 0
+          ? 100
+          : Math.round(effectiveDefaultMax * 0.5));
+
+  const effectiveMode =
+    mode === "single-band" || mode === "single"
+      ? "single-band-normalized"
+      : mode === "rgb"
+        ? "rgb-composite"
+        : mode;
+
+  // 1. Single Band Normalized mode
+  if (effectiveMode === "single-band-normalized") {
+    const bandIdx = bandIndex ?? bands[0] ?? 1;
+
+    if (interactiveMinMax) {
+      style.variables = {
+        vmin: effectiveDefaultMin,
+        vmax: effectiveDefaultMax,
+      };
+
+      const normalizedExpression = [
+        "/",
+        ["-", ["band", bandIdx], ["var", "vmin"]],
+        ["-", ["var", "vmax"], ["var", "vmin"]],
+      ];
+
+      const interpolateStops = [
+        "interpolate",
+        ["linear"],
+        normalizedExpression,
+      ];
+      const step = 1.0 / (palette.length - 1);
+      for (let i = 0; i < palette.length; i++) {
+        interpolateStops.push(Number((step * i).toFixed(4)), palette[i]);
+      }
+
+      style.color = [
+        "case",
+        ["==", ["band", bandIdx], 0],
+        [0, 0, 0, 0], // Transparent nodata
+        interpolateStops,
+      ];
+
+      style.legend = {
+        domainProperties: ["vmin", "vmax"],
+        range: palette,
+        scaleType: "continuous",
+      };
+
+      style.jsonform = {
+        type: "object",
+        title: "Layer Data Settings",
+        properties: {
+          vminmax: {
+            title: "Value Range",
+            type: "object",
+            properties: {
+              vmin: {
+                type: "number",
+                minimum: effectiveSliderMin,
+                maximum: effectiveSliderMax,
+                default: effectiveDefaultMin,
+                format: "range",
+              },
+              vmax: {
+                type: "number",
+                minimum: effectiveSliderMin,
+                maximum: effectiveSliderMax,
+                default: effectiveDefaultMax,
+                format: "range",
+              },
+            },
+            format: "minmax",
+          },
+        },
+      };
+    } else {
+      const normalizedExpression = [
+        "/",
+        ["-", ["band", bandIdx], effectiveDefaultMin],
+        effectiveDefaultMax - effectiveDefaultMin,
+      ];
+
+      const interpolateStops = [
+        "interpolate",
+        ["linear"],
+        normalizedExpression,
+      ];
+      const step = 1.0 / (palette.length - 1);
+      for (let i = 0; i < palette.length; i++) {
+        interpolateStops.push(Number((step * i).toFixed(4)), palette[i]);
+      }
+
+      style.color = [
+        "case",
+        ["==", ["band", bandIdx], 0],
+        [0, 0, 0, 0],
+        interpolateStops,
+      ];
+
+      style.legend = {
+        domain: [effectiveDefaultMin, effectiveDefaultMax],
+        range: palette,
+        scaleType: "continuous",
+      };
+    }
+  }
+
+  // 2. RGB Composite mode
+  if (effectiveMode === "rgb-composite") {
+    const rBand = redBand ?? bands[0] ?? 1;
+    const gBand = greenBand ?? bands[1] ?? 2;
+    const bBand = blueBand ?? bands[2] ?? 3;
+    const divisor = effectiveDefaultMax || 255;
+
+    style.variables = {
+      bandDivisor: divisor,
+    };
+
+    style.color = [
+      "case",
+      ["==", ["band", rBand], 0],
+      [0, 0, 0, 0],
+      [
+        "array",
+        ["/", ["band", rBand], ["var", "bandDivisor"]],
+        ["/", ["band", gBand], ["var", "bandDivisor"]],
+        ["/", ["band", bBand], ["var", "bandDivisor"]],
+        1,
+      ],
+    ];
+
+    style.jsonform = {
+      type: "object",
+      title: "RGB Scaling Settings",
+      properties: {
+        bandDivisor: {
+          type: "number",
+          title: "Band Divisor (Brightness)",
+          minimum: 1,
+          maximum: 10000,
+          default: divisor,
+          format: "range",
+        },
+      },
+    };
+  }
+
+  // 3. Band Ratio Index mode (e.g. NDVI, NDWI)
+  if (mode === "band-ratio-index") {
+    const nirBand = bands[0] || 8;
+    const redBand = bands[1] || 4;
+
+    const diff = ["-", ["band", nirBand], ["band", redBand]];
+    const sum = ["+", ["band", nirBand], ["band", redBand]];
+    const indexExpr = ["/", diff, sum];
+
+    const interpolateStops = ["interpolate", ["linear"], indexExpr];
+    const minVal = -1.0;
+    const maxVal = 1.0;
+    const step = (maxVal - minVal) / (palette.length - 1);
+    for (let i = 0; i < palette.length; i++) {
+      interpolateStops.push(Number((minVal + step * i).toFixed(2)), palette[i]);
+    }
+
+    style.color = ["case", ["==", sum, 0], [0, 0, 0, 0], interpolateStops];
+
+    style.legend = {
+      domain: [-1, 1],
+      range: palette,
+      scaleType: "continuous",
+    };
+  }
+
+  return style;
+}
+
+/**
+ * Generate eodash:rasterform for TiTiler / WMS / XYZ layers
+ */
+export function generateRasterForm({
+  _serviceType = "titiler",
+  colormaps = [
+    "viridis",
+    "magma",
+    "plasma",
+    "inferno",
+    "cividis",
+    "spectral",
+    "rainbow",
+    "turbo",
+  ],
+  colormapOptions,
+  defaultColormap = "viridis",
+  vmin,
+  vmax,
+  min,
+  max,
+  sliderMin,
+  sliderMax,
+  defaultMin,
+  defaultMax,
+  hasRescale = true,
+  hasMultiAssetBranching = false,
+  assets = [],
+} = {}) {
+  const effectiveColormaps = colormapOptions || colormaps;
+  const effectiveDefaultMin = defaultMin ?? vmin ?? min ?? 0;
+  const effectiveDefaultMax = defaultMax ?? vmax ?? max ?? 250;
+
+  const effectiveSliderMin =
+    sliderMin ??
+    (min !== undefined && vmin !== undefined && min < vmin
+      ? min
+      : effectiveDefaultMin < 0
+        ? Math.round(effectiveDefaultMin * 1.5)
+        : effectiveDefaultMin === 0
+          ? 0
+          : Math.round(effectiveDefaultMin * 0.5));
+
+  const effectiveSliderMax =
+    sliderMax ??
+    (max !== undefined && vmax !== undefined && max > vmax
+      ? max
+      : effectiveDefaultMax > 0
+        ? Math.round(effectiveDefaultMax * 1.5)
+        : effectiveDefaultMax === 0
+          ? 100
+          : Math.round(effectiveDefaultMax * 0.5));
+
+  /** @type {Record<string, any>} */
+  const rasterform = {
+    type: "rasterform",
+    legend: {
+      rangeProperty: "colormap_name",
+      domainProperties: ["vmin", "vmax"],
+    },
+  };
+
+  if (hasMultiAssetBranching && assets && assets.length > 0) {
+    // Multi-asset branching form with keep_oneof_values: false
+    rasterform.jsonform = {
+      type: "object",
+      title: "Data Visualization Form",
+      options: {
+        keep_oneof_values: false,
+        removeProperties: ["vminmax"],
+      },
+      oneOf: assets.map((asset) => {
+        const assetDefaultMin = asset.defaultVmin ?? effectiveDefaultMin;
+        const assetDefaultMax = asset.defaultVmax ?? effectiveDefaultMax;
+        const assetSliderMin =
+          asset.sliderMin ??
+          (assetDefaultMin < 0
+            ? Math.round(assetDefaultMin * 1.5)
+            : assetDefaultMin === 0
+              ? 0
+              : Math.round(assetDefaultMin * 0.5));
+        const assetSliderMax =
+          asset.sliderMax ??
+          (assetDefaultMax > 0
+            ? Math.round(assetDefaultMax * 1.5)
+            : assetDefaultMax === 0
+              ? 100
+              : Math.round(assetDefaultMax * 0.5));
+
+        return {
+          type: "object",
+          title: asset.title || asset.id,
+          properties: {
+            assets: {
+              type: "string",
+              options: { hidden: true },
+              default: asset.id,
+            },
+            colormap_name: {
+              title: "Color Map",
+              type: "string",
+              enum: effectiveColormaps,
+              default: defaultColormap,
+            },
+            vminmax: {
+              title: "Value Range",
+              type: "object",
+              properties: {
+                vmin: {
+                  type: "number",
+                  minimum: assetSliderMin,
+                  maximum: assetSliderMax,
+                  default: assetDefaultMin,
+                  format: "range",
+                },
+                vmax: {
+                  type: "number",
+                  minimum: assetSliderMin,
+                  maximum: assetSliderMax,
+                  default: assetDefaultMax,
+                  format: "range",
+                },
+              },
+              format: "minmax",
+            },
+            rescale: {
+              type: "string",
+              template: "{{vminmax.vmin}},{{vminmax.vmax}}",
+              watch: { vminmax: "vminmax" },
+              options: { hidden: true },
+            },
+          },
+        };
+      }),
+    };
+  } else {
+    // Single asset TiTiler / WMS form
+    const properties = {};
+
+    if (effectiveColormaps && effectiveColormaps.length > 0) {
+      properties.colormap_name = {
+        title: "Color Map",
+        type: "string",
+        enum: effectiveColormaps,
+        default: defaultColormap,
+      };
+    }
+
+    if (hasRescale) {
+      properties.vminmax = {
+        title: "Value Range",
+        type: "object",
+        properties: {
+          vmin: {
+            type: "number",
+            minimum: effectiveSliderMin,
+            maximum: effectiveSliderMax,
+            default: effectiveDefaultMin,
+            format: "range",
+          },
+          vmax: {
+            type: "number",
+            minimum: effectiveSliderMin,
+            maximum: effectiveSliderMax,
+            default: effectiveDefaultMax,
+            format: "range",
+          },
+        },
+        format: "minmax",
+      };
+
+      properties.rescale = {
+        type: "string",
+        template: "{{vminmax.vmin}},{{vminmax.vmax}}",
+        watch: { vminmax: "vminmax" },
+        options: { hidden: true },
+      };
+    }
+
+    rasterform.jsonform = {
+      type: "object",
+      title: "Data Visualization Form",
+      options: {
+        removeProperties: ["vminmax"],
+      },
+      properties,
+    };
+  }
+
+  return rasterform;
+}
+
+/**
+ * Main generate_layer_style router and snippet formatter
+ */
+export async function generateLayerStyle({
+  styleType,
+  vectorConfig = {},
+  rasterWebglConfig = {},
+  rasterConfig,
+  rasterformConfig = {},
+  rasterFormConfig,
+} = {}) {
+  let resultStyle;
+  let summary = "";
+  let stacItemSnippet = {};
+  let catalogCollectionSnippet = {};
+  const rulesAndBestPractices = [];
+
+  const effectiveRasterWebglConfig = rasterConfig || rasterWebglConfig;
+  const effectiveRasterFormConfig = rasterFormConfig || rasterformConfig;
+
+  if (styleType === "vector-flatstyle") {
+    if (vectorConfig.colormap && !cachedColormaps) {
+      await fetchColormaps();
+    }
+    resultStyle = generateVectorFlatStyle(vectorConfig);
+    summary = `Generated OpenLayers Vector FlatStyle for ${vectorConfig.geometryType || "polygon"} (${vectorConfig.mode || "single"} mode).`;
+
+    rulesAndBestPractices.push(
+      "Style and eox:flatstyle MUST be URL strings in STAC items and catalog collections. Host the style JSON file on your assets server.",
+      "OpenLayers flat styles support vector layers (GeoJSON, FlatGeobuf) and vector tile layers (MVT).",
+      "Dynamic style variables (e.g. ['var', 'strokeWidth']) are reactive when paired with a matching jsonform schema in the style.",
+      "OpenLayers Flat Style Specification: https://openlayers.org/en/latest/apidoc/module-ol_style_flat.html",
+      "OpenLayers Style Expressions Reference: https://openlayers.org/en/latest/apidoc/module-ol_style_expressions.html",
+    );
+
+    stacItemSnippet = {
+      rel: "data",
+      href: "https://example.com/data.geojson",
+      type: "application/geo+json",
+      "eox:flatstyle": "https://assets.example.com/styles/vector_style.json",
+      roles: ["data", "visible"],
+    };
+
+    catalogCollectionSnippet = {
+      Name: "vector_collection_resource",
+      Style: "https://assets.example.com/styles/vector_style.json",
+      Resources: [
+        {
+          Name: "GeoJSON Vector Resource",
+          Style: "https://assets.example.com/styles/vector_style.json",
+        },
+      ],
+    };
+  } else if (styleType === "raster-webgl-flatstyle") {
+    resultStyle = await generateRasterWebglStyle(effectiveRasterWebglConfig);
+    summary = `Generated OpenLayers WebGLTile FlatStyle for COG / GeoTIFF (${effectiveRasterWebglConfig.mode || "single-band-normalized"}).`;
+
+    rulesAndBestPractices.push(
+      "The 'color' expression (case + interpolate shader) is mandatory for raster rendering. When adding or modifying 'jsonform' sliders, never omit the 'color' property.",
+      "WebGL FlatStyles run in client-side GPU shaders using OpenLayers style expressions (['band', index], ['var', name], ['interpolate', ...]).",
+      "Style and eox:flatstyle MUST be URL strings referencing the hosted style JSON file.",
+      "The legend.domainProperties array connects slider min/max variables directly to the legend scale.",
+      "Colormaps can use any preset from https://raw.githubusercontent.com/eurodatacube/eodash-assets/refs/heads/main/defaults/colormaps.json",
+      "OpenLayers Raster Expressions & WebGL Shaders: https://openlayers.org/en/latest/apidoc/module-ol_style_expressions.html",
+      "OpenLayers WebGLTile Layer API: https://openlayers.org/en/latest/apidoc/module-ol_layer_WebGLTile-WebGLTileLayer.html",
+    );
+
+    stacItemSnippet = {
+      rel: "data",
+      href: "https://example.com/cog.tif",
+      type: "image/tiff",
+      "eox:flatstyle": "https://assets.example.com/styles/cog_style.json",
+      roles: ["data", "visible"],
+    };
+
+    catalogCollectionSnippet = {
+      Name: "cog_collection_resource",
+      Resources: [
+        {
+          Name: "COG Resource",
+          Style: "https://assets.example.com/styles/cog_style.json",
+          EndPoint: "https://example.com/cog.tif",
+        },
+      ],
+    };
+  } else if (styleType === "rasterform") {
+    resultStyle = generateRasterForm(effectiveRasterFormConfig);
+    summary = `Generated eodash:rasterform for ${effectiveRasterFormConfig.serviceType || "titiler"} layer.`;
+
+    rulesAndBestPractices.push(
+      "The eodash:rasterform property is a hybrid and supports BOTH direct JSON objects and URL strings.",
+      "When using branching forms (oneOf / anyOf) with differing properties, always set 'keep_oneof_values': false in options.",
+      "Use 'removeProperties': ['vminmax'] in options so intermediate slider values do not pollute tile URL query strings.",
+      "eodash STAC & Processing Guidelines: https://eodash.github.io/eodash/",
+      "JSON-Editor Schema Documentation: https://github.com/json-editor/json-editor",
+    );
+
+    stacItemSnippet = {
+      rel: "data",
+      href: "https://example.com/titiler/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=https://example.com/cog.tif&colormap_name={colormap_name}&rescale={rescale}",
+      type: "image/png",
+      "eodash:rasterform": resultStyle,
+      roles: ["data", "visible"],
+    };
+
+    catalogCollectionSnippet = {
+      Name: "titiler_collection_resource",
+      Resources: [
+        {
+          Name: "TiTiler Dynamic Resource",
+          EndPoint:
+            "https://example.com/titiler/tiles/WebMercatorQuad/{z}/{x}/{y}@1x?url=https://example.com/cog.tif&colormap_name={colormap_name}&rescale={rescale}",
+          Rasterform: resultStyle,
+        },
+      ],
+    };
+  }
+
+  return {
+    styleType,
+    style: resultStyle,
+    stacItemSnippet,
+    catalogCollectionSnippet,
+    summary,
+    notice:
+      "All top-level style properties (e.g. 'color', 'fill-color', 'stroke-color', 'variables', 'legend', 'jsonform') form a complete style definition. When adding sliders or editing properties, always output the full JSON with all style properties preserved.",
+    rulesAndBestPractices,
+  };
+}

--- a/packages/mcp/generators/style.js
+++ b/packages/mcp/generators/style.js
@@ -299,9 +299,9 @@ export function generateVectorFlatStyle({
 }
 
 /**
- * Generate OpenLayers WebGLTile FlatStyle for GeoTIFF / COG layers
+ * Generate OpenLayers Raster FlatStyle for GeoTIFF / COG layers
  */
-export async function generateRasterWebglStyle({
+export async function generateRasterFlatStyle({
   mode = "single-band-normalized",
   bands = [1],
   bandIndex,
@@ -522,6 +522,9 @@ export async function generateRasterWebglStyle({
 
   return style;
 }
+
+/** Alias for generateRasterFlatStyle */
+export const generateRasterWebglStyle = generateRasterFlatStyle;
 
 /**
  * Generate eodash:rasterform for TiTiler / WMS / XYZ layers
@@ -744,6 +747,7 @@ export async function generateLayerStyle({
 
     rulesAndBestPractices.push(
       "Style and eox:flatstyle MUST be URL strings in STAC items and catalog collections. Host the style JSON file on your assets server.",
+      "In eodash catalog configs use 'Style' on Collection or 'Resources[].Style'. Note: 'Flatstyle' does NOT exist on Resources (it is only used under Process execution definitions).",
       "OpenLayers flat styles support vector layers (GeoJSON, FlatGeobuf) and vector tile layers (MVT).",
       "Dynamic style variables (e.g. ['var', 'strokeWidth']) are reactive when paired with a matching jsonform schema in the style.",
       "OpenLayers Flat Style Specification: https://openlayers.org/en/latest/apidoc/module-ol_style_flat.html",
@@ -768,18 +772,22 @@ export async function generateLayerStyle({
         },
       ],
     };
-  } else if (styleType === "raster-webgl-flatstyle") {
-    resultStyle = await generateRasterWebglStyle(effectiveRasterWebglConfig);
-    summary = `Generated OpenLayers WebGLTile FlatStyle for COG / GeoTIFF (${effectiveRasterWebglConfig.mode || "single-band-normalized"}).`;
+  } else if (
+    styleType === "raster-flatstyle" ||
+    styleType === "raster-webgl-flatstyle" ||
+    styleType === "raster-cog"
+  ) {
+    resultStyle = await generateRasterFlatStyle(effectiveRasterWebglConfig);
+    summary = `Generated OpenLayers Raster FlatStyle for COG / GeoTIFF (${effectiveRasterWebglConfig.mode || "single-band-normalized"}).`;
 
     rulesAndBestPractices.push(
-      "The 'color' expression (case + interpolate shader) is mandatory for raster rendering. When adding or modifying 'jsonform' sliders, never omit the 'color' property.",
-      "WebGL FlatStyles run in client-side GPU shaders using OpenLayers style expressions (['band', index], ['var', name], ['interpolate', ...]).",
-      "Style and eox:flatstyle MUST be URL strings referencing the hosted style JSON file.",
+      "The 'color' expression (case + interpolate) is mandatory for raster rendering. When adding or modifying 'jsonform' sliders, never omit the 'color' property.",
+      "Raster FlatStyles run client-side for COG/GeoTIFF rendering using OpenLayers style expressions (['band', index], ['var', name], ['interpolate', ...]).",
+      "Style and eox:flatstyle MUST be URL strings referencing the hosted style JSON file. In catalog configs use 'Style' or 'Resources[].Style' ('Flatstyle' only exists under Process outputs).",
       "The legend.domainProperties array connects slider min/max variables directly to the legend scale.",
       "Colormaps can use any preset from https://raw.githubusercontent.com/eurodatacube/eodash-assets/refs/heads/main/defaults/colormaps.json",
-      "OpenLayers Raster Expressions & WebGL Shaders: https://openlayers.org/en/latest/apidoc/module-ol_style_expressions.html",
-      "OpenLayers WebGLTile Layer API: https://openlayers.org/en/latest/apidoc/module-ol_layer_WebGLTile-WebGLTileLayer.html",
+      "OpenLayers Raster Expressions: https://openlayers.org/en/latest/apidoc/module-ol_style_expressions.html",
+      "OpenLayers Flat Style Specification: https://openlayers.org/en/latest/apidoc/module-ol_style_flat.html",
     );
 
     stacItemSnippet = {

--- a/packages/mcp/generators/validator.js
+++ b/packages/mcp/generators/validator.js
@@ -1,0 +1,270 @@
+import Ajv from "ajv";
+import addFormats from "ajv-formats";
+
+export const COLLECTION_SCHEMA_URL =
+  "https://eodash.github.io/eodash-schemas/catalog/collection-schema.json";
+export const INDICATOR_SCHEMA_URL =
+  "https://eodash.github.io/eodash-schemas/catalog/indicator-schema.json";
+
+let cachedValidators = null;
+
+/**
+ * Configure an Ajv instance with standard formats and custom eodash schema formats
+ */
+export function createAjvInstance() {
+  const ajv = new Ajv({
+    allErrors: true,
+    strict: false,
+    verbose: true,
+  });
+
+  addFormats(ajv);
+
+  // Custom formats used in eodash-schemas
+  ajv.addFormat("categories", true);
+  ajv.addFormat("markdown", true);
+  ajv.addFormat("datetime", {
+    type: "string",
+    validate: (dateTime) => {
+      if (typeof dateTime !== "string") return false;
+      const d = new Date(dateTime);
+      return !isNaN(d.getTime());
+    },
+  });
+  ajv.addFormat("bounding-box", {
+    type: "array",
+    validate: (bbox) => {
+      return (
+        Array.isArray(bbox) &&
+        bbox.length === 4 &&
+        bbox.every((n) => typeof n === "number")
+      );
+    },
+  });
+  ajv.addFormat("point", {
+    type: "array",
+    validate: (pt) => {
+      return (
+        Array.isArray(pt) &&
+        pt.length === 2 &&
+        pt.every((n) => typeof n === "number")
+      );
+    },
+  });
+
+  return ajv;
+}
+
+/**
+ * Fetch remote schemas from eodash-schemas GitHub Pages
+ */
+export async function loadSchemas() {
+  try {
+    const [colSchema, indSchema] = await Promise.all([
+      fetch(COLLECTION_SCHEMA_URL).then((r) => r.json()),
+      fetch(INDICATOR_SCHEMA_URL).then((r) => r.json()),
+    ]);
+
+    return { colSchema, indSchema };
+  } catch (_err) {
+    // Return minimal fallback schemas if network is unreachable
+    const colSchema = {
+      $id: COLLECTION_SCHEMA_URL,
+      type: "object",
+      properties: {
+        Name: { type: "string" },
+        Title: { type: "string" },
+        Description: { type: "string" },
+        Resources: { type: "array", minItems: 1 },
+      },
+      required: ["Name", "Title", "Description", "Resources"],
+    };
+    const indSchema = {
+      $id: INDICATOR_SCHEMA_URL,
+      type: "object",
+      properties: {
+        Name: { type: "string" },
+        Title: { type: "string" },
+        Description: { type: "string" },
+        Collections: { type: "array", minItems: 1 },
+      },
+      required: ["Name", "Title", "Description", "Collections"],
+    };
+    return { colSchema, indSchema };
+  }
+}
+
+/**
+ * Initialize or get cached compiled validators
+ */
+export async function getValidators() {
+  if (cachedValidators) {
+    return cachedValidators;
+  }
+
+  const ajv = createAjvInstance();
+  const { colSchema, indSchema } = await loadSchemas();
+
+  const validateCollection = ajv.compile(colSchema);
+  const validateIndicator = ajv.compile(indSchema);
+
+  cachedValidators = {
+    ajv,
+    validateCollection,
+    validateIndicator,
+  };
+
+  return cachedValidators;
+}
+
+/**
+ * Validate a catalog configuration (collection or indicator) against official schemas and business rules
+ *
+ * @param {object} options
+ * @param {string|object} options.config - Catalog configuration JSON string or object
+ * @param {'collection'|'indicator'|'auto'} [options.configType='auto'] - Type of config to validate
+ * @returns {Promise<{
+ *   valid: boolean,
+ *   configType: string,
+ *   schemaUrl: string,
+ *   errors: Array<{ path: string, message: string, params?: any, suggestion?: string }>,
+ *   warnings: string[],
+ *   summary: string
+ * }>}
+ */
+export async function validateCatalogConfig({
+  config,
+  configType = "auto",
+} = {}) {
+  let parsed = config;
+  if (typeof config === "string") {
+    try {
+      parsed = JSON.parse(config);
+    } catch (err) {
+      return {
+        valid: false,
+        configType: "unknown",
+        schemaUrl: "",
+        errors: [
+          {
+            path: "/",
+            message: `JSON Parse error: ${err.message}`,
+            suggestion: "Ensure configuration is valid JSON.",
+          },
+        ],
+        warnings: [],
+        summary: `Validation failed: Invalid JSON syntax.`,
+      };
+    }
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return {
+      valid: false,
+      configType: "unknown",
+      schemaUrl: "",
+      errors: [
+        {
+          path: "/",
+          message: "Configuration must be a JSON object.",
+        },
+      ],
+      warnings: [],
+      summary: "Validation failed: Root configuration must be an object.",
+    };
+  }
+
+  // Auto-detect config type
+  let resolvedType = configType;
+  if (resolvedType === "auto") {
+    if (Array.isArray(parsed.Collections)) {
+      resolvedType = "indicator";
+    } else if (Array.isArray(parsed.Resources)) {
+      resolvedType = "collection";
+    } else {
+      resolvedType = "collection"; // default assumption
+    }
+  }
+
+  const { validateCollection, validateIndicator } = await getValidators();
+
+  const isIndicator = resolvedType === "indicator";
+  const validator = isIndicator ? validateIndicator : validateCollection;
+  const schemaUrl = isIndicator ? INDICATOR_SCHEMA_URL : COLLECTION_SCHEMA_URL;
+
+  const valid = validator(parsed);
+  const errors = [];
+  const warnings = [];
+
+  if (!valid && validator.errors) {
+    for (const err of validator.errors) {
+      const errPath = err.instancePath || "/";
+      let suggestion = "";
+
+      if (err.keyword === "required") {
+        suggestion = `Add missing required property '${err.params.missingProperty}'.`;
+      } else if (err.keyword === "type") {
+        suggestion = `Property '${errPath}' should be of type '${err.params.type}'.`;
+      } else if (err.keyword === "enum") {
+        suggestion = `Allowed values are: ${err.params.allowedValues.join(", ")}.`;
+      }
+
+      errors.push({
+        path: errPath,
+        keyword: err.keyword,
+        message: err.message,
+        params: err.params,
+        suggestion: suggestion || undefined,
+      });
+    }
+  }
+
+  // Business Rules Checks
+  if (parsed.Resources && Array.isArray(parsed.Resources)) {
+    for (let i = 0; i < parsed.Resources.length; i++) {
+      const res = parsed.Resources[i];
+      // Rule 1: Style / eox:flatstyle must be URL string, not JSON object
+      if (res.Style && typeof res.Style === "object") {
+        errors.push({
+          path: `/Resources/${i}/Style`,
+          keyword: "type",
+          message: "Style MUST be a URL string, not a direct JSON object.",
+          suggestion:
+            "Save the style to an external JSON file and provide the relative or absolute URL in Style.",
+        });
+      }
+
+      // Rule 2: Rasterform branching keep_oneof_values check
+      if (res.Rasterform && typeof res.Rasterform === "object") {
+        if (
+          (res.Rasterform.oneOf || res.Rasterform.anyOf) &&
+          res.Rasterform.options?.keep_oneof_values !== false
+        ) {
+          warnings.push(
+            `Resource[${i}] Rasterform uses branching (oneOf/anyOf) without "keep_oneof_values": false in options. This may cause values to leak between branches in json-editor.`,
+          );
+        }
+      }
+    }
+  }
+
+  const totalErrors = errors.length;
+  const isValid = totalErrors === 0;
+
+  let summary = isValid
+    ? `Configuration is valid according to ${schemaUrl}.`
+    : `Validation failed with ${totalErrors} error(s) according to ${schemaUrl}.`;
+
+  if (warnings.length > 0) {
+    summary += ` (${warnings.length} warning(s))`;
+  }
+
+  return {
+    valid: isValid,
+    configType: resolvedType,
+    schemaUrl,
+    errors,
+    warnings,
+    summary,
+  };
+}

--- a/packages/mcp/generators/validator.js
+++ b/packages/mcp/generators/validator.js
@@ -23,6 +23,7 @@ export function createAjvInstance() {
   // Custom formats used in eodash-schemas
   ajv.addFormat("categories", true);
   ajv.addFormat("markdown", true);
+  ajv.addFormat("iri", true);
   ajv.addFormat("datetime", {
     type: "string",
     validate: (dateTime) => {
@@ -105,24 +106,24 @@ export async function getValidators() {
   const ajv = createAjvInstance();
   const { colSchema, indSchema } = await loadSchemas();
 
-  const validateCollection = ajv.compile(colSchema);
-  const validateIndicator = ajv.compile(indSchema);
+  const validateCatalogCollection = ajv.compile(colSchema);
+  const validateCatalogIndicator = ajv.compile(indSchema);
 
   cachedValidators = {
     ajv,
-    validateCollection,
-    validateIndicator,
+    validateCatalogCollection,
+    validateCatalogIndicator,
   };
 
   return cachedValidators;
 }
 
 /**
- * Validate a catalog configuration (collection or indicator) against official schemas and business rules
+ * Validate an EODash catalog configuration against official eodash schemas and custom business rules
  *
  * @param {object} options
- * @param {string|object} options.config - Catalog configuration JSON string or object
- * @param {'collection'|'indicator'|'auto'} [options.configType='auto'] - Type of config to validate
+ * @param {string|object} options.config - JSON string or object to validate
+ * @param {'collection'|'indicator'|'catalog-collection'|'catalog-indicator'|'auto'|string} [options.configType='auto'] - Type of config to validate
  * @returns {Promise<{
  *   valid: boolean,
  *   configType: string,
@@ -174,23 +175,42 @@ export async function validateCatalogConfig({
     };
   }
 
-  // Auto-detect config type
-  let resolvedType = configType;
-  if (resolvedType === "auto") {
-    if (Array.isArray(parsed.Collections)) {
+  // Auto-detect or normalize config type
+  const rawType = String(configType).toLowerCase().trim();
+  let resolvedType = rawType;
+
+  if (rawType === "auto") {
+    if (
+      parsed.Indicators ||
+      (parsed.Name && Array.isArray(parsed.Collections))
+    ) {
       resolvedType = "indicator";
-    } else if (Array.isArray(parsed.Resources)) {
-      resolvedType = "collection";
     } else {
-      resolvedType = "collection"; // default assumption
+      resolvedType = "collection";
     }
+  } else if (
+    rawType === "indicator" ||
+    rawType === "catalog-indicator" ||
+    rawType === "catalog_indicator"
+  ) {
+    resolvedType = "indicator";
+  } else {
+    resolvedType = "collection";
   }
 
-  const { validateCollection, validateIndicator } = await getValidators();
+  const { validateCatalogCollection, validateCatalogIndicator } =
+    await getValidators();
 
-  const isIndicator = resolvedType === "indicator";
-  const validator = isIndicator ? validateIndicator : validateCollection;
-  const schemaUrl = isIndicator ? INDICATOR_SCHEMA_URL : COLLECTION_SCHEMA_URL;
+  let validator;
+  let schemaUrl;
+
+  if (resolvedType === "indicator" || resolvedType === "catalog-indicator") {
+    validator = validateCatalogIndicator;
+    schemaUrl = INDICATOR_SCHEMA_URL;
+  } else {
+    validator = validateCatalogCollection;
+    schemaUrl = COLLECTION_SCHEMA_URL;
+  }
 
   const valid = validator(parsed);
   const errors = [];
@@ -219,11 +239,11 @@ export async function validateCatalogConfig({
     }
   }
 
-  // Business Rules Checks
+  // Business Rules Checks for EODash Catalog Configs (PascalCase)
   if (parsed.Resources && Array.isArray(parsed.Resources)) {
     for (let i = 0; i < parsed.Resources.length; i++) {
       const res = parsed.Resources[i];
-      // Rule 1: Style / eox:flatstyle must be URL string, not JSON object
+      // Rule 1: Style must be URL string, not JSON object
       if (res.Style && typeof res.Style === "object") {
         errors.push({
           path: `/Resources/${i}/Style`,
@@ -231,6 +251,17 @@ export async function validateCatalogConfig({
           message: "Style MUST be a URL string, not a direct JSON object.",
           suggestion:
             "Save the style to an external JSON file and provide the relative or absolute URL in Style.",
+        });
+      }
+
+      // Rule 1b: Resources[].Flatstyle does not exist
+      if (res.Flatstyle !== undefined) {
+        errors.push({
+          path: `/Resources/${i}/Flatstyle`,
+          keyword: "additionalProperties",
+          message:
+            "Property 'Flatstyle' does not exist on Resources. Use 'Style' for resource styles (Flatstyle is only valid under Process outputs).",
+          suggestion: "Rename 'Flatstyle' to 'Style' with a valid URL string.",
         });
       }
 
@@ -248,23 +279,38 @@ export async function validateCatalogConfig({
     }
   }
 
-  const totalErrors = errors.length;
-  const isValid = totalErrors === 0;
-
-  let summary = isValid
-    ? `Configuration is valid according to ${schemaUrl}.`
-    : `Validation failed with ${totalErrors} error(s) according to ${schemaUrl}.`;
-
-  if (warnings.length > 0) {
-    summary += ` (${warnings.length} warning(s))`;
+  // Top-level Style object check
+  if (parsed.Style && typeof parsed.Style === "object") {
+    errors.push({
+      path: "/Style",
+      keyword: "type",
+      message: "Style MUST be a URL string, not a direct JSON object.",
+      suggestion:
+        "Save the style to an external JSON file and provide the relative or absolute URL in Style.",
+    });
   }
 
+  // Top-level Flatstyle check on catalog collection
+  if (parsed.Flatstyle !== undefined) {
+    errors.push({
+      path: "/Flatstyle",
+      keyword: "additionalProperties",
+      message:
+        "Property 'Flatstyle' does not exist on catalog collection. Use 'Style' (Flatstyle is only valid under Process outputs).",
+      suggestion: "Rename 'Flatstyle' to 'Style' with a valid URL string.",
+    });
+  }
+
+  const isActuallyValid = valid && errors.length === 0;
+
   return {
-    valid: isValid,
+    valid: isActuallyValid,
     configType: resolvedType,
     schemaUrl,
     errors,
     warnings,
-    summary,
+    summary: isActuallyValid
+      ? `Configuration is valid according to ${resolvedType} schema.`
+      : `Validation failed with ${errors.length} error(s)${warnings.length ? ` and ${warnings.length} warning(s)` : ""}.`,
   };
 }

--- a/packages/mcp/helpers.js
+++ b/packages/mcp/helpers.js
@@ -245,8 +245,64 @@ if (store) {
 /**
  * Generates the HTML landing page for the MCP server Express dashboard
  */
-export function generateLandingPage(widgets, _arch) {
-  const totalWidgets = Object.keys(widgets).length;
+export function generateLandingPage(widgets, _arch, options = {}) {
+  const totalWidgets = Object.keys(widgets || {}).length;
+  const templates = options.templates || getAvailableTemplates();
+  const examplesCount = options.examplesCount ?? 12;
+  const tools = options.tools || [];
+  const totalTools = tools.length || 8;
+
+  const toolCards =
+    tools.length > 0
+      ? tools
+          .map(
+            (t) => `
+        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4 hover:border-blue-200 transition-colors">
+          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">${t.name}</span>
+          <p class="text-xs text-slate-600 mt-2 leading-relaxed">${t.description || ""}</p>
+        </div>
+      `,
+          )
+          .join("")
+      : `
+        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
+          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">list_widgets</span>
+          <p class="text-xs text-slate-600 mt-2">List all built-in eodash widgets with category and store interactions.</p>
+        </div>
+        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
+          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">get_widget_details</span>
+          <p class="text-xs text-slate-600 mt-2">Get full TypeScript props, defaults, store bindings, STAC extensions, and examples.</p>
+        </div>
+        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
+          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">get_custom_widget_guide</span>
+          <p class="text-xs text-slate-600 mt-2">Guides and boilerplate for Web Component, Functional, and IFrame widgets.</p>
+        </div>
+        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
+          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">get_eodash_architecture</span>
+          <p class="text-xs text-slate-600 mt-2">Comprehensive architecture docs: layout grid, templates, store states, and deployment.</p>
+        </div>
+        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
+          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">scaffold_dashboard</span>
+          <p class="text-xs text-slate-600 mt-2">Bootstrap complete SPA, VitePress narrative docs, or Web Component boilerplate.</p>
+        </div>
+        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
+          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">generate_eodash_config</span>
+          <p class="text-xs text-slate-600 mt-2">Create valid, type-safe eodash configuration files with brand theme and templates.</p>
+        </div>
+        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
+          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">generate_layer_style</span>
+          <p class="text-xs text-slate-600 mt-2">Generate map layer styles and visualization controls (vector, raster, and forms).</p>
+        </div>
+        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
+          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">find_examples</span>
+          <p class="text-xs text-slate-600 mt-2">Search and discover working eodash dashboard examples, layer styles, and catalog configs.</p>
+        </div>
+        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
+          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">validate_catalog_config</span>
+          <p class="text-xs text-slate-600 mt-2">Validate catalog collection and indicator configurations against official eodash schemas.</p>
+        </div>
+      `;
+
   const widgetCards = Object.values(widgets)
     .map(
       (w) => `
@@ -302,7 +358,7 @@ export function generateLandingPage(widgets, _arch) {
             This server implements the <a href="https://modelcontextprotocol.io" target="_blank" class="text-blue-600 hover:underline font-medium">Model Context Protocol (MCP)</a> for <strong>@eodash/eodash</strong>.
           </p>
           <p class="text-sm text-slate-600 leading-relaxed">
-            Coding agents and LLMs can query rich metadata, TypeScript props, reactive store flows, layout grids, and full usage snippets for all eodash built-in widgets and custom widget extensions.
+            Coding agents and LLMs can query rich metadata, TypeScript props, reactive store flows, layout grids, OpenLayers FlatStyles, dynamic forms, and curated snippets for all eodash instances.
           </p>
         </div>
         <div class="mt-6 pt-6 border-t border-slate-100 flex flex-wrap gap-3">
@@ -317,68 +373,59 @@ export function generateLandingPage(widgets, _arch) {
 
       <div class="bg-gradient-to-br from-slate-900 to-slate-800 rounded-xl p-6 text-white shadow-lg flex flex-col justify-between">
         <h2 class="text-sm font-semibold text-slate-400 tracking-wider uppercase mb-4">Dashboard Overview</h2>
-        <div class="grid grid-cols-2 gap-4 my-auto">
-          <div class="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
+        <div class="grid grid-cols-3 gap-3 my-auto">
+          <div class="bg-slate-800/50 rounded-lg p-3 border border-slate-700/50 text-center">
             <div class="text-2xl font-bold text-blue-400">${totalWidgets}</div>
-            <div class="text-xs text-slate-400 mt-1">Built-in Widgets</div>
+            <div class="text-[11px] text-slate-400 mt-1">Widgets</div>
           </div>
-          <div class="bg-slate-800/50 rounded-lg p-4 border border-slate-700/50">
-            <div class="text-2xl font-bold text-teal-400">4</div>
-            <div class="text-xs text-slate-400 mt-1">Templates (Lite, Explore, Expert, Compare)</div>
+          <div class="bg-slate-800/50 rounded-lg p-3 border border-slate-700/50 text-center">
+            <div class="text-2xl font-bold text-teal-400">${templates.length}</div>
+            <div class="text-[11px] text-slate-400 mt-1">Templates</div>
+          </div>
+          <div class="bg-slate-800/50 rounded-lg p-3 border border-slate-700/50 text-center">
+            <div class="text-2xl font-bold text-indigo-400">${examplesCount}</div>
+            <div class="text-[11px] text-slate-400 mt-1">Examples</div>
           </div>
         </div>
         <div class="mt-4 pt-4 border-t border-slate-700/40 text-xs text-slate-400 flex justify-between items-center">
-          <span>Grid System:</span>
-          <span class="font-mono text-slate-200 bg-slate-800 px-2 py-0.5 rounded">12-Column Responsive</span>
+          <span>Templates:</span>
+          <span class="font-mono text-slate-200 bg-slate-800 px-2 py-0.5 rounded text-[11px]">${templates.join(", ")}</span>
         </div>
       </div>
     </div>
 
     <!-- Supported Tools -->
     <div class="bg-white rounded-xl border border-slate-200 p-6 shadow-sm">
-      <h2 class="text-lg font-semibold text-slate-950 mb-4">Supported MCP Tools (6)</h2>
-      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
-          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">list_widgets</span>
-          <p class="text-xs text-slate-600 mt-2">List all built-in eodash widgets with category and store interactions.</p>
-        </div>
-        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
-          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">get_widget_details</span>
-          <p class="text-xs text-slate-600 mt-2">Get full TypeScript props, defaults, store bindings, STAC extensions, and examples.</p>
-        </div>
-        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
-          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">get_custom_widget_guide</span>
-          <p class="text-xs text-slate-600 mt-2">Guides and boilerplate for Web Component, Functional, and IFrame widgets.</p>
-        </div>
-        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
-          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">get_eodash_architecture</span>
-          <p class="text-xs text-slate-600 mt-2">Comprehensive architecture docs: layout grid, templates, store states, and deployment.</p>
-        </div>
-        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
-          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">scaffold_dashboard</span>
-          <p class="text-xs text-slate-600 mt-2">Bootstrap complete SPA, VitePress narrative docs, or Web Component boilerplate.</p>
-        </div>
-        <div class="border border-slate-100 bg-slate-50/50 rounded-lg p-4">
-          <span class="font-mono text-xs font-semibold text-blue-600 bg-blue-50 px-2 py-0.5 rounded">generate_eodash_config</span>
-          <p class="text-xs text-slate-600 mt-2">Create valid, type-safe eodash configuration files with brand theme and templates.</p>
-        </div>
+      <div class="flex items-center justify-between mb-4">
+        <h2 class="text-lg font-semibold text-slate-950">Supported MCP Tools (${totalTools})</h2>
+        <span class="text-xs text-slate-500 font-mono bg-slate-100 px-2.5 py-1 rounded">Streamable HTTP / SSE Endpoint: POST /</span>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+        ${toolCards}
       </div>
     </div>
 
     <!-- Available Widgets -->
     <div>
-      <h2 class="text-lg font-semibold text-slate-950 mb-4">Available Widgets (${totalWidgets})</h2>
+      <div class="flex items-center justify-between mb-6">
+        <div>
+          <h2 class="text-xl font-bold text-slate-950">Available Widgets (${totalWidgets})</h2>
+          <p class="text-sm text-slate-500 mt-1">Auto-extracted from Vue components and TypeScript props in @eodash/eodash.</p>
+        </div>
+      </div>
       <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
         ${widgetCards}
       </div>
     </div>
   </main>
 
-  <footer class="bg-slate-100 border-t border-slate-200 py-6 text-center text-xs text-slate-500">
-    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-      <p>&copy; ${new Date().getFullYear()} EOX IT Services GmbH & eodash contributors. Released under the MIT License.</p>
+  <footer class="bg-white border-t border-slate-200 mt-auto py-6">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between text-xs text-slate-500">
+      <div>@eodash/eodash MCP Server • European Space Agency & EOX IT Services</div>
+      <div class="font-mono">JSON-RPC 2.0 • MCP Spec 2024-11-05</div>
     </div>
   </footer>
 </body>
-</html>`;
+</html>
+`;
 }

--- a/packages/mcp/index.js
+++ b/packages/mcp/index.js
@@ -427,12 +427,18 @@ export function createMcpServer() {
     "generate_layer_style",
     {
       description:
-        "Generate complete OpenLayers layer styles and visualization controls (vector flatstyles, raster WebGL shaders with 'color' expressions, and dynamic raster forms). Always outputs and maintains complete style JSON definitions including 'color', 'variables', 'legend', and 'jsonform'.",
+        "Generate complete OpenLayers layer styles and visualization controls (vector flatstyles for GeoJSON/FlatGeobuf/MVT, raster flatstyles with 'color' expressions for COG/GeoTIFF single files, and dynamic raster forms). Always outputs and maintains complete style JSON definitions including 'color', 'variables', 'legend', and 'jsonform'.",
       inputSchema: z.object({
         styleType: z
-          .enum(["vector-flatstyle", "raster-webgl-flatstyle", "rasterform"])
+          .enum([
+            "vector-flatstyle",
+            "raster-flatstyle",
+            "raster-webgl-flatstyle",
+            "raster-cog",
+            "rasterform",
+          ])
           .describe(
-            "Style generator target type: 'vector-flatstyle' (OpenLayers Vector FlatStyle for vector & vector tile layers), 'raster-webgl-flatstyle' (OpenLayers WebGLTile FlatStyle for COG/GeoTIFF), or 'rasterform' (eodash:rasterform for TiTiler/WMS/XYZ).",
+            "Style generator target type: 'vector-flatstyle' (OpenLayers Vector FlatStyle for vector & vector tile layers), 'raster-flatstyle' / 'raster-cog' (OpenLayers FlatStyle for COG/GeoTIFF client-side single file rendering), or 'rasterform' (eodash:rasterform for TiTiler/WMS/XYZ).",
           ),
         vectorConfig: z
           .object({
@@ -543,7 +549,7 @@ export function createMcpServer() {
           })
           .optional()
           .describe("Options for 'vector-flatstyle' generation."),
-        rasterWebglConfig: z
+        rasterConfig: z
           .object({
             mode: z
               .enum([
@@ -557,7 +563,7 @@ export function createMcpServer() {
               .optional()
               .default("single-band-normalized")
               .describe(
-                "WebGL shader rendering mode: 'single-band-normalized' / 'single-band' (normalized float band with colormap), 'rgb-composite' / 'rgb' (3-band true color / false color), or 'band-ratio-index' (normalized difference index math).",
+                "Raster rendering mode: 'single-band-normalized' / 'single-band' (normalized float band with colormap), 'rgb-composite' / 'rgb' (3-band true color / false color composite), or 'band-ratio-index' (normalized difference index math).",
               ),
             bands: z
               .array(z.number())
@@ -620,7 +626,7 @@ export function createMcpServer() {
               .number()
               .optional()
               .describe(
-                "Explicit slider track upper bound. If omitted, computed dynamically as ~1.5x headroom over defaultMax.",
+                "Explicit slider track upper bound. If omitted, computed dynamically as ~1.5x headroom over defaultMax (e.g. 250 -> 375).",
               ),
             colorMap: z
               .string()
@@ -646,12 +652,12 @@ export function createMcpServer() {
           })
           .optional()
           .describe(
-            "Options for 'raster-webgl-flatstyle' (COG/GeoTIFF) generation.",
+            "Options for raster flatstyle (COG / single GeoTIFF) generation.",
           ),
-        rasterConfig: z
+        rasterWebglConfig: z
           .any()
           .optional()
-          .describe("Alias for rasterWebglConfig."),
+          .describe("Alias for rasterConfig."),
         rasterformConfig: z
           .object({
             serviceType: z
@@ -774,6 +780,7 @@ export function createMcpServer() {
           .enum([
             "all",
             "vector-flatstyle",
+            "raster-flatstyle",
             "raster-webgl-flatstyle",
             "rasterform",
             "jsonform",
@@ -802,7 +809,7 @@ export function createMcpServer() {
           .string()
           .optional()
           .describe(
-            "Filter by specific feature capability (e.g. 'legend', 'tooltip', 'drawtools', 'branching-oneof', 'threshold-filter', 'webgl-shader', 'time-series', 'roles').",
+            "Filter by specific feature capability (e.g. 'legend', 'tooltip', 'drawtools', 'branching-oneof', 'threshold-filter', 'time-series', 'roles').",
           ),
         limit: z
           .number()
@@ -831,7 +838,7 @@ export function createMcpServer() {
     "validate_catalog_config",
     {
       description:
-        "Validate eodash catalog collection or indicator JSON configurations against official eodash schemas (https://eodash.github.io/eodash-schemas/) and core catalog rules.",
+        "Validate EODash catalog configurations (collection or indicator JSON files) against official eodash schemas and custom business rules (e.g., verifying 'Style' is a URL string, catching invalid 'Resources[].Flatstyle', checking JSON-Editor rasterform branching options).",
       inputSchema: z.object({
         config: z
           .union([z.string(), z.record(z.any())])
@@ -839,11 +846,17 @@ export function createMcpServer() {
             "Collection or indicator configuration as a JSON string or parsed JSON object.",
           ),
         configType: z
-          .enum(["collection", "indicator", "auto"])
+          .enum([
+            "auto",
+            "collection",
+            "indicator",
+            "catalog-collection",
+            "catalog-indicator",
+          ])
           .optional()
           .default("auto")
           .describe(
-            "Target schema type: 'collection' (for collection JSONs), 'indicator' (for indicator JSONs), or 'auto' (detect automatically based on Collections/Resources properties).",
+            "Target schema type: 'auto' (auto-detects between collection and indicator), 'collection' / 'catalog-collection' (EODash collection config with Name, Title, Description, Resources), or 'indicator' / 'catalog-indicator' (EODash indicator config with Name, Title, Indicators/Collections).",
           ),
       }),
     },

--- a/packages/mcp/index.js
+++ b/packages/mcp/index.js
@@ -10,6 +10,9 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 import { scaffoldDashboard } from "./generators/dashboard.js";
 import { generateEodashConfig } from "./generators/config.js";
+import { generateLayerStyle } from "./generators/style.js";
+import { findExamples } from "./generators/examples.js";
+import { validateCatalogConfig } from "./generators/validator.js";
 import {
   getMetadata,
   generateLandingPage,
@@ -48,7 +51,8 @@ export function createMcpServer() {
     },
     {
       instructions:
-        "This MCP server provides tools to inspect, configure, and scaffold @eodash/eodash instances, widgets, layouts, and STAC integrations.",
+        "This MCP server provides tools to inspect, configure, and scaffold @eodash/eodash instances, widgets, layouts, styles, and STAC integrations. " +
+        "NOTE: MCP generation tools (scaffold_dashboard, generate_eodash_config, generate_layer_style) generate code and file maps in-memory and do NOT write directly to the user's filesystem. When the user asks to create or scaffold a project or file, you MUST write the returned files/code to disk using your file-writing tools before presenting completion.",
       capabilities: {
         tools: {
           call: {},
@@ -57,12 +61,12 @@ export function createMcpServer() {
     },
   );
 
-  // Tool 1: list_widgets
+  // list_widgets
   server.registerTool(
     "list_widgets",
     {
       description:
-        "List all built-in eodash widgets with their category, summary, background capability, and prop count. Optionally filter by category.",
+        "List all built-in eodash widgets with their category, capability tags, summary, background capability, and prop count. Optionally filter by category, capability tag, or search query.",
       inputSchema: z.object({
         category: z
           .string()
@@ -70,18 +74,51 @@ export function createMcpServer() {
           .describe(
             "Optional category filter: 'Visualization & Map', 'Catalog & Discovery', 'Filtering & Selection', 'Temporal Navigation', 'Analysis & Processing', 'Layout & Orchestration', 'Branding & Metadata'",
           ),
+        tag: z
+          .string()
+          .optional()
+          .describe(
+            "Optional capability tag filter: 'map', 'time', 'filter', 'catalog', 'layer', 'chart', 'process', 'stac', etc.",
+          ),
+        search: z
+          .string()
+          .optional()
+          .describe(
+            "Optional free-text search across widget names, summaries, and capability tags.",
+          ),
       }),
     },
-    async ({ category }) => {
+    async ({ category, tag, search }) => {
       let list = Object.values(widgetsData);
       if (category) {
         const catLower = category.toLowerCase();
         list = list.filter((w) => w.category?.toLowerCase().includes(catLower));
       }
+      if (tag) {
+        const tagLower = tag.toLowerCase();
+        list = list.filter(
+          (w) =>
+            w.tags?.some((t) => t.toLowerCase().includes(tagLower)) ||
+            w.category?.toLowerCase().includes(tagLower) ||
+            w.name?.toLowerCase().includes(tagLower) ||
+            w.summary?.toLowerCase().includes(tagLower),
+        );
+      }
+      if (search) {
+        const sLower = search.toLowerCase();
+        list = list.filter(
+          (w) =>
+            w.name?.toLowerCase().includes(sLower) ||
+            w.summary?.toLowerCase().includes(sLower) ||
+            w.tags?.some((t) => t.toLowerCase().includes(sLower)) ||
+            w.category?.toLowerCase().includes(sLower),
+        );
+      }
 
       const summaryList = list.map((w) => ({
         name: w.name,
         category: w.category,
+        tags: w.tags || [],
         summary: w.summary,
         isBackground: w.isBackground,
         propCount: w.props?.length || 0,
@@ -102,29 +139,32 @@ export function createMcpServer() {
     },
   );
 
-  // Tool 2: get_widget_details
+  // get_widget_details
   server.registerTool(
     "get_widget_details",
     {
       description:
-        "Get details for a specific eodash widget: full TypeScript props (types, defaults, descriptions), store interactions, supported STAC extensions, copy-pasteable example config, and markdown guide.",
+        "Get details for a specific eodash widget: full TypeScript props (types, schemas, defaults, descriptions), store interactions, supported STAC extensions, copy-pasteable example config, and markdown guide.",
       inputSchema: z.object({
         widgetName: z
           .string()
+          .optional()
           .describe(
             "The name of the widget (e.g. 'EodashMap', 'EodashItemCatalog', 'EodashItemFilter', 'EodashLayerControl', 'EodashTimeSlider', 'EodashProcess', 'EodashChart', 'EodashStacInfo', 'EodashTools', 'EodashDatePicker', 'EodashLayoutSwitcher').",
           ),
+        name: z.string().optional().describe("Alias for widgetName."),
       }),
     },
-    async ({ widgetName }) => {
-      const widget = widgetsData[widgetName];
+    async ({ widgetName, name }) => {
+      const targetName = widgetName || name;
+      const widget = targetName ? widgetsData[targetName] : null;
       if (!widget) {
         return {
           isError: true,
           content: [
             {
               type: "text",
-              text: `Widget '${widgetName}' not found in eodash widgets registry. Available widgets: ${Object.keys(widgetsData).join(", ")}`,
+              text: `Widget '${targetName || "undefined"}' not found in eodash widgets registry. Available widgets: ${Object.keys(widgetsData).join(", ")}`,
             },
           ],
         };
@@ -141,7 +181,7 @@ export function createMcpServer() {
     },
   );
 
-  // Tool 3: get_custom_widget_guide
+  // get_custom_widget_guide
   server.registerTool(
     "get_custom_widget_guide",
     {
@@ -157,16 +197,28 @@ export function createMcpServer() {
             "all",
           ])
           .optional()
-          .default("all")
           .describe(
             "Specific custom widget type guide to retrieve ('web-component', 'functional', 'iframe', 'eox-elements', or 'all').",
           ),
+        widgetType: z
+          .enum([
+            "web-component",
+            "functional",
+            "iframe",
+            "eox-elements",
+            "all",
+          ])
+          .optional()
+          .describe("Alias for type."),
       }),
     },
-    async ({ type }) => {
+    async ({ type, widgetType }) => {
+      const selectedType = type || widgetType || "all";
       const guides = CUSTOM_WIDGET_GUIDES;
       const selectedContent =
-        type === "all" ? guides : { [type]: guides[type] };
+        selectedType === "all"
+          ? guides
+          : { [selectedType]: guides[selectedType] };
 
       return {
         content: [
@@ -179,7 +231,7 @@ export function createMcpServer() {
     },
   );
 
-  // Tool 4: get_eodash_architecture
+  // get_eodash_architecture
   server.registerTool(
     "get_eodash_architecture",
     {
@@ -227,12 +279,12 @@ export function createMcpServer() {
     },
   );
 
-  // Tool 5: scaffold_dashboard
+  // scaffold_dashboard
   server.registerTool(
     "scaffold_dashboard",
     {
       description:
-        "Scaffold complete project boilerplate for an eodash dashboard: standalone SPA, VitePress narrative documentation, or embedded web component. Returns ready-to-write file dictionary including package.json, eodash.config.js, index.html, Dockerfile, and README.",
+        "Scaffold complete project boilerplate for an eodash dashboard: standalone SPA, VitePress narrative documentation, or embedded web component. Returns ready-to-write in-memory file dictionary (filePath -> fileContent). NOTE: This tool does NOT write to disk itself; you MUST use your local file writing tool to write each file in the returned 'files' map to disk under the project folder.",
       inputSchema: z.object({
         name: z
           .string()
@@ -282,12 +334,12 @@ export function createMcpServer() {
     },
   );
 
-  // Tool 6: generate_eodash_config
+  // generate_eodash_config
   server.registerTool(
     "generate_eodash_config",
     {
       description:
-        "Generate a complete, type-safe eodash configuration (eodash.config.js / baseConfig.js) with STAC endpoint, brand styling, template selection (lite/explore/expert/compare), custom widget placements, and runtime options.",
+        "Generate a complete, type-safe eodash configuration (eodash.config.js / baseConfig.js) with STAC endpoint, brand styling, template selection (lite/explore/expert/compare), custom widget placements, and runtime options. Returns configuration code string (does not write to disk directly).",
       inputSchema: z.object({
         id: z
           .string()
@@ -370,6 +422,444 @@ export function createMcpServer() {
     },
   );
 
+  // generate_layer_style
+  server.registerTool(
+    "generate_layer_style",
+    {
+      description:
+        "Generate complete OpenLayers layer styles and visualization controls (vector flatstyles, raster WebGL shaders with 'color' expressions, and dynamic raster forms). Always outputs and maintains complete style JSON definitions including 'color', 'variables', 'legend', and 'jsonform'.",
+      inputSchema: z.object({
+        styleType: z
+          .enum(["vector-flatstyle", "raster-webgl-flatstyle", "rasterform"])
+          .describe(
+            "Style generator target type: 'vector-flatstyle' (OpenLayers Vector FlatStyle for vector & vector tile layers), 'raster-webgl-flatstyle' (OpenLayers WebGLTile FlatStyle for COG/GeoTIFF), or 'rasterform' (eodash:rasterform for TiTiler/WMS/XYZ).",
+          ),
+        vectorConfig: z
+          .object({
+            geometryType: z
+              .enum(["point", "polygon", "line"])
+              .optional()
+              .default("polygon")
+              .describe("Geometry symbolizer type."),
+            mode: z
+              .enum(["single", "categorical", "graduated"])
+              .optional()
+              .default("single")
+              .describe(
+                "Coloring mode: 'single' (uniform color), 'categorical' (match expression by attribute), or 'graduated' (continuous linear interpolation).",
+              ),
+            attribute: z
+              .string()
+              .optional()
+              .default("value")
+              .describe("Feature property name for data-driven styling."),
+            colormap: z
+              .string()
+              .optional()
+              .default("viridis")
+              .describe(
+                "Colormap preset name (e.g. 'viridis', 'magma', 'plasma', 'spectral') for graduated styling.",
+              ),
+            colors: z
+              .array(z.string())
+              .optional()
+              .describe(
+                "Explicit color hex array for graduated styling (overrides colormap preset).",
+              ),
+            categories: z
+              .array(
+                z.object({
+                  value: z.union([z.string(), z.number()]),
+                  label: z.string().optional(),
+                  color: z.string(),
+                }),
+              )
+              .optional()
+              .describe("Category value-to-color mapping objects."),
+            range: z
+              .array(z.number())
+              .optional()
+              .describe(
+                "Min and max values [min, max] or [vmin, vmax] for graduated styling domain.",
+              ),
+            min: z
+              .number()
+              .optional()
+              .describe("Minimum value for graduated styling domain."),
+            max: z
+              .number()
+              .optional()
+              .describe("Maximum value for graduated styling domain."),
+            vmin: z
+              .number()
+              .optional()
+              .describe("Minimum value (alias for min)."),
+            vmax: z
+              .number()
+              .optional()
+              .describe("Maximum value (alias for max)."),
+            fillColor: z
+              .string()
+              .optional()
+              .describe("Fill color for single mode polygons/points."),
+            strokeColor: z
+              .string()
+              .optional()
+              .describe(
+                "Stroke color for lines, polygon borders, or point circle borders.",
+              ),
+            strokeWidth: z
+              .number()
+              .optional()
+              .describe("Stroke width in pixels."),
+            pointRadius: z
+              .number()
+              .optional()
+              .describe("Point circle radius in pixels."),
+            tooltipFields: z
+              .array(
+                z.object({
+                  id: z.string().describe("Feature property ID to display."),
+                  title: z.string().optional().describe("Tooltip label title."),
+                  appendix: z
+                    .string()
+                    .optional()
+                    .describe("Suffix unit (e.g. ' µg/m³', ' %')."),
+                  decimals: z
+                    .number()
+                    .optional()
+                    .describe("Decimal rounding precision."),
+                }),
+              )
+              .optional()
+              .describe("Interactive tooltip configuration fields."),
+            interactiveSliders: z
+              .boolean()
+              .optional()
+              .default(false)
+              .describe(
+                "If true, generates dynamic style variables and jsonform sliders for strokeWidth in layer control.",
+              ),
+          })
+          .optional()
+          .describe("Options for 'vector-flatstyle' generation."),
+        rasterWebglConfig: z
+          .object({
+            mode: z
+              .enum([
+                "single-band-normalized",
+                "single-band",
+                "single",
+                "rgb-composite",
+                "rgb",
+                "band-ratio-index",
+              ])
+              .optional()
+              .default("single-band-normalized")
+              .describe(
+                "WebGL shader rendering mode: 'single-band-normalized' / 'single-band' (normalized float band with colormap), 'rgb-composite' / 'rgb' (3-band true color / false color), or 'band-ratio-index' (normalized difference index math).",
+              ),
+            bands: z
+              .array(z.number())
+              .optional()
+              .default([1])
+              .describe(
+                "1-based band index array (e.g. [1] for single band, [4,3,2] for RGB, [8,4] for NDVI).",
+              ),
+            bandIndex: z
+              .number()
+              .optional()
+              .describe("Single band index (1-based, default: 1)."),
+            redBand: z
+              .number()
+              .optional()
+              .describe("Red channel band index (1-based, default: 4)."),
+            greenBand: z
+              .number()
+              .optional()
+              .describe("Green channel band index (1-based, default: 3)."),
+            blueBand: z
+              .number()
+              .optional()
+              .describe("Blue channel band index (1-based, default: 2)."),
+            range: z
+              .array(z.number())
+              .optional()
+              .describe("Min and max data range [vmin, vmax] or [min, max]."),
+            vmin: z
+              .number()
+              .optional()
+              .describe("Initial/default minimum data value (default: 0)."),
+            vmax: z
+              .number()
+              .optional()
+              .describe("Initial/default maximum data value (default: 250)."),
+            min: z
+              .number()
+              .optional()
+              .describe("Minimum data value (alias for vmin)."),
+            max: z
+              .number()
+              .optional()
+              .describe("Maximum data value (alias for vmax)."),
+            defaultMin: z
+              .number()
+              .optional()
+              .describe("Explicit default minimum value."),
+            defaultMax: z
+              .number()
+              .optional()
+              .describe("Explicit default maximum value."),
+            sliderMin: z
+              .number()
+              .optional()
+              .describe(
+                "Explicit slider track lower bound. If omitted, computed dynamically (0 or ~1.5x of negative defaultMin).",
+              ),
+            sliderMax: z
+              .number()
+              .optional()
+              .describe(
+                "Explicit slider track upper bound. If omitted, computed dynamically as ~1.5x headroom over defaultMax.",
+              ),
+            colorMap: z
+              .string()
+              .optional()
+              .describe(
+                "Colormap preset name (supports viridis, magma, plasma, inferno, cividis, spectral, turbo, rainbow, etc. from eurodatacube colormaps).",
+              ),
+            colormap: z
+              .string()
+              .optional()
+              .describe("Colormap preset name (alias for colorMap)."),
+            customColors: z
+              .array(z.string())
+              .optional()
+              .describe("Custom color ramp array overriding preset colormap."),
+            interactiveMinMax: z
+              .boolean()
+              .optional()
+              .default(true)
+              .describe(
+                "If true, generates variables { vmin, vmax }, jsonform minmax slider, and domainProperties legend binding.",
+              ),
+          })
+          .optional()
+          .describe(
+            "Options for 'raster-webgl-flatstyle' (COG/GeoTIFF) generation.",
+          ),
+        rasterConfig: z
+          .any()
+          .optional()
+          .describe("Alias for rasterWebglConfig."),
+        rasterformConfig: z
+          .object({
+            serviceType: z
+              .enum(["titiler", "wms", "custom-xyz"])
+              .optional()
+              .default("titiler")
+              .describe("Raster service backend type."),
+            colormaps: z
+              .array(z.string())
+              .optional()
+              .describe("List of supported colormaps in the dropdown."),
+            colormapOptions: z
+              .array(z.string())
+              .optional()
+              .describe(
+                "List of supported colormaps in the dropdown (alias for colormaps).",
+              ),
+            defaultColormap: z
+              .string()
+              .optional()
+              .default("viridis")
+              .describe("Default active colormap."),
+            vmin: z
+              .number()
+              .optional()
+              .describe("Default minimum value for rescale slider."),
+            vmax: z
+              .number()
+              .optional()
+              .describe("Default maximum value for rescale slider."),
+            min: z
+              .number()
+              .optional()
+              .describe("Minimum value (alias for vmin)."),
+            max: z
+              .number()
+              .optional()
+              .describe("Maximum value (alias for vmax)."),
+            defaultMin: z
+              .number()
+              .optional()
+              .describe("Default minimum slider value."),
+            defaultMax: z
+              .number()
+              .optional()
+              .describe("Default maximum slider value."),
+            sliderMin: z
+              .number()
+              .optional()
+              .describe(
+                "Explicit slider track lower bound. If omitted, computed dynamically (0 or ~1.5x of negative defaultMin).",
+              ),
+            sliderMax: z
+              .number()
+              .optional()
+              .describe(
+                "Explicit slider track upper bound. If omitted, computed dynamically as ~1.5x headroom over defaultMax (e.g. 250 -> 375).",
+              ),
+            hasRescale: z
+              .boolean()
+              .optional()
+              .default(true)
+              .describe(
+                "If true, generates rescale template parameter with removeProperties: ['vminmax'].",
+              ),
+            hasMultiAssetBranching: z
+              .boolean()
+              .optional()
+              .default(false)
+              .describe(
+                "If true, generates multi-asset oneOf branching form with 'keep_oneof_values': false.",
+              ),
+            assets: z
+              .array(
+                z.object({
+                  id: z.string(),
+                  title: z.string(),
+                  defaultVmin: z.number().optional(),
+                  defaultVmax: z.number().optional(),
+                }),
+              )
+              .optional()
+              .describe("Asset options for multi-asset branching oneOf forms."),
+          })
+          .optional()
+          .describe("Options for 'rasterform' (TiTiler/WMS/XYZ) generation."),
+        rasterFormConfig: z
+          .any()
+          .optional()
+          .describe("Alias for rasterformConfig."),
+      }),
+    },
+    async (params) => {
+      const generated = await generateLayerStyle(params);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(generated, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // find_examples
+  server.registerTool(
+    "find_examples",
+    {
+      description:
+        "Search and discover working eodash dashboard examples, layer styles, and catalog configurations.",
+      inputSchema: z.object({
+        query: z
+          .string()
+          .optional()
+          .describe(
+            "Free-text search terms (e.g. 'titiler rescale', 'cmems wmts', 'ice charts match', 'bounding-box drawtools', 'in situ air quality points', 'ndvi band math').",
+          ),
+        category: z
+          .enum([
+            "all",
+            "vector-flatstyle",
+            "raster-webgl-flatstyle",
+            "rasterform",
+            "jsonform",
+            "catalog-collection",
+            "catalog-indicator",
+            "stac-item",
+          ])
+          .optional()
+          .default("all")
+          .describe("Filter snippets by specific configuration category."),
+        dataType: z
+          .enum([
+            "all",
+            "vector",
+            "cog",
+            "xyz",
+            "wmts",
+            "point",
+            "polygon",
+            "timeseries",
+          ])
+          .optional()
+          .default("all")
+          .describe("Filter snippets by geospatial data type."),
+        feature: z
+          .string()
+          .optional()
+          .describe(
+            "Filter by specific feature capability (e.g. 'legend', 'tooltip', 'drawtools', 'branching-oneof', 'threshold-filter', 'webgl-shader', 'time-series', 'roles').",
+          ),
+        limit: z
+          .number()
+          .optional()
+          .default(5)
+          .describe(
+            "Maximum number of examples to return (default 5, max 20).",
+          ),
+      }),
+    },
+    async (params) => {
+      const results = findExamples(params);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(results, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
+  // validate_catalog_config
+  server.registerTool(
+    "validate_catalog_config",
+    {
+      description:
+        "Validate eodash catalog collection or indicator JSON configurations against official eodash schemas (https://eodash.github.io/eodash-schemas/) and core catalog rules.",
+      inputSchema: z.object({
+        config: z
+          .union([z.string(), z.record(z.any())])
+          .describe(
+            "Collection or indicator configuration as a JSON string or parsed JSON object.",
+          ),
+        configType: z
+          .enum(["collection", "indicator", "auto"])
+          .optional()
+          .default("auto")
+          .describe(
+            "Target schema type: 'collection' (for collection JSONs), 'indicator' (for indicator JSONs), or 'auto' (detect automatically based on Collections/Resources properties).",
+          ),
+      }),
+    },
+    async (params) => {
+      const results = await validateCatalogConfig(params);
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(results, null, 2),
+          },
+        ],
+      };
+    },
+  );
+
   return server;
 }
 
@@ -400,8 +890,15 @@ export function createExpressApp() {
 
   app.get("/ui", (_req, res) => {
     const { widgetsData, architectureData } = getMetadata();
+    const serverInstance = createMcpServer();
+    const tools = Object.entries(serverInstance._registeredTools || {}).map(
+      ([name, def]) => ({
+        name,
+        description: def.description,
+      }),
+    );
     res.setHeader("Content-Type", "text/html");
-    res.send(generateLandingPage(widgetsData, architectureData));
+    res.send(generateLandingPage(widgetsData, architectureData, { tools }));
   });
 
   app.get("/", (_req, res) => {

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -31,6 +31,8 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@vue/compiler-sfc": "^3.5.41",
+    "ajv": "^8.20.0",
+    "ajv-formats": "^3.0.1",
     "cors": "^2.8.5",
     "express": "^5.2.1",
     "typescript": "^6.0.3",

--- a/packages/mcp/tests/generators.test.js
+++ b/packages/mcp/tests/generators.test.js
@@ -21,7 +21,9 @@ function assertValidJavaScript(filename, code) {
     const errMessages = diagnostics
       .map((d) => `${d.messageText} at pos ${d.start}`)
       .join("; ");
-    throw new Error(`Syntax error in generated file '${filename}': ${errMessages}\n\nCode:\n${code}`);
+    throw new Error(
+      `Syntax error in generated file '${filename}': ${errMessages}\n\nCode:\n${code}`,
+    );
   }
 }
 
@@ -29,7 +31,9 @@ function assertValidJson(filename, content) {
   try {
     JSON.parse(content);
   } catch (err) {
-    throw new Error(`Invalid JSON in generated file '${filename}': ${err.message}\n\nContent:\n${content}`);
+    throw new Error(
+      `Invalid JSON in generated file '${filename}': ${err.message}\n\nContent:\n${content}`,
+    );
   }
 }
 
@@ -60,6 +64,8 @@ describe("eodash Generators - scaffoldDashboard", () => {
 
     expect(res.projectType).toBe("standalone-spa");
     expect(res.name).toBe("alpine-monitor");
+    expect(res.filesWrittenToDisk).toBe(false);
+    expect(res.actionRequired).toContain("write each file to disk");
     expect(res.files["package.json"]).toBeDefined();
     expect(res.files["src/main.js"]).toContain("alpine-monitor");
     expect(res.files["src/main.js"]).toContain("https://example.com/stac");

--- a/packages/mcp/tests/mcp-server.test.js
+++ b/packages/mcp/tests/mcp-server.test.js
@@ -31,7 +31,11 @@ describe("eodash MCP Server - Core Tools", () => {
     expect(instructions).toContain("eodash");
 
     const tools = await client.listTools();
-    expect(tools.tools.length).toBeGreaterThanOrEqual(6);
+    expect(tools.tools.length).toBe(9);
+    const toolNames = tools.tools.map((t) => t.name);
+    expect(toolNames).toContain("generate_layer_style");
+    expect(toolNames).toContain("find_examples");
+    expect(toolNames).toContain("validate_catalog_config");
   });
 
   it("list_widgets tool returns all widgets and supports filtering by category", async () => {
@@ -270,13 +274,20 @@ describe("eodash MCP Server - Metadata Generator", () => {
 
     const templateFiles = fs
       .readdirSync(templatesDir)
-      .filter((f) => f.endsWith(".js") && f !== "index.js" && f !== "baseConfig.js");
+      .filter(
+        (f) => f.endsWith(".js") && f !== "index.js" && f !== "baseConfig.js",
+      );
 
     expect(templateFiles.length).toBeGreaterThanOrEqual(4);
 
     for (const file of templateFiles) {
       const content = fs.readFileSync(path.join(templatesDir, file), "utf8");
-      const sf = ts.createSourceFile(file, content, ts.ScriptTarget.Latest, true);
+      const sf = ts.createSourceFile(
+        file,
+        content,
+        ts.ScriptTarget.Latest,
+        true,
+      );
 
       function traverse(node) {
         if (
@@ -418,5 +429,53 @@ describe("eodash MCP Server - HTTP Endpoints", () => {
     expect(callBody.result?.content?.[0]?.type).toBe("text");
     const widgets = JSON.parse(callBody.result.content[0].text);
     expect(widgets.length).toBeGreaterThanOrEqual(10);
+
+    // 3. tools/call for generate_layer_style via HTTP
+    const styleRes = await fetch(`${baseUrl}/`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 3,
+        method: "tools/call",
+        params: {
+          name: "generate_layer_style",
+          arguments: {
+            styleType: "vector-flatstyle",
+            vectorConfig: {
+              geometryType: "line",
+              mode: "single",
+              strokeColor: "#003366",
+            },
+          },
+        },
+      }),
+    });
+    expect(styleRes.status).toBe(200);
+    const styleBody = await styleRes.json();
+    const styleData = JSON.parse(styleBody.result.content[0].text);
+    expect(styleData.styleType).toBe("vector-flatstyle");
+    expect(styleData.style["stroke-color"]).toBe("#003366");
+
+    // 4. tools/call for find_examples via HTTP
+    const examplesRes = await fetch(`${baseUrl}/`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 4,
+        method: "tools/call",
+        params: {
+          name: "find_examples",
+          arguments: {
+            query: "cmems",
+          },
+        },
+      }),
+    });
+    expect(examplesRes.status).toBe(200);
+    const examplesBody = await examplesRes.json();
+    const examplesData = JSON.parse(examplesBody.result.content[0].text);
+    expect(examplesData.totalFound).toBeGreaterThan(0);
   });
 });

--- a/packages/mcp/tests/style-and-examples.test.js
+++ b/packages/mcp/tests/style-and-examples.test.js
@@ -367,17 +367,17 @@ describe("eodash Style Generator - generateLayerStyle Router & Docs URLs", () =>
     ).toBe(true);
   });
 
-  it("routes raster-webgl-flatstyle and includes WebGL expressions doc link", async () => {
+  it("routes raster-flatstyle (and raster-webgl-flatstyle) with OpenLayers doc links", async () => {
     const res = await generateLayerStyle({
-      styleType: "raster-webgl-flatstyle",
-      rasterWebglConfig: {
+      styleType: "raster-flatstyle",
+      rasterConfig: {
         mode: "single-band-normalized",
         vmin: 10,
         vmax: 90,
       },
     });
 
-    expect(res.styleType).toBe("raster-webgl-flatstyle");
+    expect(res.styleType).toBe("raster-flatstyle");
     expect(res.style.variables.vmin).toBe(10);
     expect(res.stacItemSnippet["eox:flatstyle"]).toBeDefined();
     expect(res.catalogCollectionSnippet.Resources[0].Style).toBeDefined();

--- a/packages/mcp/tests/style-and-examples.test.js
+++ b/packages/mcp/tests/style-and-examples.test.js
@@ -1,0 +1,656 @@
+import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMcpServer } from "../index.js";
+import {
+  generateVectorFlatStyle,
+  generateRasterWebglStyle,
+  generateRasterForm,
+  generateLayerStyle,
+  fetchColormaps,
+  getColormapRamp,
+} from "../generators/style.js";
+import { findExamples, getExamples } from "../generators/examples.js";
+import { generateLandingPage } from "../helpers.js";
+
+async function createTestClientServer() {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test-client", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return { server, client };
+}
+
+describe("eodash Style Generator - Colormaps Fetching", () => {
+  it("fetches or falls back to valid colormaps dictionary", async () => {
+    const colormaps = await fetchColormaps();
+    expect(colormaps).toBeDefined();
+    expect(typeof colormaps).toBe("object");
+    expect(colormaps.viridis).toBeDefined();
+    expect(Array.isArray(colormaps.viridis)).toBe(true);
+  });
+
+  it("retrieves specific colormap ramp", async () => {
+    const ramp = await getColormapRamp("magma");
+    expect(ramp).toBeDefined();
+    expect(ramp.length).toBeGreaterThan(0);
+    expect(ramp[0].startsWith("#")).toBe(true);
+  });
+
+  it("falls back gracefully for unknown colormap name", async () => {
+    const ramp = await getColormapRamp("non_existent_colormap_xyz");
+    expect(ramp).toBeDefined();
+    expect(ramp.length).toBeGreaterThan(0);
+    expect(ramp[0].startsWith("#")).toBe(true);
+  });
+});
+
+describe("eodash Style Generator - generateVectorFlatStyle", () => {
+  it("generates single mode polygon flatstyle with tooltips", () => {
+    const res = generateVectorFlatStyle({
+      geometryType: "polygon",
+      mode: "single",
+      fillColor: "rgba(0, 113, 194, 0.5)",
+      strokeColor: "#000000",
+      strokeWidth: 2,
+      tooltipFields: [
+        { id: "name", title: "Country Name" },
+        { id: "pop", title: "Population", decimals: 0, appendix: " people" },
+      ],
+    });
+
+    expect(res["fill-color"]).toBe("rgba(0, 113, 194, 0.5)");
+    expect(res["stroke-color"]).toBe("#000000");
+    expect(res["stroke-width"]).toBe(2);
+    expect(res.legend.scaleType).toBe("categorical");
+    expect(res.tooltip).toHaveLength(2);
+    expect(res.tooltip[0].id).toBe("name");
+    expect(res.tooltip[1].appendix).toBe(" people");
+    expect(res.tooltip[1].decimals).toBe(0);
+  });
+
+  it("generates line geometry single mode flatstyle", () => {
+    const res = generateVectorFlatStyle({
+      geometryType: "line",
+      mode: "single",
+      strokeColor: "#ff5500",
+      strokeWidth: 3,
+    });
+
+    expect(res["stroke-color"]).toBe("#ff5500");
+    expect(res["stroke-width"]).toBe(3);
+    expect(res["fill-color"]).toBeUndefined();
+    expect(res.legend.scaleType).toBe("categorical");
+  });
+
+  it("generates categorical mode point flatstyle with match expression and legend", () => {
+    const res = generateVectorFlatStyle({
+      geometryType: "point",
+      mode: "categorical",
+      attribute: "status",
+      categories: [
+        { value: "active", label: "Active", color: "#00ff00" },
+        { value: "inactive", label: "Inactive", color: "#ff0000" },
+      ],
+      pointRadius: 8,
+    });
+
+    expect(res["circle-radius"]).toBe(8);
+    expect(res["circle-fill-color"]).toEqual([
+      "match",
+      ["get", "status"],
+      "active",
+      "#00ff00",
+      "inactive",
+      "#ff0000",
+      "rgba(128, 128, 128, 0.5)",
+    ]);
+    expect(res.legend.domain).toEqual(["Active", "Inactive"]);
+    expect(res.legend.range).toEqual(["#00ff00", "#ff0000"]);
+  });
+
+  it("generates categorical mode with default categories if none provided", () => {
+    const res = generateVectorFlatStyle({
+      geometryType: "line",
+      mode: "categorical",
+      attribute: "highway",
+    });
+
+    expect(res["stroke-color"][0]).toBe("match");
+    expect(res["stroke-color"][1]).toEqual(["get", "highway"]);
+    expect(res.legend.domain).toContain("Category A");
+  });
+
+  it("generates graduated mode polygon flatstyle with linear interpolate expression", () => {
+    const res = generateVectorFlatStyle({
+      geometryType: "polygon",
+      mode: "graduated",
+      attribute: "pm25",
+      colors: ["#00ff00", "#ffff00", "#ff0000"],
+      range: [0, 100],
+    });
+
+    expect(res["fill-color"][0]).toBe("interpolate");
+    expect(res["fill-color"][1]).toEqual(["linear"]);
+    expect(res["fill-color"][2]).toEqual(["get", "pm25"]);
+    expect(res.legend.type).toBeUndefined();
+    expect(res.legend.scaleType).toBe("continuous");
+    expect(res.legend.domain).toEqual([0, 100]);
+  });
+
+  it("generates graduated mode with colormap name without explicit colors", () => {
+    const res = generateVectorFlatStyle({
+      geometryType: "polygon",
+      mode: "graduated",
+      attribute: "pm25",
+      colormap: "magma",
+      range: [0, 100],
+    });
+
+    expect(res["fill-color"][0]).toBe("interpolate");
+    expect(res.legend.range.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("generates graduated mode point flatstyle", () => {
+    const res = generateVectorFlatStyle({
+      geometryType: "point",
+      mode: "graduated",
+      attribute: "temperature",
+      range: [-10, 40],
+      pointRadius: 5,
+    });
+
+    expect(res["circle-radius"]).toBe(5);
+    expect(res["circle-fill-color"][0]).toBe("interpolate");
+    expect(res.legend.scaleType).toBe("continuous");
+    expect(res.legend.domain).toEqual([-10, 40]);
+  });
+
+  it("generates interactive sliders jsonform for strokeWidth and excludes opacity (eodash covers opacity automatically)", () => {
+    const res = generateVectorFlatStyle({
+      geometryType: "line",
+      mode: "single",
+      strokeColor: "#ff0000",
+      interactiveSliders: true,
+    });
+
+    expect(res.variables.strokeWidth).toBeDefined();
+    expect(res.variables.opacity).toBeUndefined();
+    expect(res["stroke-width"]).toEqual(["var", "strokeWidth"]);
+    expect(res.jsonform.properties.strokeWidth.format).toBe("range");
+    expect(res.jsonform.properties.opacity).toBeUndefined();
+  });
+});
+
+describe("eodash Style Generator - generateRasterWebglStyle", () => {
+  it("generates single-band normalized COG shader with minmax sliders", async () => {
+    const res = await generateRasterWebglStyle({
+      mode: "single-band-normalized",
+      bands: [1],
+      vmin: 0,
+      vmax: 500,
+      colorMap: "magma",
+      interactiveMinMax: true,
+    });
+
+    expect(res.variables.vmin).toBe(0);
+    expect(res.variables.vmax).toBe(500);
+    expect(res.color[0]).toBe("case");
+    expect(res.legend.domainProperties).toEqual(["vmin", "vmax"]);
+    expect(res.legend.range.length).toBeGreaterThanOrEqual(8);
+    expect(res.legend.range[0].startsWith("#")).toBe(true);
+    expect(res.jsonform.properties.vminmax.format).toBe("minmax");
+  });
+
+  it("generates static single-band normalized COG shader without interactive sliders", async () => {
+    const res = await generateRasterWebglStyle({
+      mode: "single-band-normalized",
+      bands: [2],
+      vmin: 100,
+      vmax: 2000,
+      interactiveMinMax: false,
+    });
+
+    expect(res.variables).toBeUndefined();
+    expect(res.jsonform).toBeUndefined();
+    expect(res.legend.domain).toEqual([100, 2000]);
+  });
+
+  it("generates RGB composite COG shader with band divisor variable", async () => {
+    const res = await generateRasterWebglStyle({
+      mode: "rgb-composite",
+      bands: [4, 3, 2],
+      vmax: 4000,
+    });
+
+    expect(res.variables.bandDivisor).toBe(4000);
+    expect(res.color[0]).toBe("case");
+    expect(res.color[3][0]).toBe("array");
+    expect(res.jsonform.properties.bandDivisor.default).toBe(4000);
+  });
+
+  it("generates normalized difference index COG shader", async () => {
+    const res = await generateRasterWebglStyle({
+      mode: "band-ratio-index",
+      bands: [8, 4],
+      colorMap: "algae",
+    });
+
+    expect(res.color[0]).toBe("case");
+    expect(res.legend.domain).toEqual([-1, 1]);
+    expect(res.legend.range.length).toBeGreaterThanOrEqual(8);
+    expect(res.legend.range[0].startsWith("#")).toBe(true);
+  });
+
+  it("supports custom color array overriding preset colormap", async () => {
+    const customColors = ["#000000", "#112233", "#ffffff"];
+    const res = await generateRasterWebglStyle({
+      mode: "single-band-normalized",
+      customColors,
+      interactiveMinMax: false,
+    });
+
+    expect(res.legend.range).toEqual(customColors);
+  });
+});
+
+describe("eodash Style Generator - generateRasterForm", () => {
+  it("generates single asset TiTiler rasterform with rescale template and removeProperties", () => {
+    const res = generateRasterForm({
+      _serviceType: "titiler",
+      defaultColormap: "spectral",
+      vmin: 0,
+      vmax: 2000,
+      hasRescale: true,
+    });
+
+    expect(res.legend.rangeProperty).toBe("colormap_name");
+    expect(res.legend.domainProperties).toEqual(["vmin", "vmax"]);
+    expect(res.jsonform.options.removeProperties).toEqual(["vminmax"]);
+    expect(res.jsonform.properties.colormap_name.default).toBe("spectral");
+    expect(res.jsonform.properties.rescale.template).toBe(
+      "{{vminmax.vmin}},{{vminmax.vmax}}",
+    );
+    // Dynamic 1.5x slider bounds check
+    expect(res.jsonform.properties.vminmax.properties.vmin.default).toBe(0);
+    expect(res.jsonform.properties.vminmax.properties.vmax.default).toBe(2000);
+    expect(res.jsonform.properties.vminmax.properties.vmin.maximum).toBe(3000);
+    expect(res.jsonform.properties.vminmax.properties.vmax.maximum).toBe(3000);
+  });
+
+  it("calculates dynamic 1.5x headroom for rasterform slider track (0 to 250 -> maximum 375)", () => {
+    const res = generateRasterForm({
+      vmin: 0,
+      vmax: 250,
+      hasRescale: true,
+    });
+
+    expect(res.jsonform.properties.vminmax.properties.vmin.default).toBe(0);
+    expect(res.jsonform.properties.vminmax.properties.vmax.default).toBe(250);
+    expect(res.jsonform.properties.vminmax.properties.vmin.minimum).toBe(0);
+    expect(res.jsonform.properties.vminmax.properties.vmax.maximum).toBe(375);
+  });
+
+  it("generates minimal rasterform without rescale slider", () => {
+    const res = generateRasterForm({
+      _serviceType: "wms",
+      colormaps: ["viridis", "turbo"],
+      hasRescale: false,
+    });
+
+    expect(res.jsonform.properties.rescale).toBeUndefined();
+    expect(res.jsonform.properties.vminmax).toBeUndefined();
+    expect(res.jsonform.properties.colormap_name.enum).toEqual([
+      "viridis",
+      "turbo",
+    ]);
+  });
+
+  it("enforces keep_oneof_values: false for multi-asset branching rasterforms", () => {
+    const res = generateRasterForm({
+      _serviceType: "titiler",
+      hasMultiAssetBranching: true,
+      assets: [
+        { id: "visual", title: "RGB True Color" },
+        {
+          id: "ndvi",
+          title: "NDVI Index",
+          defaultVmin: -0.2,
+          defaultVmax: 0.8,
+        },
+      ],
+    });
+
+    expect(res.jsonform.options.keep_oneof_values).toBe(false);
+    expect(res.jsonform.options.removeProperties).toEqual(["vminmax"]);
+    expect(res.jsonform.oneOf).toHaveLength(2);
+    expect(res.jsonform.oneOf[0].title).toBe("RGB True Color");
+    expect(res.jsonform.oneOf[1].title).toBe("NDVI Index");
+    expect(
+      res.jsonform.oneOf[1].properties.vminmax.properties.vmin.default,
+    ).toBe(-0.2);
+    expect(
+      res.jsonform.oneOf[1].properties.vminmax.properties.vmax.default,
+    ).toBe(0.8);
+  });
+});
+
+describe("eodash Style Generator - generateLayerStyle Router & Docs URLs", () => {
+  it("routes vector-flatstyle and generates full snippets with OpenLayers doc links", async () => {
+    const res = await generateLayerStyle({
+      styleType: "vector-flatstyle",
+      vectorConfig: {
+        geometryType: "polygon",
+        mode: "single",
+        fillColor: "rgba(255, 0, 0, 0.5)",
+      },
+    });
+
+    expect(res.styleType).toBe("vector-flatstyle");
+    expect(res.style["fill-color"]).toBe("rgba(255, 0, 0, 0.5)");
+    expect(res.stacItemSnippet["eox:flatstyle"]).toBeDefined();
+    expect(res.catalogCollectionSnippet.Style).toBeDefined();
+    expect(res.rulesAndBestPractices.length).toBeGreaterThan(0);
+    expect(
+      res.rulesAndBestPractices.some((r) =>
+        r.includes(
+          "https://openlayers.org/en/latest/apidoc/module-ol_style_flat.html",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("routes raster-webgl-flatstyle and includes WebGL expressions doc link", async () => {
+    const res = await generateLayerStyle({
+      styleType: "raster-webgl-flatstyle",
+      rasterWebglConfig: {
+        mode: "single-band-normalized",
+        vmin: 10,
+        vmax: 90,
+      },
+    });
+
+    expect(res.styleType).toBe("raster-webgl-flatstyle");
+    expect(res.style.variables.vmin).toBe(10);
+    expect(res.stacItemSnippet["eox:flatstyle"]).toBeDefined();
+    expect(res.catalogCollectionSnippet.Resources[0].Style).toBeDefined();
+    expect(
+      res.rulesAndBestPractices.some((r) =>
+        r.includes(
+          "https://openlayers.org/en/latest/apidoc/module-ol_style_expressions.html",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("routes rasterform and generates full snippets with rules", async () => {
+    const res = await generateLayerStyle({
+      styleType: "rasterform",
+      rasterformConfig: {
+        serviceType: "titiler",
+        vmin: 0,
+        vmax: 500,
+      },
+    });
+
+    expect(res.styleType).toBe("rasterform");
+    expect(res.style.jsonform.properties.vminmax).toBeDefined();
+    expect(res.stacItemSnippet["eodash:rasterform"]).toBeDefined();
+    expect(res.catalogCollectionSnippet.Resources[0].EndPoint).toContain(
+      "rescale",
+    );
+    expect(
+      res.rulesAndBestPractices.some((r) =>
+        r.includes("https://github.com/json-editor/json-editor"),
+      ),
+    ).toBe(true);
+  });
+});
+
+describe("eodash Landing Page HTML Generator", () => {
+  it("renders landing page with dynamic tools list and statistics", () => {
+    const tools = [
+      { name: "tool_a", description: "Alpha tool" },
+      { name: "tool_b", description: "Beta tool" },
+    ];
+    const html = generateLandingPage(
+      { EodashMap: { name: "EodashMap" } },
+      {},
+      { tools, templates: ["lite", "explore"], examplesCount: 15 },
+    );
+
+    expect(html).toContain("Supported MCP Tools (2)");
+    expect(html).toContain("tool_a");
+    expect(html).toContain("Alpha tool");
+    expect(html).toContain("tool_b");
+    expect(html).toContain("lite, explore");
+  });
+
+  it("renders default tool cards when no tools provided in options", () => {
+    const html = generateLandingPage({ EodashMap: { name: "EodashMap" } }, {});
+    expect(html).toContain("generate_layer_style");
+    expect(html).toContain("find_examples");
+    expect(html).toContain("list_widgets");
+  });
+});
+
+describe("eodash Examples Discovery - findExamples", () => {
+  it("loads examples database cleanly", () => {
+    const examples = getExamples();
+    expect(examples.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it("searches examples by free-text keywords", () => {
+    const res = findExamples({ query: "titiler rescale" });
+    expect(res.totalFound).toBeGreaterThan(0);
+    expect(res.results[0].category).toBe("rasterform");
+  });
+
+  it("filters examples by category", () => {
+    const res = findExamples({ category: "catalog-collection" });
+    expect(res.totalFound).toBeGreaterThan(0);
+    for (const ex of res.results) {
+      expect(ex.category).toBe("catalog-collection");
+    }
+  });
+
+  it("filters examples by dataType (e.g. cog, vector, wmts)", () => {
+    const cogRes = findExamples({ dataType: "cog" });
+    expect(cogRes.totalFound).toBeGreaterThan(0);
+    expect(cogRes.results.every((r) => r.dataType === "cog")).toBe(true);
+
+    const vecRes = findExamples({ dataType: "vector" });
+    expect(vecRes.totalFound).toBeGreaterThan(0);
+    expect(vecRes.results.every((r) => r.dataType === "vector")).toBe(true);
+  });
+
+  it("filters examples by feature tag", () => {
+    const res = findExamples({ feature: "bounding-box" });
+    expect(res.totalFound).toBeGreaterThan(0);
+    expect(res.results.some((ex) => ex.features.includes("bounding-box"))).toBe(
+      true,
+    );
+  });
+
+  it("respects limit parameter and clamps maximum to 20", () => {
+    const limitedRes = findExamples({ limit: 2 });
+    expect(limitedRes.results.length).toBe(2);
+
+    const clampedRes = findExamples({ limit: 50 });
+    expect(clampedRes.results.length).toBeLessThanOrEqual(20);
+  });
+
+  it("handles non-matching query cleanly", () => {
+    const res = findExamples({
+      query: "non_existent_random_search_term_12345",
+    });
+    expect(res.totalFound).toBe(0);
+    expect(res.results).toEqual([]);
+  });
+});
+
+describe("eodash MCP Tools via Client - generate_layer_style & find_examples", () => {
+  it("calls generate_layer_style via MCP client for vector-flatstyle", async () => {
+    const { client } = await createTestClientServer();
+    const result = await client.callTool({
+      name: "generate_layer_style",
+      arguments: {
+        styleType: "vector-flatstyle",
+        vectorConfig: {
+          geometryType: "polygon",
+          mode: "categorical",
+          attribute: "risk_level",
+          categories: [
+            { value: "low", label: "Low Risk", color: "#00ff00" },
+            { value: "high", label: "High Risk", color: "#ff0000" },
+          ],
+        },
+      },
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.styleType).toBe("vector-flatstyle");
+    expect(parsed.style["fill-color"]).toBeDefined();
+    expect(parsed.stacItemSnippet["eox:flatstyle"]).toBeDefined();
+    expect(parsed.catalogCollectionSnippet.Style).toBeDefined();
+    expect(parsed.rulesAndBestPractices).toBeInstanceOf(Array);
+  });
+
+  it("calls generate_layer_style via MCP client for raster-webgl-flatstyle", async () => {
+    const { client } = await createTestClientServer();
+    const result = await client.callTool({
+      name: "generate_layer_style",
+      arguments: {
+        styleType: "raster-webgl-flatstyle",
+        rasterWebglConfig: {
+          mode: "single-band-normalized",
+          bands: [1],
+          vmin: 0,
+          vmax: 1000,
+        },
+      },
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.styleType).toBe("raster-webgl-flatstyle");
+    expect(parsed.style.color).toBeDefined();
+    expect(parsed.stacItemSnippet["eox:flatstyle"]).toBeDefined();
+  });
+
+  it("calls generate_layer_style via MCP client for rasterform", async () => {
+    const { client } = await createTestClientServer();
+    const result = await client.callTool({
+      name: "generate_layer_style",
+      arguments: {
+        styleType: "rasterform",
+        rasterformConfig: {
+          serviceType: "titiler",
+          vmin: 10,
+          vmax: 200,
+        },
+      },
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.styleType).toBe("rasterform");
+    expect(parsed.style.jsonform).toBeDefined();
+    expect(parsed.stacItemSnippet["eodash:rasterform"]).toBeDefined();
+  });
+
+  it("calls find_examples via MCP client with keyword and category", async () => {
+    const { client } = await createTestClientServer();
+    const result = await client.callTool({
+      name: "find_examples",
+      arguments: {
+        query: "ice charts match",
+        category: "vector-flatstyle",
+      },
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.totalFound).toBeGreaterThan(0);
+    expect(parsed.results[0].id).toBe(
+      "vector-flatstyle-ice-charts-categorical",
+    );
+  });
+
+  it("calls find_examples via MCP client with dataType filter", async () => {
+    const { client } = await createTestClientServer();
+    const result = await client.callTool({
+      name: "find_examples",
+      arguments: {
+        dataType: "cog",
+      },
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.totalFound).toBeGreaterThan(0);
+    expect(parsed.results[0].dataType).toBe("cog");
+  });
+
+  it("calls generate_layer_style with parameter aliases (rasterConfig & colormap)", async () => {
+    const { client } = await createTestClientServer();
+    const result = await client.callTool({
+      name: "generate_layer_style",
+      arguments: {
+        styleType: "raster-webgl-flatstyle",
+        rasterConfig: {
+          mode: "single-band",
+          bandIndex: 1,
+          range: [-2, 35],
+          colormap: "magma",
+        },
+      },
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.styleType).toBe("raster-webgl-flatstyle");
+    expect(parsed.style.variables.vmin).toBe(-2);
+    expect(parsed.style.variables.vmax).toBe(35);
+  });
+
+  it("calls list_widgets with tag and search filter", async () => {
+    const { client } = await createTestClientServer();
+    const tagRes = await client.callTool({
+      name: "list_widgets",
+      arguments: {
+        tag: "time",
+      },
+    });
+    const tagList = JSON.parse(tagRes.content[0].text);
+    expect(tagList.some((w) => w.name === "EodashTimeSlider")).toBe(true);
+
+    const searchRes = await client.callTool({
+      name: "list_widgets",
+      arguments: {
+        search: "temporal",
+      },
+    });
+    const searchList = JSON.parse(searchRes.content[0].text);
+    expect(searchList.some((w) => w.name === "EodashDatePicker")).toBe(true);
+  });
+
+  it("calls get_widget_details with name alias and verifies structured schema for btns", async () => {
+    const { client } = await createTestClientServer();
+    const res = await client.callTool({
+      name: "get_widget_details",
+      arguments: {
+        name: "EodashMap",
+      },
+    });
+    const widget = JSON.parse(res.content[0].text);
+    expect(widget.name).toBe("EodashMap");
+    const btnsProp = widget.props.find((p) => p.name === "btns");
+    expect(btnsProp).toBeDefined();
+    expect(btnsProp.schema).toBeDefined();
+    expect(btnsProp.schema.type).toBe("object");
+    expect(btnsProp.schema.properties.enableExportMap).toBeDefined();
+  });
+});

--- a/packages/mcp/tests/validator.test.js
+++ b/packages/mcp/tests/validator.test.js
@@ -1,0 +1,231 @@
+import { describe, it, expect } from "vitest";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createMcpServer } from "../index.js";
+import {
+  validateCatalogConfig,
+  COLLECTION_SCHEMA_URL,
+  INDICATOR_SCHEMA_URL,
+} from "../generators/validator.js";
+
+async function createTestClientServer() {
+  const server = createMcpServer();
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  const client = new Client(
+    { name: "test-client", version: "1.0.0" },
+    { capabilities: {} },
+  );
+  await Promise.all([
+    server.connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return { server, client };
+}
+
+describe("eodash Catalog Schema Validator - Unit Tests", () => {
+  it("validates a minimal valid collection configuration", async () => {
+    const validCollection = {
+      Name: "test-collection",
+      Title: "Test Collection Title",
+      Description: "Detailed description of the test collection.",
+      Resources: [
+        {
+          Name: "COG source",
+          Style: "styles/test.json",
+          TimeEntries: [
+            {
+              Time: "2024-01-01T00:00:00Z",
+              Assets: [
+                {
+                  Identifier: "cog_asset",
+                  File: "https://example.com/test.tif",
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await validateCatalogConfig({
+      config: validCollection,
+      configType: "collection",
+    });
+
+    expect(res.valid).toBe(true);
+    expect(res.errors).toHaveLength(0);
+    expect(res.configType).toBe("collection");
+    expect(res.schemaUrl).toBe(COLLECTION_SCHEMA_URL);
+  });
+
+  it("validates a minimal valid indicator configuration", async () => {
+    const validIndicator = {
+      Name: "test-indicator",
+      Title: "Test Indicator Title",
+      Description: "Detailed description of the test indicator.",
+      Collections: ["test-collection-1", "test-collection-2"],
+    };
+
+    const res = await validateCatalogConfig({
+      config: validIndicator,
+      configType: "indicator",
+    });
+
+    expect(res.valid).toBe(true);
+    expect(res.errors).toHaveLength(0);
+    expect(res.configType).toBe("indicator");
+    expect(res.schemaUrl).toBe(INDICATOR_SCHEMA_URL);
+  });
+
+  it("auto-detects indicator and collection config types", async () => {
+    const indRes = await validateCatalogConfig({
+      config: {
+        Name: "auto-indicator",
+        Title: "Auto Indicator",
+        Description: "Description text",
+        Collections: ["col-a"],
+      },
+      configType: "auto",
+    });
+    expect(indRes.configType).toBe("indicator");
+
+    const colRes = await validateCatalogConfig({
+      config: {
+        Name: "auto-collection",
+        Title: "Auto Collection",
+        Description: "Description text",
+        Resources: [],
+      },
+      configType: "auto",
+    });
+    expect(colRes.configType).toBe("collection");
+  });
+
+  it("fails validation for invalid JSON string", async () => {
+    const res = await validateCatalogConfig({
+      config: "{ invalid json: true ",
+    });
+
+    expect(res.valid).toBe(false);
+    expect(res.errors[0].message).toContain("JSON Parse error");
+  });
+
+  it("fails validation when required properties are missing", async () => {
+    const invalidCol = {
+      Name: "invalid-collection",
+      // Missing Title and Resources
+    };
+
+    const res = await validateCatalogConfig({
+      config: invalidCol,
+      configType: "collection",
+    });
+
+    expect(res.valid).toBe(false);
+    expect(res.errors.length).toBeGreaterThanOrEqual(1);
+    expect(res.summary).toContain("Validation failed");
+  });
+
+  it("enforces rule: Style MUST be a URL string and not a JSON object", async () => {
+    const colWithObjStyle = {
+      Name: "obj-style-col",
+      Title: "Object Style",
+      Resources: [
+        {
+          Name: "COG source",
+          Style: { "fill-color": "#ff0000" }, // Illegal object
+          TimeEntries: [
+            {
+              Time: "2024-01-01T00:00:00Z",
+              Assets: [{ Identifier: "a", File: "https://example.com/a.tif" }],
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = await validateCatalogConfig({
+      config: colWithObjStyle,
+      configType: "collection",
+    });
+
+    expect(res.valid).toBe(false);
+    expect(
+      res.errors.some((e) => e.message.includes("Style MUST be a URL string")),
+    ).toBe(true);
+  });
+
+  it("warns when Rasterform uses branching without keep_oneof_values: false", async () => {
+    const colWithBranchingRasterform = {
+      Name: "branch-col",
+      Title: "Branching Rasterform",
+      Resources: [
+        {
+          Name: "WMS resource",
+          EndPoint: "https://example.com/wms",
+          Type: "image/png",
+          LayerId: "layer1",
+          Rasterform: {
+            oneOf: [
+              { title: "Asset A", properties: {} },
+              { title: "Asset B", properties: {} },
+            ],
+            options: {}, // Missing keep_oneof_values: false
+          },
+        },
+      ],
+    };
+
+    const res = await validateCatalogConfig({
+      config: colWithBranchingRasterform,
+      configType: "collection",
+    });
+
+    expect(res.warnings.length).toBeGreaterThan(0);
+    expect(res.warnings[0]).toContain("keep_oneof_values");
+  });
+});
+
+describe("eodash MCP Tool - validate_catalog_config via Client", () => {
+  it("calls validate_catalog_config tool via MCP client with valid indicator config", async () => {
+    const { client } = await createTestClientServer();
+
+    const result = await client.callTool({
+      name: "validate_catalog_config",
+      arguments: {
+        config: {
+          Name: "indicator-test",
+          Title: "Indicator Test",
+          Description: "Description text for indicator test",
+          Collections: ["collection-1", "collection-2"],
+        },
+        configType: "indicator",
+      },
+    });
+
+    expect(result.content[0].type).toBe("text");
+    const data = JSON.parse(result.content[0].text);
+    expect(data.valid).toBe(true);
+    expect(data.configType).toBe("indicator");
+  });
+
+  it("calls validate_catalog_config tool via MCP client with invalid config string", async () => {
+    const { client } = await createTestClientServer();
+
+    const result = await client.callTool({
+      name: "validate_catalog_config",
+      arguments: {
+        config: JSON.stringify({
+          Name: "broken-collection",
+          // Missing Resources and Title
+        }),
+        configType: "collection",
+      },
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.valid).toBe(false);
+    expect(data.errors.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/mcp/tests/validator.test.js
+++ b/packages/mcp/tests/validator.test.js
@@ -131,6 +131,7 @@ describe("eodash Catalog Schema Validator - Unit Tests", () => {
     const colWithObjStyle = {
       Name: "obj-style-col",
       Title: "Object Style",
+      Description: "Description text",
       Resources: [
         {
           Name: "COG source",
@@ -160,6 +161,7 @@ describe("eodash Catalog Schema Validator - Unit Tests", () => {
     const colWithBranchingRasterform = {
       Name: "branch-col",
       Title: "Branching Rasterform",
+      Description: "Description text",
       Resources: [
         {
           Name: "WMS resource",
@@ -185,47 +187,68 @@ describe("eodash Catalog Schema Validator - Unit Tests", () => {
     expect(res.warnings.length).toBeGreaterThan(0);
     expect(res.warnings[0]).toContain("keep_oneof_values");
   });
-});
 
-describe("eodash MCP Tool - validate_catalog_config via Client", () => {
-  it("calls validate_catalog_config tool via MCP client with valid indicator config", async () => {
-    const { client } = await createTestClientServer();
-
-    const result = await client.callTool({
-      name: "validate_catalog_config",
-      arguments: {
-        config: {
-          Name: "indicator-test",
-          Title: "Indicator Test",
-          Description: "Description text for indicator test",
-          Collections: ["collection-1", "collection-2"],
+  it("catches invalid Resources[].Flatstyle in catalog collection config", async () => {
+    const invalidCol = {
+      Name: "invalid-flatstyle-col",
+      Title: "Invalid Flatstyle Resource",
+      Description: "Testing Flatstyle on resource error",
+      Resources: [
+        {
+          Name: "SAR Sigma0",
+          Flatstyle: "https://example.com/style.json", // Invalid property on Resource
+          TimeEntries: [],
         },
-        configType: "indicator",
-      },
+      ],
+    };
+
+    const res = await validateCatalogConfig({
+      config: invalidCol,
+      configType: "collection",
     });
 
-    expect(result.content[0].type).toBe("text");
-    const data = JSON.parse(result.content[0].text);
-    expect(data.valid).toBe(true);
-    expect(data.configType).toBe("indicator");
+    expect(res.valid).toBe(false);
+    expect(
+      res.errors.some((e) =>
+        e.message.includes("Property 'Flatstyle' does not exist on Resources"),
+      ),
+    ).toBe(true);
   });
 
-  it("calls validate_catalog_config tool via MCP client with invalid config string", async () => {
+  it("calls validate_catalog_config via MCP client successfully", async () => {
     const { client } = await createTestClientServer();
 
-    const result = await client.callTool({
+    const response = await client.callTool({
       name: "validate_catalog_config",
       arguments: {
         config: JSON.stringify({
-          Name: "broken-collection",
-          // Missing Resources and Title
+          Name: "test-client-collection",
+          Title: "Client Collection Title",
+          Description: "Valid description.",
+          Resources: [
+            {
+              Name: "GeoJSON source",
+              Style: "https://example.com/styles/vector.json",
+              TimeEntries: [
+                {
+                  Time: "2024-01-01T00:00:00Z",
+                  Assets: [
+                    {
+                      Identifier: "sample",
+                      File: "https://example.com/data.geojson",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
         }),
-        configType: "collection",
+        configType: "catalog-collection",
       },
     });
 
-    const data = JSON.parse(result.content[0].text);
-    expect(data.valid).toBe(false);
-    expect(data.errors.length).toBeGreaterThan(0);
+    const parsed = JSON.parse(response.content[0].text);
+    expect(parsed.valid).toBe(true);
+    expect(parsed.configType).toBe("collection");
   });
 });


### PR DESCRIPTION
## Description                                                                                                                                                             
Enhance the MCP with 3 new tools: layer style generation, examples discovery, catalog configuration validation, and improves previous tools developer ergonomics a bit:
   1. **Layer Style & Visualization (`generate_layer_style`)**:
      - Generates complete OpenLayers FlatStyles (`vector-flatstyle`, `raster-flatstyle` for client-side COG/vector rendering) and dynamic forms (`rasterform` for TiTiler/WMS/XYZ).
      - Fetches and caches remote colormaps registry from `eurodatacube/eodash-assets`.
      - Enforces complete style output preservation (`color`, `variables`, `legend`, `jsonform`).
   2. **Catalog Schema & Business Rules Validation (`validate_catalog_config`)**:
      - Validates EODash catalog configurations against official `collection-schema.json` and `indicator-schema.json` with some additional heuristics.
   3. **Curated Examples Discovery (`find_examples`)**:
      - Curated reference catalog covering vector flatstyles, raster COG flatstyles, TiTiler rasterforms, and draw tool selectors.                                            
      - Supports filtering by category, data type, feature tags, and weighted free-text queries.
   4. **Widget Metadata & Developer Ergonomics**:
      - Added capability tag and free-text search filters to `list_widgets`.
      - Added structured JSON schema generation for complex props like `EodashMap.btns`.
   5. **token footprint reduction of all tools**:
    - Tightened property descriptions from multi-sentence paragraphs to short functional tags.
    - Simplified and flattened the input schemas
   ## Checklist                                                                                                                                                               

   - [x] I have performed a self review on my code                                                                                                                            
   - [x] I added a test related to this feature/fix                                                                                                                           
   - [x] I ran `npm run format` and `npm run check` pass                                                                                                                      
   - [ ] Docs under `docs/` are updated for any public API, config, or behavior change                                                                                        
   - [ ] New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](https://eodash.github.io/eodash/eodash-store) reference is generated from it                      
   - [ ] New widget props are typed properly and they appear typed in the API reference        