### PR TITLE
Feat/remove subcode logic

### DIFF
--- a/core/client/composables/index.js
+++ b/core/client/composables/index.js
@@ -173,9 +173,7 @@ export const useURLSearchParametersSync = () => {
           }
           case "indicator": {
             log.debug("Found indicator key in url");
-            const match = store.stac?.find(
-              (link) => useGetSubCodeId(link) == value,
-            );
+            const match = store.stac?.find((link) => link?.id == value);
             if (match) {
               log.debug("Found match, loading stac item", match);
               if (searchParams.has("poi")) {
@@ -424,25 +422,6 @@ export const useEmitLayersUpdate = async (event, mapEl, layers) => {
       res(true);
     });
   });
-};
-
-/**
- * @param {import("stac-ts").StacCollection | import("stac-ts").StacLink | import("stac-ts").StacItem | null} collection
- * @returns {string} - Returns the collection id or subcode if `useSubCode` is enabled
- */
-export const useGetSubCodeId = (collection) => {
-  const eodash = useEodash();
-
-  if (!collection) {
-    return "";
-  }
-
-  if (eodash?.options?.useSubCode) {
-    return typeof collection.subcode === "string"
-      ? collection.subcode
-      : /** @type {string} */ (collection.id);
-  }
-  return /** @type {string} */ (collection.id);
 };
 
 /**

--- a/core/client/store/stac.js
+++ b/core/client/store/stac.js
@@ -4,7 +4,6 @@ import axios from "@/plugins/axios";
 import {
   useAbsoluteUrl,
   useCompareAbsoluteUrl,
-  useGetSubCodeId,
 } from "@/composables/index";
 import { compareIndicator, comparePoi, indicator, poi } from "@/store/states";
 import {
@@ -211,9 +210,7 @@ export const useSTAcStore = defineStore("stac", () => {
       selectedItem.value = /** @type {any} */ (stacItem) ?? undefined;
       selectedStac.value = resp.data;
       // set indicator and poi
-      indicator.value = isPoi
-        ? indicator.value
-        : useGetSubCodeId(selectedStac.value);
+      indicator.value = isPoi ? indicator.value : (selectedStac.value?.id ?? "");
       poi.value = isPoi ? (selectedStac.value?.id ?? "") : "";
     });
   }
@@ -255,7 +252,7 @@ export const useSTAcStore = defineStore("stac", () => {
       selectedCompareStac.value = resp.data;
       compareIndicator.value = isPOI
         ? compareIndicator.value
-        : useGetSubCodeId(selectedCompareStac.value);
+        : (selectedCompareStac.value?.id ?? "");
       comparePoi.value = isPOI ? (selectedCompareStac.value?.id ?? "") : "";
     });
   }
@@ -281,8 +278,7 @@ export const useSTAcStore = defineStore("stac", () => {
     }
     // construct absolute URL of a poi
     const indicatorUrl =
-      stac.value?.find((link) => useGetSubCodeId(link) === indicatorStr)
-        ?.href ?? "";
+      stac.value?.find((link) => link?.id === indicatorStr)?.href ?? "";
     const absoluteIndicatorUrl = toAbsolute(indicatorUrl, stacEndpoint.value);
     return toAbsolute(relativePath, absoluteIndicatorUrl);
   }

--- a/core/client/types.ts
+++ b/core/client/types.ts
@@ -372,7 +372,6 @@ export type Eodash = {
   id?: string;
   /** Object containing potential special configuration options */
   options?: {
-    useSubCode?: boolean;
     /**
      * TiTiler render presets, keyed by collection id then render name,
      * following the STAC `renders` extension shape. Used to render a

--- a/docs/STAC.md
+++ b/docs/STAC.md
@@ -23,8 +23,6 @@ The links in a catalog pointing to indicator collections can contain several met
 |---|---|
 | `title` | The display title for the linked collection. |
 | `subtitle` | A longer description of the collection's content. |
-| `code` | A code or identifier for the indicator. |
-| `subcode` | A subcode or identifier for the indicator. |
 | `themes` | An array of thematic categories. |
 | `satellite` | An array of satellites used for data acquisition. |
 | `sensor` | An array of sensors used for data acquisition. |

--- a/templates/baseConfig.js
+++ b/templates/baseConfig.js
@@ -8,7 +8,6 @@ import explore from "./explore";
 const baseConfig = {
   id: "demo",
   options: {
-    // useSubCode: true,
   },
   stacEndpoint: {
     endpoint:

--- a/widgets/EodashProcess/methods/handling.js
+++ b/widgets/EodashProcess/methods/handling.js
@@ -21,8 +21,8 @@ import { handleLayersCustomEndpoints } from "./custom-endpoints/layers";
 import { handleChartCustomEndpoints } from "./custom-endpoints/chart";
 import { useSTAcStore } from "@/store/stac";
 import axios from "@/plugins/axios";
-import { useGetSubCodeId } from "@/composables";
 import { getLayers, getCompareLayers } from "@/store/actions";
+
 
 /**
  * Fetch and set the jsonform schema to initialize the process
@@ -412,13 +412,13 @@ export const loadPOiIndicator = () => {
   }
   const stacStore = useSTAcStore();
   const link = stacStore.stac?.find(
-    (link) => useGetSubCodeId(link) === indicator.value,
+    (link) => link?.id === indicator.value,
   );
   stacStore.loadSelectedSTAC(link?.href);
   if (comparePoi.value) {
     if (compareIndicator.value) {
       const comparelink = stacStore.stac?.find(
-        (link) => useGetSubCodeId(link) === compareIndicator.value,
+        (link) => link?.id === compareIndicator.value,
       );
       stacStore.loadSelectedCompareSTAC(comparelink?.href).catch((err) => {
         console.error("[eodash] Error loading compare STAC:", err);


### PR DESCRIPTION
## Description

Removes concept of EodashIdentifier -> stac[code/subcode]

Part of overall work to remove this superfluous config and handling, which deviates the RACE/eodashboard catalogs from the rest. Can be seen as part of eodash schemas simplification.

This is technically a breaking change, but both those catalogs utilizing it are under our control, so I would keep it a `feat` minor release feature only.

## Checklist

- [x] I have performed a self review on my code
- [ ] I added a test related to this feature/fix
- [x] I ran `npm run format` and `npm run check` pass
- [x] Docs under `docs/` are updated for any public API, config, or behavior change
- [ ] New store `states` / `actions` / `stac` have JSDoc. [Eodash Store](https://eodash.github.io/eodash/eodash-store) reference is generated from it
- [ ] New widget props are typed properly and they appear typed in the API reference
